### PR TITLE
Predicate pushdown

### DIFF
--- a/tests/modeling/tcp_ds_duckdb/query07.preql
+++ b/tests/modeling/tcp_ds_duckdb/query07.preql
@@ -5,8 +5,12 @@
 import store_sales as store_sales;
 
 
+
+
 with filtered_sales as 
     SELECT
+    store_sales.ticket_number,
+    store_sales.item.id,
     store_sales.item.name,
     store_sales.quantity,
     store_sales.list_price,

--- a/tests/optimization/conftest.py
+++ b/tests/optimization/conftest.py
@@ -1,0 +1,227 @@
+from pytest import fixture
+
+from trilogy import Environment
+from trilogy.core.enums import (
+    Purpose,
+    FunctionType,
+    ComparisonOperator,
+    WindowType,
+)
+from trilogy.core.env_processor import generate_graph
+from trilogy.core.functions import Count, CountDistinct, Max, Min
+from trilogy.core.models import (
+    Concept,
+    DataType,
+    Datasource,
+    ColumnAssignment,
+    Function,
+    Grain,
+    WindowItem,
+    FilterItem,
+    OrderItem,
+    WhereClause,
+    Comparison,
+)
+
+
+@fixture(scope="session")
+def test_environment():
+    env = Environment()
+    order_id = Concept(name="order_id", datatype=DataType.INTEGER, purpose=Purpose.KEY)
+
+    order_timestamp = Concept(
+        name="order_timestamp", datatype=DataType.TIMESTAMP, purpose=Purpose.PROPERTY
+    )
+
+    order_count = Concept(
+        name="order_count",
+        datatype=DataType.INTEGER,
+        purpose=Purpose.METRIC,
+        lineage=Count([order_id]),
+    )
+
+    distinct_order_count = Concept(
+        name="distinct_order_count",
+        datatype=DataType.INTEGER,
+        purpose=Purpose.METRIC,
+        lineage=CountDistinct([order_id]),
+    )
+
+    max_order_id = Concept(
+        name="max_order_id",
+        datatype=DataType.INTEGER,
+        purpose=Purpose.METRIC,
+        lineage=Max([order_id]),
+    )
+
+    min_order_id = Concept(
+        name="min_order_id",
+        datatype=DataType.INTEGER,
+        purpose=Purpose.METRIC,
+        lineage=Min([order_id]),
+    )
+
+    revenue = Concept(
+        name="revenue",
+        datatype=DataType.FLOAT,
+        purpose=Purpose.PROPERTY,
+        keys=[order_id],
+        grain=Grain(components=[order_id]),
+    )
+
+    total_revenue = Concept(
+        name="total_revenue",
+        datatype=DataType.FLOAT,
+        purpose=Purpose.METRIC,
+        lineage=Function(
+            arguments=[revenue],
+            output_datatype=DataType.FLOAT,
+            output_purpose=Purpose.METRIC,
+            operator=FunctionType.SUM,
+        ),
+    )
+    product_id = Concept(
+        name="product_id", datatype=DataType.INTEGER, purpose=Purpose.KEY
+    )
+
+    assert product_id.grain.components[0].name == "product_id"
+
+    category_id = Concept(
+        name="category_id", datatype=DataType.INTEGER, purpose=Purpose.KEY
+    )
+    category_name = Concept(
+        name="category_name",
+        datatype=DataType.STRING,
+        purpose=Purpose.PROPERTY,
+        grain=category_id,
+        keys=[category_id],
+    )
+
+    category_name_length = Concept(
+        name="category_name_length",
+        datatype=DataType.INTEGER,
+        purpose=Purpose.PROPERTY,
+        grain=category_id,
+        lineage=Function(
+            arguments=[category_name],
+            output_datatype=DataType.INTEGER,
+            output_purpose=Purpose.PROPERTY,
+            operator=FunctionType.LENGTH,
+        ),
+        keys=[category_id],
+    )
+
+    category_name_length_sum = Concept(
+        name="category_name_length_sum",
+        datatype=DataType.INTEGER,
+        purpose=Purpose.METRIC,
+        grain=category_id,
+        lineage=Function(
+            arguments=[category_name_length],
+            output_datatype=DataType.INTEGER,
+            output_purpose=Purpose.METRIC,
+            operator=FunctionType.SUM,
+        ),
+    )
+
+    product_revenue_rank = Concept(
+        name="product_revenue_rank",
+        datatype=DataType.INTEGER,
+        purpose=Purpose.PROPERTY,
+        lineage=WindowItem(
+            type=WindowType.RANK,
+            content=product_id,
+            order_by=[
+                OrderItem(expr=total_revenue.with_grain(product_id), order="desc")
+            ],
+        ),
+        grain=product_id,
+    )
+    product_revenue_rank_by_category = Concept(
+        name="product_revenue_rank_by_category",
+        datatype=DataType.INTEGER,
+        purpose=Purpose.PROPERTY,
+        lineage=WindowItem(
+            type=WindowType.RANK,
+            content=product_id,
+            over=[category_id],
+            order_by=[OrderItem(expr=total_revenue, order="desc")],
+        ),
+    )
+
+    products_with_revenue_over_50 = Concept(
+        name="products_with_revenue_over_50",
+        datatype=DataType.INTEGER,
+        purpose=Purpose.KEY,
+        lineage=FilterItem(
+            content=product_id,
+            where=WhereClause(
+                conditional=Comparison(
+                    left=total_revenue.with_grain(product_id),
+                    operator=ComparisonOperator.GT,
+                    right=50,
+                )
+            ),
+        ),
+    )
+    test_revenue = Datasource(
+        identifier="revenue",
+        columns=[
+            ColumnAssignment(alias="revenue", concept=revenue),
+            ColumnAssignment(alias="order_id", concept=order_id),
+            ColumnAssignment(alias="product_id", concept=product_id),
+            ColumnAssignment(alias="order_timestamp", concept=order_timestamp),
+        ],
+        address="tblRevenue",
+        grain=Grain(components=[order_id]),
+    )
+
+    test_product = Datasource(
+        identifier="products",
+        columns=[
+            ColumnAssignment(alias="product_id", concept=product_id),
+            ColumnAssignment(alias="category_id", concept=category_id),
+        ],
+        address="tblProducts",
+        grain=Grain(components=[product_id]),
+    )
+
+    test_category = Datasource(
+        identifier="category",
+        columns=[
+            ColumnAssignment(alias="category_id", concept=category_id),
+            ColumnAssignment(alias="category_name", concept=category_name),
+        ],
+        address="tblCategory",
+        grain=Grain(components=[category_id]),
+    )
+
+    for item in [test_product, test_category, test_revenue]:
+        env.add_datasource(item)
+
+    for item in [
+        category_id,
+        category_name,
+        category_name_length,
+        total_revenue,
+        revenue,
+        product_id,
+        order_id,
+        order_count,
+        order_timestamp,
+        distinct_order_count,
+        min_order_id,
+        max_order_id,
+        product_revenue_rank,
+        product_revenue_rank_by_category,
+        products_with_revenue_over_50,
+        category_name_length_sum,
+    ]:
+        env.add_concept(item)
+        # env.concepts[item.name] = item
+    yield env
+
+
+@fixture(scope="session")
+def test_environment_graph(test_environment):
+    yield generate_graph(test_environment)

