### PR TITLE
Add in Optimization Pass

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,6 @@
 pytest
 pytest-cov
+pytest-mock
 duckdb
 duckdb-engine
 mypy

--- a/tests/complex/test_aggregate_of_aggregate.py
+++ b/tests/complex/test_aggregate_of_aggregate.py
@@ -56,9 +56,8 @@ select
 
     generator = BigqueryDialect()
     sql = generator.compile_statement(query)
-    print(sql)
 
-    assert re.search(r"(count\([A-z0-9\_]+\.`post_id`\) as `user_post_count`)", sql)
+    assert re.search(r"(count\([A-z0-9\_]+\.`id`\) as `user_post_count`)", sql)
     assert re.search(
         r"avg\([A-z0-9\_]+\.`user_post_count`\) as `avg_user_post_count`", sql
     )

--- a/tests/complex/test_complex_source_fetching.py
+++ b/tests/complex/test_complex_source_fetching.py
@@ -130,7 +130,7 @@ def test_aggregate_of_aggregate(stackoverflow_environment):
 
     assert avg_user_post_count in cte.output_columns
     assert user_post_count in parent_cte.output_columns
-    assert len(query.ctes) == 3
+    assert len(query.ctes) == 2
     assert len(cte.parent_ctes) > 0
 
     generator = SqlServerDialect()

--- a/tests/engine/demo/test_demo_duckdb.py
+++ b/tests/engine/demo/test_demo_duckdb.py
@@ -472,15 +472,15 @@ ORDER BY
         results.strip()
         == """
 SELECT
-    local_raw_data."passengerid" as "passenger_id",
-    (local_raw_data."passengerid" + 1) as "id_one",
-    local_raw_data."name" as "passenger_name"
+    raw_data."passengerid" as "passenger_id",
+    (raw_data."passengerid" + 1) as "id_one",
+    raw_data."name" as "passenger_name"
 FROM
-    raw_titanic as local_raw_data
+    raw_titanic as raw_data
 WHERE
-     CASE WHEN local_raw_data."name" like '%a%' THEN True ELSE False END = True
+     CASE WHEN raw_data."name" like '%a%' THEN True ELSE False END = True
 
 ORDER BY 
-    local_raw_data."name" asc
+    raw_data."name" asc
 """.strip()
     )

--- a/tests/engine/test_duckdb.py
+++ b/tests/engine/test_duckdb.py
@@ -133,9 +133,7 @@ order by item desc;
     assert len(parsed) == 1
     results = duckdb_engine.execute_text(test)[0].fetchall()
     assert len(results) == 1
-    assert (
-        'local_fact_items."item" as "item"' in results[0]["__preql_internal_query_text"]
-    )
+    assert 'fact_items."item" as "item"' in results[0]["__preql_internal_query_text"]
 
 
 def test_rollback(duckdb_engine: Executor, expected_results):

--- a/tests/engine/test_trino.py
+++ b/tests/engine/test_trino.py
@@ -1,0 +1,4 @@
+def test_render_query(trino_engine):
+    results = trino_engine.generate_sql("""select pi;""")[0]
+
+    assert "3.14" in results

--- a/tests/generators/test_merge_concept_node.py
+++ b/tests/generators/test_merge_concept_node.py
@@ -57,4 +57,4 @@ def test_merge_concepts():
             ):
                 assert cte.source_map["local.__merge_one_env2_one"] == ""
 
-        assert "env2_num1.`one` as `__merge_one_env2_one`" in compiled
+        assert "num1.`one` as `__merge_one_env2_one`" in compiled