--- a/tests/optimization/test_optimization.py
+++ b/tests/optimization/test_optimization.py
@@ -1,0 +1,265 @@
+from trilogy.core.optimization import (
+    PredicatePushdown,
+    decompose_condition,
+    is_child_of,
+)
+from trilogy.core.models import (
+    CTE,
+    QueryDatasource,
+    Conditional,
+    Environment,
+    Grain,
+    Comparison,
+)
+from trilogy.core.enums import BooleanOperator, ComparisonOperator
+
+
+def test_is_child_function():
+    condition = Conditional(
+        left=Comparison(left=1, right=2, operator=ComparisonOperator.EQ),
+        right=Comparison(left=3, right=4, operator=ComparisonOperator.EQ),
+        operator=BooleanOperator.AND,
+    )
+    assert (
+        is_child_of(
+            Comparison(left=1, right=2, operator=ComparisonOperator.EQ), condition
+        )
+        is True
+    )
+    assert (
+        is_child_of(
+            Comparison(left=3, right=4, operator=ComparisonOperator.EQ), condition
+        )
+        is True
+    )
+    assert (
+        is_child_of(
+            Comparison(left=1, right=2, operator=ComparisonOperator.EQ), condition.left
+        )
+        is True
+    )
+    assert (
+        is_child_of(
+            Comparison(left=3, right=4, operator=ComparisonOperator.EQ), condition.right
+        )
+        is True
+    )
+    assert (
+        is_child_of(
+            Comparison(left=1, right=2, operator=ComparisonOperator.EQ), condition.right
+        )
+        is False
+    )
+    assert (
+        is_child_of(
+            Comparison(left=3, right=4, operator=ComparisonOperator.EQ), condition.left
+        )
+        is False
+    )
+
+
+def test_decomposition_function():
+    condition = Conditional(
+        left=Comparison(left=1, right=2, operator=ComparisonOperator.EQ),
+        right=Comparison(left=3, right=4, operator=ComparisonOperator.EQ),
+        operator=BooleanOperator.AND,
+    )
+    decomposed = decompose_condition(condition)
+    assert decomposed == [
+        Comparison(left=1, right=2, operator=ComparisonOperator.EQ),
+        Comparison(left=3, right=4, operator=ComparisonOperator.EQ),
+    ]
+
+
+def test_basic_pushdown(test_environment: Environment, test_environment_graph):
+    datasource = list(test_environment.datasources.values())[0]
+    outputs = [c.concept for c in datasource.columns]
+    cte_source_map = {outputs[0].address: datasource.name}
+    parent = CTE(
+        name="parent",
+        source=QueryDatasource(
+            input_concepts=[outputs[0]],
+            output_concepts=[outputs[0]],
+            datasources=[datasource],
+            grain=Grain(),
+            joins=[],
+            source_map={outputs[0].address: {datasource}},
+        ),
+        output_columns=[],
+        parent_ctes=[],
+        grain=Grain(),
+        source_map=cte_source_map,
+    )
+
+    cte2 = CTE(
+        name="test",
+        source=QueryDatasource(
+            input_concepts=[outputs[0]],
+            output_concepts=[outputs[0]],
+            datasources=[datasource],
+            grain=Grain(),
+            joins=[],
+            source_map={outputs[0].address: {datasource}},
+        ),
+        output_columns=[],
+        parent_ctes=[parent],
+        condition=Comparison(
+            left=outputs[0], right=outputs[0], operator=ComparisonOperator.EQ
+        ),
+        grain=Grain(),
+        source_map=cte_source_map,
+    )
+    inverse_map = {"parent": [cte2]}
+    rule = PredicatePushdown()
+    assert rule.optimize(cte2, inverse_map) is True
+    assert (
+        cte2.condition is None
+    ), f"{cte2.condition}, {parent.condition}, {is_child_of(cte2.condition, parent.condition)}"
+
+
+def test_invalid_pushdown(test_environment: Environment, test_environment_graph):
+    datasource = list(test_environment.datasources.values())[0]
+    outputs = [c.concept for c in datasource.columns]
+    cte_source_map = {outputs[0].address: datasource.name}
+    parent = CTE(
+        name="parent",
+        source=QueryDatasource(
+            input_concepts=[outputs[0]],
+            output_concepts=[outputs[0]],
+            datasources=[datasource],
+            grain=Grain(),
+            joins=[],
+            source_map={outputs[0].address: {datasource}},
+        ),
+        output_columns=[],
+        grain=Grain(),
+        source_map=cte_source_map,
+    )
+    cte1 = CTE(
+        name="test1",
+        source=QueryDatasource(
+            input_concepts=[outputs[0]],
+            output_concepts=[outputs[0]],
+            datasources=[datasource],
+            grain=Grain(),
+            joins=[],
+            source_map={outputs[0].address: {datasource}},
+        ),
+        output_columns=[],
+        parent_ctes=[parent],
+        grain=Grain(),
+        source_map=cte_source_map,
+    )
+
+    cte2 = CTE(
+        name="test2",
+        source=QueryDatasource(
+            input_concepts=[outputs[0]],
+            output_concepts=[outputs[0]],
+            datasources=[datasource],
+            grain=Grain(),
+            joins=[],
+            source_map={outputs[0].address: {datasource}},
+        ),
+        output_columns=[],
+        parent_ctes=[parent],
+        condition=Comparison(
+            left=outputs[0], right=outputs[0], operator=ComparisonOperator.EQ
+        ),
+        grain=Grain(),
+        source_map=cte_source_map,
+    )
+
+    inverse_map = {"parent": [cte1, cte2]}
+    rule = PredicatePushdown()
+    assert rule.optimize(cte1, inverse_map) is False
+    assert cte1.condition is None
+    assert cte2.condition is not None
+
+
+def test_decomposition_pushdown(test_environment: Environment, test_environment_graph):
+    datasource = list(test_environment.datasources.values())[0]
+    outputs = [c.concept for c in datasource.columns]
+    concept_0 = outputs[0]
+    concept_1 = outputs[1]
+    cte_source_map = {output.address: datasource.name for output in outputs}
+    parent1 = CTE(
+        name="parent1",
+        source=QueryDatasource(
+            input_concepts=[concept_0],
+            output_concepts=[concept_0],
+            datasources=[datasource],
+            grain=Grain(),
+            joins=[],
+            source_map={outputs[0].address: {datasource}},
+        ),
+        output_columns=[],
+        condition=Comparison(left=outputs[0], right=1, operator=ComparisonOperator.EQ),
+        grain=Grain(),
+        source_map={outputs[0].address: datasource.name},
+    )
+    parent2 = CTE(
+        name="parent2",
+        source=QueryDatasource(
+            input_concepts=[concept_1],
+            output_concepts=[concept_1],
+            datasources=[datasource],
+            grain=Grain(),
+            joins=[],
+            source_map={concept_1.address: {datasource}},
+        ),
+        output_columns=[],
+        grain=Grain(),
+        source_map={concept_1.address: datasource.name},
+    )
+    cte1 = CTE(
+        name="test1",
+        source=QueryDatasource(
+            input_concepts=[outputs[0], outputs[1]],
+            output_concepts=[outputs[0], concept_1],
+            datasources=[datasource],
+            grain=Grain(),
+            joins=[],
+            source_map={
+                outputs[0].address: {datasource},
+                concept_1.address: {datasource},
+            },
+        ),
+        output_columns=[],
+        parent_ctes=[parent1, parent2],
+        condition=Conditional(
+            left=Comparison(
+                left=outputs[0], right=outputs[0], operator=ComparisonOperator.EQ
+            ),
+            right=Comparison(
+                left=concept_1, right=concept_1, operator=ComparisonOperator.EQ
+            ),
+            operator=BooleanOperator.AND,
+        ),
+        grain=Grain(),
+        source_map=cte_source_map,
+    )
+
+    inverse_map = {"parent1": [cte1], "parent2": [cte1]}
+
+    assert parent2.condition is None
+    rule = PredicatePushdown()
+    assert rule.optimize(cte1, inverse_map) is True
+
+    assert parent1.condition == Conditional(
+        left=Comparison(left=outputs[0], right=1, operator=ComparisonOperator.EQ),
+        right=Comparison(
+            left=outputs[0], right=outputs[0], operator=ComparisonOperator.EQ
+        ),
+        operator=BooleanOperator.AND,
+    )
+    assert isinstance(parent2.condition, Comparison)
+    assert parent2.condition.left == concept_1
+    assert parent2.condition.right == concept_1
+    assert parent2.condition.operator == ComparisonOperator.EQ
+    assert str(parent2.condition) == str(
+        Comparison(left=outputs[1], right=outputs[1], operator=ComparisonOperator.EQ)
+    )
+    # we cannot safely remove this condition
+    # as not all parents have both
+    assert cte1.condition is not None

--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -4,6 +4,6 @@ from trilogy.executor import Executor
 from trilogy.parser import parse
 from trilogy.constants import CONFIG
 
-__version__ = "0.0.1.109"
+__version__ = "0.0.1.110"
 
 __all__ = ["parse", "Executor", "Dialects", "Environment", "CONFIG"]

--- a/trilogy/constants.py
+++ b/trilogy/constants.py
@@ -1,5 +1,5 @@
 from logging import getLogger
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 
 logger = getLogger("preql")
@@ -18,12 +18,20 @@ class MagicConstants(Enum):
 NULL_VALUE = MagicConstants.NULL
 
 
+@dataclass
+class Optimizations:
+    predicate_pushdown: bool = True
+    datasource_inlining: bool = True
+    direct_return: bool = True
+
+
 # TODO: support loading from environments
 @dataclass
 class Config:
     strict_mode: bool = True
     human_identifiers: bool = True
     inline_datasources: bool = True
+    optimizations: Optimizations = field(default_factory=Optimizations)
 
 
 CONFIG = Config()

--- a/trilogy/constants.py
+++ b/trilogy/constants.py
@@ -2,7 +2,7 @@ from logging import getLogger
 from dataclasses import dataclass, field
 from enum import Enum
 
-logger = getLogger("preql")
+logger = getLogger("trilogy")
 
 DEFAULT_NAMESPACE = "local"
 