--- a/tests/modeling/google_analytics/test_sane_ga_rendering.py
+++ b/tests/modeling/google_analytics/test_sane_ga_rendering.py
@@ -3,7 +3,6 @@ from trilogy.executor import Executor
 from pathlib import Path
 from trilogy.core.models import (
     ProcessedQuery,
-    SourceType,
     Environment,
     Concept,
     DataType,
@@ -49,12 +48,12 @@ def test_sane_rendering():
     select: ProcessedQuery = pstatements[-1]
     # this should be a
     # constant node since we have constants
-    assert select.ctes[0].source.source_type == SourceType.DIRECT_SELECT
+    # assert select.ctes[0].source.source_type == SourceType.DIRECT_SELECT
     # basic derivation
-    assert select.ctes[1].source.source_type == SourceType.MERGE
+    # assert select.ctes[1].source.source_type == SourceType.MERGE
 
     # select node for the data
-    assert select.ctes[2].source.source_type == SourceType.GROUP
+    # assert select.ctes[2].source.source_type == SourceType.GROUP
     # a group as groups happen without any constants
     # assert select.ctes[2].source.source_type == SourceType.CONSTANT
     # merge node to get in constants

--- a/tests/modeling/tcp_ds_duckdb/store_sales.preql
+++ b/tests/modeling/tcp_ds_duckdb/store_sales.preql
@@ -26,7 +26,7 @@ datasource store_sales (
     SS_CUSTOMER_SK: customer.id,
     SS_CDEMO_SK: customer_demographic.id,
     SS_TICKET_NUMBER: ticket_number,
-    SS_ITEM_SK: item.id,
+    SS_ITEM_SK: ~item.id,
     SS_SALES_PRICE: sales_price,
     SS_LIST_PRICE: list_price,
     SS_EXT_SALES_PRICE: ext_sales_price,

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -125,4 +125,5 @@ def test_modifiers():
     generator = BigqueryDialect()
 
     text = generator.compile_statement(query)
-    assert "`b` = 2" in text
+    assert "2 = 2" in text
+    assert "as `b`" not in text

--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -2,7 +2,8 @@ from trilogy.core.models import Environment
 from trilogy.dialect.enums import Dialects
 from trilogy.executor import Executor
 from trilogy.parser import parse
+from trilogy.constants import CONFIG
 
-__version__ = "0.0.1.105"
+__version__ = "0.0.1.106"
 
-__all__ = ["parse", "Executor", "Dialects", "Environment"]
+__all__ = ["parse", "Executor", "Dialects", "Environment", "CONFIG"]

--- a/trilogy/constants.py
+++ b/trilogy/constants.py
@@ -23,6 +23,7 @@ NULL_VALUE = MagicConstants.NULL
 class Config:
     strict_mode: bool = True
     human_identifiers: bool = True
+    inline_datasources: bool = True
 
 
 CONFIG = Config()

--- a/trilogy/core/models.py
+++ b/trilogy/core/models.py
@@ -34,7 +34,11 @@ from pydantic import (
 from lark.tree import Meta
 from pathlib import Path
 from trilogy.constants import logger, DEFAULT_NAMESPACE, ENV_CACHE_NAME, MagicConstants
-from trilogy.core.constants import ALL_ROWS_CONCEPT, INTERNAL_NAMESPACE
+from trilogy.core.constants import (
+    ALL_ROWS_CONCEPT,
+    INTERNAL_NAMESPACE,
+    CONSTANT_DATASET,
+)
 from trilogy.core.enums import (
     InfiniteFunctionArgs,
     Purpose,
@@ -1434,6 +1438,7 @@ class MultiSelectStatement(Namespaced, BaseModel):
 
 class Address(BaseModel):
     location: str
+    is_query: bool = False
 
 
 class Query(BaseModel):
@@ -1529,9 +1534,26 @@ class Datasource(Namespaced, BaseModel):
         default_factory=lambda: DatasourceMetadata(freshness_concept=None)
     )
 
+    @property
+    def condition(self):
+        return None
+
     @cached_property
     def output_lcl(self) -> LooseConceptList:
         return LooseConceptList(concepts=self.output_concepts)
+
+    @property
+    def can_be_inlined(self) -> bool:
+        if isinstance(self.address, Address) and self.address.is_query:
+            return False
+        for x in self.columns:
+            if not isinstance(x.alias, str):
+                return False
+        return True
+
+    @property
+    def non_partial_concept_addresses(self) -> set[str]:
+        return set([c.address for c in self.full_concepts])
 
     @field_validator("namespace", mode="plain")
     @classmethod
@@ -1746,7 +1768,7 @@ class QueryDatasource(BaseModel):
     input_concepts: List[Concept]
     output_concepts: List[Concept]
     source_map: Dict[str, Set[Union[Datasource, "QueryDatasource", "UnnestJoin"]]]
-    datasources: Sequence[Union[Datasource, "QueryDatasource"]]
+    datasources: List[Union[Datasource, "QueryDatasource"]]
     grain: Grain
     joins: List[BaseJoin | UnnestJoin]
     limit: Optional[int] = None
@@ -1797,10 +1819,7 @@ class QueryDatasource(BaseModel):
             c.address for c in values["input_concepts"]
         )
         seen = set()
-        for k, val in v.items():
-            # if val:
-            #     if len(val) != 1:
-            #         raise SyntaxError(f"source map {k} has multiple values {len(val)}")
+        for k, _ in v.items():
             seen.add(k)
         for x in expected:
             if x not in seen:
@@ -1924,16 +1943,10 @@ class QueryDatasource(BaseModel):
     def get_alias(
         self, concept: Concept, use_raw_name: bool = False, force_alias: bool = False
     ):
-        # if we should use the raw datasource name to access
-        use_raw_name = (
-            True
-            if (len(self.datasources) == 1 or use_raw_name) and not force_alias
-            # if ((len(self.datasources) == 1 and isinstance(self.datasources[0], Datasource)) or use_raw_name) and not force_alias
-            else False
-        )
         for x in self.datasources:
             # query datasources should be referenced by their alias, always
             force_alias = isinstance(x, QueryDatasource)
+            use_raw_name = isinstance(x, Datasource) and not force_alias
             try:
                 return x.get_alias(
                     concept.with_grain(self.grain),
@@ -1967,8 +1980,7 @@ class Comment(BaseModel):
 
 class CTE(BaseModel):
     name: str
-    source: "QueryDatasource"  # TODO: make recursive
-    # output columns are what are selected/grouped by
+    source: "QueryDatasource"
     output_columns: List[Concept]
     source_map: Dict[str, str | list[str]]
     grain: Grain
@@ -1979,6 +1991,10 @@ class CTE(BaseModel):
     condition: Optional[Union["Conditional", "Comparison", "Parenthetical"]] = None
     partial_concepts: List[Concept] = Field(default_factory=list)
     join_derived_concepts: List[Concept] = Field(default_factory=list)
+    order_by: Optional[OrderBy] = None
+    limit: Optional[int] = None
+    requires_nesting: bool = True
+    base_name_override: Optional[str] = None
 
     @computed_field  # type: ignore
     @property
@@ -1988,6 +2004,40 @@ class CTE(BaseModel):
     @field_validator("output_columns")
     def validate_output_columns(cls, v):
         return unique(v, "address")
+
+    def inline_parent_datasource(self, parent: CTE) -> bool:
+        qds_being_inlined = parent.source
+        ds_being_inlined = qds_being_inlined.datasources[0]
+        if not isinstance(ds_being_inlined, Datasource):
+            return False
+        self.source.datasources = [
+            ds_being_inlined,
+            *[
+                x
+                for x in self.source.datasources
+                if x.identifier != qds_being_inlined.identifier
+            ],
+        ]
+        # need to identify this before updating joins
+        if self.base_name == parent.name:
+            self.base_name_override = ds_being_inlined.safe_location
+
+        for join in self.joins:
+            if isinstance(join, InstantiatedUnnestJoin):
+                continue
+            if join.left_cte.name == parent.name:
+                join.left_cte = ds_being_inlined
+            if join.right_cte.name == parent.name:
+                join.right_cte = ds_being_inlined
+        for k, v in self.source_map.items():
+            if isinstance(v, list):
+                self.source_map[k] = [
+                    ds_being_inlined.name if x == parent.name else x for x in v
+                ]
+            elif v == parent.name:
+                self.source_map[k] = ds_being_inlined.name
+        self.parent_ctes = [x for x in self.parent_ctes if x.name != parent.name]
+        return True
 
     def __add__(self, other: "CTE"):
         logger.info('Merging two copies of CTE "%s"', self.name)
@@ -2032,15 +2082,24 @@ class CTE(BaseModel):
         return self.parent_ctes
 
     @property
+    def is_root_datasource(self) -> bool:
+        return (
+            len(self.source.datasources) == 1
+            and isinstance(self.source.datasources[0], Datasource)
+            and not self.source.datasources[0].name == CONSTANT_DATASET
+        )
+
+    @property
     def base_name(self) -> str:
+        if self.base_name_override:
+            return self.base_name_override
         # if this cte selects from a single datasource, select right from it
         valid_joins: List[Join] = [
             join for join in self.joins if isinstance(join, Join)
         ]
-        if len(self.source.datasources) == 1 and isinstance(
-            self.source.datasources[0], Datasource
-        ):
+        if self.is_root_datasource:
             return self.source.datasources[0].safe_location
+
         # if we have multiple joined CTEs, pick the base
         # as the root
         elif len(self.source.datasources) == 1 and len(self.parent_ctes) == 1:
@@ -2079,12 +2138,16 @@ class CTE(BaseModel):
             return self.parent_ctes[0].name
         return self.name
 
-    def get_alias(self, concept: Concept) -> str:
+    def get_alias(self, concept: Concept, source: str | None = None) -> str:
         for cte in self.parent_ctes:
             if concept.address in [x.address for x in cte.output_columns]:
+                if source and source != cte.name:
+                    continue
                 return concept.safe_address
         try:
             source = self.source.get_alias(concept)
+            if not source:
+                raise ValueError("No source found")
             return source
         except ValueError as e:
             return f"INVALID_ALIAS: {str(e)}"
@@ -2095,6 +2158,11 @@ class CTE(BaseModel):
             all([c.derivation == PurposeLineage.CONSTANT for c in self.output_columns])
             and not self.parent_ctes
             and not self.group_to_grain
+        ):
+            return False
+        if (
+            len(self.source.datasources) == 1
+            and self.source.datasources[0].name == CONSTANT_DATASET
         ):
             return False
         return True
@@ -2130,19 +2198,43 @@ class JoinKey(BaseModel):
 
 
 class Join(BaseModel):
-    left_cte: CTE
-    right_cte: CTE
+    left_cte: CTE | Datasource
+    right_cte: CTE | Datasource
     jointype: JoinType
     joinkeys: List[JoinKey]
 
     @property
+    def left_name(self) -> str:
+        if isinstance(self.left_cte, Datasource):
+            return self.left_cte.identifier
+        return self.left_cte.name
+
+    @property
+    def right_name(self) -> str:
+        if isinstance(self.right_cte, Datasource):
+            return self.right_cte.identifier
+        return self.right_cte.name
+
+    @property
+    def left_ref(self) -> str:
+        if isinstance(self.left_cte, Datasource):
+            return f"{self.left_cte.safe_location} as {self.left_cte.identifier}"
+        return self.left_cte.name
+
+    @property
+    def right_ref(self) -> str:
+        if isinstance(self.right_cte, Datasource):
+            return f"{self.right_cte.safe_location} as {self.right_cte.identifier}"
+        return self.right_cte.name
+
+    @property
     def unique_id(self) -> str:
-        return self.left_cte.name + self.right_cte.name + self.jointype.value
+        return self.left_name + self.right_name + self.jointype.value
 
     def __str__(self):
         return (
-            f"{self.jointype.value} JOIN {self.left_cte.name} and"
-            f" {self.right_cte.name} on {','.join([str(k) for k in self.joinkeys])}"
+            f"{self.jointype.value} JOIN {self.left_name} and"
+            f" {self.right_name} on {','.join([str(k) for k in self.joinkeys])}"
         )
 
 

--- a/trilogy/core/optimization.py
+++ b/trilogy/core/optimization.py
@@ -19,20 +19,6 @@ class OptimizationRule(ABC):
         logger.info(f"[Optimization][{self.__class__.__name__}] {message}")
 
 
-def invert_dict(original_dict):
-    inverted_dict = {}
-    for key, value in original_dict.items():
-        if isinstance(value, str):
-            values = [value]
-        else:
-            values = value
-        for svalue in values:
-            if svalue not in inverted_dict:
-                inverted_dict[svalue] = []
-            inverted_dict[svalue].append(key)
-    return inverted_dict
-
-
 class InlineDatasource(OptimizationRule):
 
     def optimize(self, cte: CTE) -> bool:

--- a/trilogy/core/optimization.py
+++ b/trilogy/core/optimization.py
@@ -1,0 +1,155 @@
+from trilogy.core.models import (
+    CTE,
+    SelectStatement,
+    PersistStatement,
+    Datasource,
+    MultiSelectStatement,
+)
+from trilogy.core.enums import PurposeLineage
+from trilogy.constants import logger
+from abc import ABC
+
+
+class OptimizationRule(ABC):
+
+    def optimize(self, cte: CTE) -> bool:
+        raise NotImplementedError
+
+    def log(self, message: str):
+        logger.info(f"[Optimization][{self.__class__.__name__}] {message}")
+
+
+def invert_dict(original_dict):
+    inverted_dict = {}
+    for key, value in original_dict.items():
+        if isinstance(value, str):
+            values = [value]
+        else:
+            values = value
+        for svalue in values:
+            if svalue not in inverted_dict:
+                inverted_dict[svalue] = []
+            inverted_dict[svalue].append(key)
+    return inverted_dict
+
+
+class InlineDatasource(OptimizationRule):
+
+    def optimize(self, cte: CTE) -> bool:
+        if not cte.parent_ctes:
+            return False
+
+        optimized = False
+        self.log(
+            f"Checking {cte.name} for consolidating inline tables with {len(cte.parent_ctes)} parents"
+        )
+        to_inline: list[CTE] = []
+        for parent_cte in cte.parent_ctes:
+            if not parent_cte.is_root_datasource:
+                self.log(f"parent {parent_cte.name} is not root")
+                continue
+            if parent_cte.parent_ctes:
+                self.log(f"parent {parent_cte.name} has parents")
+                continue
+            raw_root = parent_cte.source.datasources[0]
+            if not isinstance(raw_root, Datasource):
+                self.log(f"parent {parent_cte.name} is not datasource")
+                continue
+            root: Datasource = raw_root
+            if not root.can_be_inlined:
+                self.log(f"parent {parent_cte.name} datasource is not inlineable")
+                continue
+            root_outputs = {x.address for x in root.output_concepts}
+            cte_outputs = {x.address for x in parent_cte.output_columns}
+            if not cte_outputs.issubset(root_outputs):
+                self.log(f"Not all {parent_cte.name} outputs are found on datasource")
+                continue
+
+            to_inline.append(parent_cte)
+
+        for replaceable in to_inline:
+            self.log(f"Inlining parent {replaceable.name}")
+            cte.inline_parent_datasource(replaceable)
+
+        return optimized
+
+
+REGISTERED_RULES: list[OptimizationRule] = [InlineDatasource()]
+
+
+def filter_irrelevant_ctes(input: list[CTE], root_cte: CTE):
+    relevant_ctes = set()
+
+    def recurse(cte: CTE):
+        relevant_ctes.add(cte.name)
+        for cte in cte.parent_ctes:
+            recurse(cte)
+
+    recurse(root_cte)
+    return [cte for cte in input if cte.name in relevant_ctes]
+
+
+def is_direct_return_eligible(
+    cte: CTE, select: SelectStatement | PersistStatement | MultiSelectStatement
+) -> bool:
+    if isinstance(select, (PersistStatement, MultiSelectStatement)):
+        return False
+    derived_concepts = [
+        c for c in cte.source.output_concepts if c not in cte.source.input_concepts
+    ]
+    eligible = True
+    conditions = (
+        set(x.address for x in select.where_clause.concept_arguments)
+        if select.where_clause
+        else set()
+    )
+    if conditions and select.limit:
+        return False
+    for x in derived_concepts:
+        if x.derivation == PurposeLineage.WINDOW:
+            return False
+        if x.derivation == PurposeLineage.AGGREGATE:
+            if x.address in conditions:
+                return False
+    logger.info(
+        f"Upleveling output select to final CTE with derived_concepts {[x.address for x in derived_concepts]}"
+    )
+    return eligible
+
+
+def sort_select_output(cte: CTE, query: SelectStatement | MultiSelectStatement):
+    hidden_addresses = [c.address for c in query.hidden_components]
+    output_addresses = [
+        c.address for c in query.output_components if c.address not in hidden_addresses
+    ]
+
+    mapping = {x.address: x for x in cte.output_columns}
+
+    new_output = []
+    for x in output_addresses:
+        new_output.append(mapping[x])
+    cte.output_columns = new_output
+
+
+def optimize_ctes(
+    input: list[CTE], root_cte: CTE, select: SelectStatement | MultiSelectStatement
+):
+    complete = False
+
+    while not complete:
+        actions_taken = False
+        for rule in REGISTERED_RULES:
+            for cte in input:
+                actions_taken = rule.optimize(cte)
+        complete = not actions_taken
+
+    if is_direct_return_eligible(root_cte, select):
+        root_cte.order_by = select.order_by
+        root_cte.limit = select.limit
+        root_cte.condition = (
+            select.where_clause.conditional if select.where_clause else None
+        )
+        root_cte.requires_nesting = False
+        sort_select_output(cte, select)
+
+    return filter_irrelevant_ctes(input, root_cte)

--- a/trilogy/core/processing/nodes/base_node.py
+++ b/trilogy/core/processing/nodes/base_node.py
@@ -45,7 +45,7 @@ def concept_list_to_grain(
 
 
 def resolve_concept_map(
-    inputs: List[QueryDatasource],
+    inputs: List[QueryDatasource | Datasource],
     targets: List[Concept],
     inherited_inputs: List[Concept],
     full_joins: List[Concept] | None = None,
@@ -156,7 +156,9 @@ class StrategyNode:
         return f"{self.__class__.__name__}<{contents}>"
 
     def _resolve(self) -> QueryDatasource:
-        parent_sources = [p.resolve() for p in self.parents]
+        parent_sources: List[QueryDatasource | Datasource] = [
+            p.resolve() for p in self.parents
+        ]
 
         # if conditional:
         #     for condition in conditions[1:]:

--- a/trilogy/core/processing/nodes/group_node.py
+++ b/trilogy/core/processing/nodes/group_node.py
@@ -4,6 +4,7 @@ from trilogy.constants import logger
 from trilogy.core.models import (
     Grain,
     QueryDatasource,
+    Datasource,
     SourceType,
     Concept,
     Environment,
@@ -45,7 +46,9 @@ class GroupNode(StrategyNode):
         )
 
     def _resolve(self) -> QueryDatasource:
-        parent_sources: list[QueryDatasource] = [p.resolve() for p in self.parents]
+        parent_sources: List[QueryDatasource | Datasource] = [
+            p.resolve() for p in self.parents
+        ]
 
         grain = concept_list_to_grain(self.output_concepts, [])
         comp_grain = Grain()
@@ -66,7 +69,7 @@ class GroupNode(StrategyNode):
                 len(parent_sources) == 1
                 and LooseConceptList(concepts=parent_sources[0].output_concepts)
                 == self.output_lcl
-            ):
+            ) and isinstance(parent_sources[0], QueryDatasource):
                 logger.info(
                     f"{self.logging_prefix}{LOGGER_PREFIX} No group by required, returning parent node"
                 )

--- a/trilogy/core/query_processor.py
+++ b/trilogy/core/query_processor.py
@@ -187,7 +187,7 @@ def datasource_to_ctes(
             source_map = {k: "" for k in query_datasource.source_map}
         else:
             source_map = {
-                k: "" if not v else source.full_name
+                k: "" if not v else source.identifier
                 for k, v in query_datasource.source_map.items()
             }
     human_id = generate_cte_name(query_datasource.full_name, name_map)

--- a/trilogy/core/query_processor.py
+++ b/trilogy/core/query_processor.py
@@ -29,6 +29,7 @@ from trilogy.hooks.base_hook import BaseHook
 from trilogy.constants import logger
 from random import shuffle
 from trilogy.core.ergonomics import CTE_NAMES
+from trilogy.core.optimization import optimize_ctes
 from math import ceil
 
 LOGGER_PREFIX = "[QUERY BUILD]"
@@ -315,7 +316,9 @@ def process_query(
             seen[cte.name] = seen[cte.name] + cte
     for cte in raw_ctes:
         cte.parent_ctes = [seen[x.name] for x in cte.parent_ctes]
-    final_ctes: List[CTE] = list(seen.values())
+    deduped_ctes: List[CTE] = list(seen.values())
+
+    final_ctes = optimize_ctes(deduped_ctes, root_cte, statement)
 
     return ProcessedQuery(
         order_by=statement.order_by,

--- a/trilogy/dialect/base.py
+++ b/trilogy/dialect/base.py
@@ -170,6 +170,9 @@ GENERIC_SQL_TEMPLATE = Template(
     """{%- if ctes %}
 WITH {% for cte in ctes %}
 {{cte.name}} as ({{cte.statement}}){% if not loop.last %},{% endif %}{% endfor %}{% endif %}
+{%- if full_select -%}
+{{full_select}}
+{%- else -%}
 SELECT
 {%- if limit is not none %}
 TOP {{ limit }}{% endif %}
@@ -185,7 +188,7 @@ TOP {{ limit }}{% endif %}
 {%- if order_by %}
 ORDER BY {% for order in order_by %}
     {{ order }}{% if not loop.last %},{% endif %}
-{% endfor %}{% endif %}
+{% endfor %}{% endif %}{% endif %}
 """
 )
 
@@ -218,15 +221,19 @@ def safe_quote(string: str, quote_char: str):
     return ".".join([f"{quote_char}{string}{quote_char}" for string in components])
 
 
-def safe_get_cte_value(coalesce, cte: CTE, address: str, rendered: str):
+def safe_get_cte_value(coalesce, cte: CTE, c: Concept):
+    address = c.address
     raw = cte.source_map.get(address, None)
+
     if not raw:
         return INVALID_REFERENCE_STRING("Missing source reference")
     if isinstance(raw, str):
+        rendered = cte.get_alias(c)
         return f"{raw}.{rendered}"
     if isinstance(raw, list) and len(raw) == 1:
+        rendered = cte.get_alias(c)
         return f"{raw[0]}.{rendered}"
-    return coalesce([f"{x}.{rendered}" for x in raw])
+    return coalesce([f"{x}.{cte.get_alias(c, x)}" for x in raw])
 
 
 class BaseDialect:
@@ -238,21 +245,13 @@ class BaseDialect:
     DATATYPE_MAP = DATATYPE_MAP
     UNNEST_MODE = UnnestMode.CROSS_APPLY
 
-    def render_order_item(self, order_item: OrderItem, ctes: List[CTE]) -> str:
-        matched_ctes = [
-            cte
-            for cte in ctes
-            if order_item.expr.address in [a.address for a in cte.output_columns]
-        ]
-        if not matched_ctes:
-            all_outputs = set()
-            for cte in ctes:
-                all_outputs.update([a.address for a in cte.output_columns])
-            raise ValueError(
-                f"No source found for concept {order_item.expr}, have {all_outputs}"
-            )
-        selected = matched_ctes[0]
-        return f"{selected.name}.{self.QUOTE_CHARACTER}{order_item.expr.safe_address}{self.QUOTE_CHARACTER} {order_item.order.value}"
+    def render_order_item(
+        self, order_item: OrderItem, cte: CTE, final: bool = False
+    ) -> str:
+        if final:
+            return f"{cte.name}.{self.QUOTE_CHARACTER}{order_item.expr.safe_address}{self.QUOTE_CHARACTER} {order_item.order.value}"
+
+        return f"{self.render_concept_sql(order_item.expr, cte=cte, alias=False)} {order_item.order.value}"
 
     def render_concept_sql(self, c: Concept, cte: CTE, alias: bool = True) -> str:
         # only recurse while it's in sources of the current cte
@@ -316,7 +315,7 @@ class BaseDialect:
             elif isinstance(raw_content, Function):
                 rval = self.render_expr(raw_content, cte=cte)
             else:
-                rval = f"{safe_get_cte_value(self.FUNCTION_MAP[FunctionType.COALESCE], cte, c.address, rendered=safe_quote(raw_content, self.QUOTE_CHARACTER))}"
+                rval = f"{safe_get_cte_value(self.FUNCTION_MAP[FunctionType.COALESCE], cte, c)}"
         if alias:
             return (
                 f"{rval} as"
@@ -456,7 +455,7 @@ class BaseDialect:
                     else None
                 ),
                 grain=cte.grain,
-                limit=None,
+                limit=cte.limit,
                 # some joins may not need to be rendered
                 joins=[
                     j
@@ -475,9 +474,11 @@ class BaseDialect:
                 where=(
                     self.render_expr(cte.condition, cte) if cte.condition else None
                 ),  # source_map=cte_output_map)
-                # where=self.render_expr(where_assignment[cte.name], cte)
-                # if cte.name in where_assignment
-                # else None,
+                order_by=(
+                    [self.render_order_item(i, cte) for i in cte.order_by.items]
+                    if cte.order_by
+                    else None
+                ),
                 group_by=(
                     list(
                         set(
@@ -522,7 +523,8 @@ class BaseDialect:
         )
 
     def generate_ctes(
-        self, query: ProcessedQuery, where_assignment: Dict[str, Conditional]
+        self,
+        query: ProcessedQuery,
     ):
         return [self.render_cte(cte) for cte in query.ctes]
 
@@ -649,35 +651,54 @@ class BaseDialect:
                     " filtered concept instead."
                 )
 
-        compiled_ctes = self.generate_ctes(query, {})
+        compiled_ctes = self.generate_ctes(query)
 
         # restort selections by the order they were written in
         sorted_select: List[str] = []
         for output_c in output_addresses:
             sorted_select.append(select_columns[output_c])
-        final = self.SQL_TEMPLATE.render(
-            output=(
-                query.output_to if isinstance(query, ProcessedQueryPersist) else None
-            ),
-            select_columns=sorted_select,
-            base=query.base.name,
-            joins=[
-                render_join(join, self.QUOTE_CHARACTER, None) for join in query.joins
-            ],
-            ctes=compiled_ctes,
-            limit=query.limit,
-            # move up to CTEs
-            where=(
-                self.render_expr(query.where_clause.conditional, cte_map=cte_output_map)
-                if query.where_clause and output_where
-                else None
-            ),
-            order_by=(
-                [self.render_order_item(i, [query.base]) for i in query.order_by.items]
-                if query.order_by
-                else None
-            ),
-        )
+        if not query.base.requires_nesting:
+            final = self.SQL_TEMPLATE.render(
+                output=(
+                    query.output_to
+                    if isinstance(query, ProcessedQueryPersist)
+                    else None
+                ),
+                full_select=compiled_ctes[-1].statement,
+                ctes=compiled_ctes[:-1],
+            )
+        else:
+            final = self.SQL_TEMPLATE.render(
+                output=(
+                    query.output_to
+                    if isinstance(query, ProcessedQueryPersist)
+                    else None
+                ),
+                select_columns=sorted_select,
+                base=query.base.name,
+                joins=[
+                    render_join(join, self.QUOTE_CHARACTER, None)
+                    for join in query.joins
+                ],
+                ctes=compiled_ctes,
+                limit=query.limit,
+                # move up to CTEs
+                where=(
+                    self.render_expr(
+                        query.where_clause.conditional, cte_map=cte_output_map
+                    )
+                    if query.where_clause and output_where
+                    else None
+                ),
+                order_by=(
+                    [
+                        self.render_order_item(i, query.base, final=True)
+                        for i in query.order_by.items
+                    ]
+                    if query.order_by
+                    else None
+                ),
+            )
 
         if CONFIG.strict_mode and INVALID_REFERENCE_STRING(1) in final:
             raise ValueError(

--- a/trilogy/dialect/bigquery.py
+++ b/trilogy/dialect/bigquery.py
@@ -43,8 +43,10 @@ CREATE OR REPLACE TABLE {{ output.address.location }} AS
 {% endif %}{%- if ctes %}
 WITH {% for cte in ctes %}
 {{cte.name}} as ({{cte.statement}}){% if not loop.last %},{% endif %}{% endfor %}{% endif %}
+{%- if full_select -%}
+{{full_select}}
+{%- else -%}
 SELECT
-
 {%- for select in select_columns %}
     {{ select }}{% if not loop.last %},{% endif %}{% endfor %}
 {% if base %}FROM
@@ -62,7 +64,7 @@ ORDER BY {% for order in order_by %}
     {{ order }}{% if not loop.last %},{% endif %}
 {% endfor %}{% endif %}
 {%- if limit is not none %}
-LIMIT {{ limit }}{% endif %}
+LIMIT {{ limit }}{% endif %}{% endif %}
 """
 )
 MAX_IDENTIFIER_LENGTH = 50

--- a/trilogy/dialect/bigquery.py
+++ b/trilogy/dialect/bigquery.py
@@ -46,6 +46,7 @@ WITH {% for cte in ctes %}
 {%- if full_select -%}
 {{full_select}}
 {%- else -%}
+
 SELECT
 {%- for select in select_columns %}
     {{ select }}{% if not loop.last %},{% endif %}{% endfor %}
@@ -61,8 +62,7 @@ SELECT
     {{group}}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}
 {%- if order_by %}
 ORDER BY {% for order in order_by %}
-    {{ order }}{% if not loop.last %},{% endif %}
-{% endfor %}{% endif %}
+    {{ order }}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}
 {%- if limit is not none %}
 LIMIT {{ limit }}{% endif %}{% endif %}
 """

--- a/trilogy/dialect/config.py
+++ b/trilogy/dialect/config.py
@@ -6,6 +6,23 @@ class DialectConfig:
     def connection_string(self) -> str:
         raise NotImplementedError
 
+    @property
+    def connect_args(self) -> dict:
+        return {}
+
+
+class BigQueryConfig(DialectConfig):
+    def __init__(self, project: str, client):
+        self.project = project
+        self.client = client
+
+    def connection_string(self) -> str:
+        return f"bigquery://{self.project}?user_supplied_client=True"
+
+    @property
+    def connect_args(self) -> dict:
+        return {"client": self.client}
+
 
 class DuckDBConfig(DialectConfig):
     def __init__(self, path: str | None = None):

--- a/trilogy/dialect/config.py
+++ b/trilogy/dialect/config.py
@@ -1,5 +1,10 @@
 class DialectConfig:
-    pass
+
+    def __init__(self):
+        pass
+
+    def connection_string(self) -> str:
+        raise NotImplementedError
 
 
 class DuckDBConfig(DialectConfig):
@@ -53,3 +58,49 @@ class SnowflakeConfig(DialectConfig):
 
     def connection_string(self) -> str:
         return f"snowflake://{self.username}:{self.password}@{self.account}"
+
+
+class PrestoConfig(DialectConfig):
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        username: str,
+        password: str,
+        catalog: str,
+        schema: str | None = None,
+    ):
+        self.host = host
+        self.port = port
+        self.username = username
+        self.password = password
+        self.catalog = catalog
+        self.schema = schema
+
+    def connection_string(self) -> str:
+        if self.schema:
+            return f"presto://{self.username}:{self.password}@{self.host}:{self.port}/{self.catalog}/{self.schema}"
+        return f"presto://{self.username}:{self.password}@{self.host}:{self.port}/{self.catalog}"
+
+
+class TrinoConfig(DialectConfig):
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        username: str,
+        password: str,
+        catalog: str,
+        schema: str | None = None,
+    ):
+        self.host = host
+        self.port = port
+        self.username = username
+        self.password = password
+        self.catalog = catalog
+        self.schema = schema
+
+    def connection_string(self) -> str:
+        if self.schema:
+            return f"trino://{self.username}:{self.password}@{self.host}:{self.port}/{self.catalog}/{self.schema}"
+        return f"trino://{self.username}:{self.password}@{self.host}:{self.port}/{self.catalog}"

--- a/trilogy/dialect/duckdb.py
+++ b/trilogy/dialect/duckdb.py
@@ -65,8 +65,7 @@ GROUP BY {% for group in group_by %}
     {{group}}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}
 {%- if order_by %}
 ORDER BY {% for order in order_by %}
-    {{ order }}{% if not loop.last %},{% endif %}
-{% endfor %}{% endif %}
+    {{ order }}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}
 {%- if limit is not none %}
 LIMIT ({{ limit }}){% endif %}{% endif %}
 """

--- a/trilogy/dialect/duckdb.py
+++ b/trilogy/dialect/duckdb.py
@@ -47,8 +47,10 @@ CREATE OR REPLACE TABLE {{ output.address.location }} AS
 {% endif %}{%- if ctes %}
 WITH {% for cte in ctes %}
 {{cte.name}} as ({{cte.statement}}){% if not loop.last %},{% endif %}{% endfor %}{% endif %}
-SELECT
+{% if full_select -%}{{full_select}}
+{% else -%}
 
+SELECT
 {%- for select in select_columns %}
     {{ select }}{% if not loop.last %},{% endif %}{% endfor %}
 {% if base %}FROM
@@ -66,7 +68,7 @@ ORDER BY {% for order in order_by %}
     {{ order }}{% if not loop.last %},{% endif %}
 {% endfor %}{% endif %}
 {%- if limit is not none %}
-LIMIT ({{ limit }}){% endif %}
+LIMIT ({{ limit }}){% endif %}{% endif %}
 """
 )
 

--- a/trilogy/dialect/enums.py
+++ b/trilogy/dialect/enums.py
@@ -9,6 +9,16 @@ from trilogy.dialect.config import DialectConfig
 from trilogy.constants import logger
 
 
+def default_factory(conf: DialectConfig, config_type):
+    from sqlalchemy import create_engine
+
+    if not isinstance(conf, config_type):
+        raise TypeError(
+            f"Invalid dialect configuration for type {type(config_type).__name__}"
+        )
+    return create_engine(conf.connection_string(), future=True)
+
+
 class Dialects(Enum):
     BIGQUERY = "bigquery"
     SQL_SERVER = "sql_server"
@@ -46,16 +56,12 @@ class Dialects(Enum):
 
             if not conf:
                 conf = DuckDBConfig()
-            if not isinstance(conf, DuckDBConfig):
-                raise TypeError("Invalid dialect configuration for type duck_db")
-            return create_engine(conf.connection_string(), future=True)
+            return default_factory(conf, DuckDBConfig)
         elif self == Dialects.SNOWFLAKE:
             from sqlalchemy import create_engine
             from trilogy.dialect.config import SnowflakeConfig
 
-            if not isinstance(conf, SnowflakeConfig):
-                raise TypeError("Invalid dialect configuration for type snowflake")
-            return create_engine(conf.connection_string(), future=True)
+            return default_factory(conf, SnowflakeConfig)
         elif self == Dialects.POSTGRES:
             logger.warn(
                 "WARN: Using experimental postgres dialect. Most functionality will not work."
@@ -70,10 +76,17 @@ class Dialects(Enum):
             from sqlalchemy import create_engine
             from trilogy.dialect.config import PostgresConfig
 
-            if not isinstance(conf, PostgresConfig):
-                raise TypeError("Invalid dialect configuration for type postgres")
+            return default_factory(conf, PostgresConfig)
+        elif self == Dialects.PRESTO:
+            from sqlalchemy import create_engine
+            from trilogy.dialect.config import PrestoConfig
 
-            return create_engine(conf.connection_string(), future=True)
+            return default_factory(conf, PrestoConfig)
+        elif self == Dialects.TRINO:
+            from sqlalchemy import create_engine
+            from trilogy.dialect.config import TrinoConfig
+
+            return default_factory(conf, TrinoConfig)
         else:
             raise ValueError(
                 f"Unsupported dialect {self} for default engine creation; create one explicitly."

--- a/trilogy/dialect/enums.py
+++ b/trilogy/dialect/enums.py
@@ -9,7 +9,7 @@ from trilogy.dialect.config import DialectConfig
 from trilogy.constants import logger
 
 
-def default_factory(conf: DialectConfig, config_type, **kwargs):
+def default_factory(conf: DialectConfig, config_type):
     from sqlalchemy import create_engine
 
     if not isinstance(conf, config_type):

--- a/trilogy/dialect/postgres.py
+++ b/trilogy/dialect/postgres.py
@@ -49,8 +49,10 @@ CREATE TABLE {{ output.address.location }} AS
 {% endif %}{%- if ctes %}
 WITH {% for cte in ctes %}
 {{cte.name}} as ({{cte.statement}}){% if not loop.last %},{% endif %}{% endfor %}{% endif %}
+{%- if full_select -%}
+{{full_select}}
+{%- else -%}
 SELECT
-
 {%- for select in select_columns %}
     {{ select }}{% if not loop.last %},{% endif %}{% endfor %}
 {% if base %}FROM
@@ -68,7 +70,7 @@ ORDER BY {% for order in order_by %}
     {{ order }}{% if not loop.last %},{% endif %}
 {% endfor %}{% endif %}
 {%- if limit is not none %}
-LIMIT {{ limit }}{% endif %}
+LIMIT {{ limit }}{% endif %}{% endif %}
 """
 )
 

--- a/trilogy/dialect/presto.py
+++ b/trilogy/dialect/presto.py
@@ -42,6 +42,7 @@ CREATE OR REPLACE TABLE {{ output.address }} AS
 {% endif %}{%- if ctes %}
 WITH {% for cte in ctes %}
 {{cte.name}} as ({{cte.statement}}){% if not loop.last %},{% endif %}{% endfor %}{% endif %}
+
 SELECT
 {%- if full_select -%}
 {{full_select}}
@@ -60,8 +61,7 @@ SELECT
     {{group}}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}
 {%- if order_by %}
 ORDER BY {% for order in order_by %}
-    {{ order }}{% if not loop.last %},{% endif %}
-{% endfor %}{% endif %}
+    {{ order }}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}
 {%- if limit is not none %}
 LIMIT {{ limit }}{% endif %}{% endif %}
 """

--- a/trilogy/dialect/presto.py
+++ b/trilogy/dialect/presto.py
@@ -43,7 +43,9 @@ CREATE OR REPLACE TABLE {{ output.address }} AS
 WITH {% for cte in ctes %}
 {{cte.name}} as ({{cte.statement}}){% if not loop.last %},{% endif %}{% endfor %}{% endif %}
 SELECT
-
+{%- if full_select -%}
+{{full_select}}
+{%- else -%}
 {%- for select in select_columns %}
     {{ select }}{% if not loop.last %},{% endif %}{% endfor %}
 {% if base %}FROM
@@ -61,7 +63,7 @@ ORDER BY {% for order in order_by %}
     {{ order }}{% if not loop.last %},{% endif %}
 {% endfor %}{% endif %}
 {%- if limit is not none %}
-LIMIT {{ limit }}{% endif %}
+LIMIT {{ limit }}{% endif %}{% endif %}
 """
 )
 MAX_IDENTIFIER_LENGTH = 50

--- a/trilogy/dialect/snowflake.py
+++ b/trilogy/dialect/snowflake.py
@@ -48,6 +48,7 @@ WITH {% for cte in ctes %}
 {%- if full_select -%}
 {{full_select}}
 {%- else -%}
+
 SELECT
 {%- for select in select_columns %}
     {{ select }}{% if not loop.last %},{% endif %}{% endfor %}
@@ -63,8 +64,7 @@ SELECT
     {{group}}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}
 {%- if order_by %}
 ORDER BY {% for order in order_by %}
-    {{ order }}{% if not loop.last %},{% endif %}
-{% endfor %}{% endif %}
+    {{ order }}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}
 {%- if limit is not none %}
 LIMIT {{ limit }}{% endif %}{% endif %}
 """

--- a/trilogy/dialect/snowflake.py
+++ b/trilogy/dialect/snowflake.py
@@ -45,8 +45,10 @@ CREATE OR REPLACE TABLE {{ output.address.location }} AS
 {% endif %}{%- if ctes %}
 WITH {% for cte in ctes %}
 {{cte.name}} as ({{cte.statement}}){% if not loop.last %},{% endif %}{% endfor %}{% endif %}
+{%- if full_select -%}
+{{full_select}}
+{%- else -%}
 SELECT
-
 {%- for select in select_columns %}
     {{ select }}{% if not loop.last %},{% endif %}{% endfor %}
 {% if base %}FROM
@@ -64,7 +66,7 @@ ORDER BY {% for order in order_by %}
     {{ order }}{% if not loop.last %},{% endif %}
 {% endfor %}{% endif %}
 {%- if limit is not none %}
-LIMIT {{ limit }}{% endif %}
+LIMIT {{ limit }}{% endif %}{% endif %}
 """
 )
 MAX_IDENTIFIER_LENGTH = 50

--- a/trilogy/dialect/sql_server.py
+++ b/trilogy/dialect/sql_server.py
@@ -40,6 +40,9 @@ TSQL_TEMPLATE = Template(
     """{%- if ctes %}
 WITH {% for cte in ctes %}
 {{cte.name}} as ({{cte.statement}}){% if not loop.last %},{% endif %}{% endfor %}{% endif %}
+{%- if full_select -%}
+{{full_select}}
+{%- else -%}
 SELECT
 {%- if limit is not none %}
 TOP {{ limit }}{% endif %}
@@ -60,7 +63,7 @@ GROUP BY {% for group in group_by %}
 {%- if order_by %}
 ORDER BY {% for order in order_by %}
     {{ order }}{% if not loop.last %},{% endif %}
-{% endfor %}{% endif %}
+{% endfor %}{% endif %}{% endif %}
 """
 )
 

--- a/trilogy/parsing/parse_engine.py
+++ b/trilogy/parsing/parse_engine.py
@@ -864,7 +864,7 @@ class ParseToObjects(Transformer):
             elif isinstance(val, Grain):
                 grain = val
             elif isinstance(val, Query):
-                address = Address(location=f"({val.text})")
+                address = Address(location=f"({val.text})", is_query=True)
         if not address:
             raise ValueError(
                 "Malformed datasource, missing address or query declaration"


### PR DESCRIPTION
## Description

This release adds in an 'Optimization' stage to query generation, which happens post CTE generation. This is intended to support various common patterns (such as predicate pushdown, etc) that do not represent logical changes to output but may affect performance via generating more efficient execution paths.

The first implemented optimization pass is 'datasource in-lining', where a datasource that is a direct table reference can be inlined directly in queries without requiring a parent CTE. Beyond reducing some query complexity overhead, this also makes queries more intuitive and readable to the average user.

This also adds an option to early exit from the final CTE without generating anultimate select, again shortening queries for readability. 

Example query in demo previously

```sql

WITH 
parrot as (
SELECT
    local_raw_data."name" as "passenger_name",
    local_raw_data."passengerid" as "passenger_id"
FROM
    raw_titanic as local_raw_data
)
SELECT
    parrot."passenger_name",
    parrot."passenger_id"
FROM
    parrot

LIMIT (5)
```

Example after

```sql

SELECT
    local_raw_data."name" as "passenger_name",
    local_raw_data."passengerid" as "passenger_id"
FROM
    raw_titanic as local_raw_data

LIMIT (5)
```

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