--- a/trilogy/core/enums.py
+++ b/trilogy/core/enums.py
@@ -263,6 +263,7 @@ class SourceType(Enum):
     WINDOW = "window"
     UNNEST = "unnest"
     CONSTANT = "constant"
+    ROWSET = "rowset"
 
 
 class ShowCategory(Enum):

--- a/trilogy/core/models.py
+++ b/trilogy/core/models.py
@@ -1941,6 +1941,9 @@ class QueryDatasource(BaseModel):
             ),
             join_derived_concepts=self.join_derived_concepts,
             force_group=self.force_group,
+            hidden_concepts=unique(
+                self.hidden_concepts + other.hidden_concepts, "address"
+            ),
         )
 
         return qds
@@ -2100,6 +2103,9 @@ class CTE(BaseModel):
         self.source.source_map = {**self.source.source_map, **other.source.source_map}
         self.source.output_concepts = unique(
             self.source.output_concepts + other.source.output_concepts, "address"
+        )
+        self.hidden_concepts = unique(
+            self.hidden_concepts + other.hidden_concepts, "address"
         )
         return self
 

--- a/trilogy/core/models.py
+++ b/trilogy/core/models.py
@@ -2734,6 +2734,9 @@ class Comparison(ConceptArgs, Namespaced, SelectGrain, BaseModel):
     def __repr__(self):
         return f"{str(self.left)} {self.operator.value} {str(self.right)}"
 
+    def __str__(self):
+        return self.__repr__()
+
     def with_namespace(self, namespace: str):
         return self.__class__(
             left=(

--- a/trilogy/core/optimization.py
+++ b/trilogy/core/optimization.py
@@ -4,6 +4,8 @@ from trilogy.core.models import (
     PersistStatement,
     Datasource,
     MultiSelectStatement,
+    Conditional,
+    BooleanOperator,
 )
 from trilogy.core.enums import PurposeLineage
 from trilogy.constants import logger, CONFIG
@@ -20,6 +22,9 @@ class OptimizationRule(ABC):
 
     def log(self, message: str):
         logger.info(f"[Optimization][{self.__class__.__name__}] {message}")
+
+    def debug(self, message: str):
+        logger.debug(f"[Optimization][{self.__class__.__name__}] {message}")
 
 
 class InlineDatasource(OptimizationRule):
@@ -64,53 +69,79 @@ class InlineDatasource(OptimizationRule):
 
 
 # This will be used in the future for more complex condition decomposition
-# def decompose_condition(conditional: Conditional):
-#     chunks = []
-#     if conditional.operator == ComparisonOperator.EQ and isinstance(conditional.left, Conditional and isinstance(conditional.right, Conditional)):
-#         for left, right in [conditional.left, conditional.right]:
-#             if isinstance(left, Conditional):
-#                 chunks.extend(decompose_condition(left))
-#             else:
-#                 chunks.append(left)
-#             if isinstance(right, Conditional):
-#                 chunks.extend(decompose_condition(right))
-#             else:
-#                 chunks.append(right)
-#     else:
-#         chunks.append(conditional)
-#     return chunks
+def decompose_condition(conditional: Conditional):
+    chunks = []
+    if conditional.operator == BooleanOperator.AND:
+        for val in [conditional.left, conditional.right]:
+            if isinstance(val, Conditional):
+                chunks.extend(decompose_condition(val))
+            else:
+                chunks.append(val)
+    else:
+        chunks.append(conditional)
+    return chunks
+
+
+def is_child_of(a, comparison):
+    if isinstance(comparison, Conditional):
+        return (
+            is_child_of(a, comparison.left) or is_child_of(a, comparison.right)
+        ) and comparison.operator == BooleanOperator.AND
+    return comparison == a
 
 
 class PredicatePushdown(OptimizationRule):
 
     def optimize(self, cte: CTE, inverse_map: dict[str, list[CTE]]) -> bool:
+
         if not cte.parent_ctes:
+            self.debug(f"No parent CTEs for {cte.name}")
+
             return False
 
         optimized = False
         if not cte.condition:
+            self.debug(f"No CTE condition for {cte.name}")
             return False
         self.log(
             f"Checking {cte.name} for predicate pushdown with {len(cte.parent_ctes)} parents"
         )
-        conditions = {x.address for x in cte.condition.concept_arguments}
-        for parent_cte in cte.parent_ctes:
-            materialized = {k for k, v in parent_cte.source_map.items() if v != ""}
-            if conditions.issubset(materialized):
-                if all(
-                    [
-                        child.condition == cte.condition
-                        for child in inverse_map[parent_cte.name]
-                    ]
-                ):
-                    self.log(
-                        f"All concepts are found on {parent_cte.name} and all it's children have same filter, pushing up filter"
-                    )
-                    parent_cte.condition = cte.condition
-                    optimized = True
+        if isinstance(cte.condition, Conditional):
+            candidates = decompose_condition(cte.condition)
+        else:
+            candidates = [cte.condition]
+        logger.info(f"Have {len(candidates)} candidates to try to push down")
+        for candidate in candidates:
+            conditions = {x.address for x in candidate.concept_arguments}
+            for parent_cte in cte.parent_ctes:
+                materialized = {k for k, v in parent_cte.source_map.items() if v != ""}
+                if conditions.issubset(materialized):
+                    if all(
+                        [
+                            is_child_of(candidate, child.condition)
+                            for child in inverse_map[parent_cte.name]
+                        ]
+                    ):
+                        self.log(
+                            f"All concepts are found on {parent_cte.name} and all it's children include same filter; pushing up filter"
+                        )
+                        if parent_cte.condition:
+                            parent_cte.condition = Conditional(
+                                left=parent_cte.condition,
+                                operator=BooleanOperator.AND,
+                                right=candidate,
+                            )
+                        else:
+                            parent_cte.condition = candidate
+                        optimized = True
+                else:
+                    logger.info("conditions not subset of parent materialized")
 
         if all(
-            [parent_cte.condition == cte.condition for parent_cte in cte.parent_ctes]
+            [
+                is_child_of(cte.condition, parent_cte.condition)
+                for parent_cte in cte.parent_ctes
+            ]
         ):
             self.log("All parents have same filter, removing filter")
             cte.condition = None

--- a/trilogy/core/optimization.py
+++ b/trilogy/core/optimization.py
@@ -4,9 +4,8 @@ from trilogy.core.models import (
     PersistStatement,
     Datasource,
     MultiSelectStatement,
-    Conditional,
 )
-from trilogy.core.enums import PurposeLineage, ComparisonOperator
+from trilogy.core.enums import PurposeLineage
 from trilogy.constants import logger, CONFIG
 from abc import ABC
 
@@ -16,7 +15,7 @@ REGISTERED_RULES: list["OptimizationRule"] = []
 
 class OptimizationRule(ABC):
 
-    def optimize(self, cte: CTE) -> bool:
+    def optimize(self, cte: CTE, inverse_map: dict[str, list[CTE]]) -> bool:
         raise NotImplementedError
 
     def log(self, message: str):
@@ -64,21 +63,22 @@ class InlineDatasource(OptimizationRule):
         return optimized
 
 
-def decompose_condition(conditional: Conditional):
-    chunks = []
-    if conditional.operator == ComparisonOperator.EQ:
-        for left, right in [conditional.left, conditional.right]:
-            if isinstance(left, Conditional):
-                chunks.extend(decompose_condition(left))
-            else:
-                chunks.append(left)
-            if isinstance(right, Conditional):
-                chunks.extend(decompose_condition(right))
-            else:
-                chunks.append(right)
-    else:
-        chunks.append(conditional)
-    return chunks
+# This will be used in the future for more complex condition decomposition
+# def decompose_condition(conditional: Conditional):
+#     chunks = []
+#     if conditional.operator == ComparisonOperator.EQ and isinstance(conditional.left, Conditional and isinstance(conditional.right, Conditional)):
+#         for left, right in [conditional.left, conditional.right]:
+#             if isinstance(left, Conditional):
+#                 chunks.extend(decompose_condition(left))
+#             else:
+#                 chunks.append(left)
+#             if isinstance(right, Conditional):
+#                 chunks.extend(decompose_condition(right))
+#             else:
+#                 chunks.append(right)
+#     else:
+#         chunks.append(conditional)
+#     return chunks
 
 
 class PredicatePushdown(OptimizationRule):

--- a/trilogy/core/processing/node_generators/rowset_node.py
+++ b/trilogy/core/processing/node_generators/rowset_node.py
@@ -60,7 +60,10 @@ def gen_rowset_node(
     ]
     select_hidden = set([x.address for x in select.hidden_components])
     rowset_hidden = [
-        x for x in rowset.derived_concepts if x.lineage.content.address in select_hidden
+        x
+        for x in rowset.derived_concepts
+        if isinstance(x.lineage, RowsetItem)
+        and x.lineage.content.address in select_hidden
     ]
     additional_relevant = [
         x for x in select.output_components if x.address in enrichment

--- a/trilogy/core/processing/nodes/merge_node.py
+++ b/trilogy/core/processing/nodes/merge_node.py
@@ -282,6 +282,7 @@ class MergeNode(StrategyNode):
                 if c.address in [x.address for x in self.output_concepts]
             ]
         )
+
         logger.info(
             f"{self.logging_prefix}{LOGGER_PREFIX} has pre grain {pregrain} and final merge node grain {grain}"
         )
@@ -307,9 +308,6 @@ class MergeNode(StrategyNode):
                 f"{self.logging_prefix}{LOGGER_PREFIX} no parents include full grain {grain} and pregrain {pregrain} does not match, assume must group to grain. Have {[str(d.grain) for d in final_datasets]}"
             )
             force_group = True
-            # Grain<returns.customer.id,returns.store.id,returns.item.id,returns.store_sales.ticket_number>
-            # Grain<returns.customer.id,returns.store.id,returns.return_date.id,returns.item.id,returns.store_sales.ticket_number>
-            # Grain<returns.customer.id,returns.store.id,returns.item.id,returns.store_sales.ticket_number>
         else:
             force_group = None
 


### PR DESCRIPTION
## Description

Do a first pass implementation of predicate pushdown, where a "filter" will be progressively moved upwards in the CTE stack as long as the filtering predicates are valid inputs to the CTE and the CTE has no downstreams that do not require unfiltered data.

This makes it easier for a database engine to appropriately filter data earlier in execution.

This can be expanded further in the future; currently the simplest conditions are supported:

To push up; for each decomposed component in a chain of boolean ANDs [or a single condition]
[x] all condition columns are on parent CTE and not derived in it
[x] all children CTEs have the same condition

To remove after pushing up
[x] all CTE conditions are a subset of parent conditions


This means that sometimes we may push a value up partially but keep it on the base; this is because the logic of 

x intersect y filter z cannot be verified to be the same for (x filter z) intersect y without additional checks.


## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
