### PR TITLE
Constant Optimization

### DIFF
--- a/tests/engine/test_duckdb.py
+++ b/tests/engine/test_duckdb.py
@@ -547,7 +547,6 @@ order by
     assert len(results) == 2
 
 
-
 def test_raw_sql():
     from trilogy.hooks.query_debugger import DebuggingHook
 

--- a/tests/engine/test_duckdb.py
+++ b/tests/engine/test_duckdb.py
@@ -545,3 +545,21 @@ order by
     results = default_duckdb_engine.execute_text(test)[0].fetchall()
     assert results[0] == (4,)
     assert len(results) == 2
+
+
+
+def test_raw_sql():
+    from trilogy.hooks.query_debugger import DebuggingHook
+
+    test = """
+raw_sql('''
+select unnest([1,2,3,4]) as x
+order by x asc
+''')
+;"""
+    default_duckdb_engine = Dialects.DUCK_DB.default_executor()
+
+    default_duckdb_engine.hooks = [DebuggingHook()]
+    results = default_duckdb_engine.execute_text(test)[0].fetchall()
+    assert results[0] == (1,)
+    assert len(results) == 4

--- a/tests/optimization/test_constant_optimization.py
+++ b/tests/optimization/test_constant_optimization.py
@@ -3,7 +3,7 @@ from trilogy import Dialects
 
 def test_constant_optimization():
 
-    test_query = '''
+    test_query = """
     const x <- 1;
 
     auto array <- unnest([1,2,3,4,5,6,7,8,9,10]);
@@ -14,11 +14,9 @@ def test_constant_optimization():
     WHERE
         array = x
     ;
-    '''
+    """
 
     exec = Dialects.DUCK_DB.default_executor()
 
     generated = exec.generate_sql(test_query)[0]
-    print(generated)
-    assert generated == 'select 1'
-    assert '1 as "x"' not in generated
+    assert '"array" = 1' in generated

--- a/tests/optimization/test_constant_optimization.py
+++ b/tests/optimization/test_constant_optimization.py
@@ -1,0 +1,24 @@
+from trilogy import Dialects
+
+
+def test_constant_optimization():
+
+    test_query = '''
+    const x <- 1;
+
+    auto array <- unnest([1,2,3,4,5,6,7,8,9,10]);
+
+    SELECT
+        x,
+        array
+    WHERE
+        array = x
+    ;
+    '''
+
+    exec = Dialects.DUCK_DB.default_executor()
+
+    generated = exec.generate_sql(test_query)[0]
+    print(generated)
+    assert generated == 'select 1'
+    assert '1 as "x"' not in generated

--- a/tests/optimization/test_optimization.py
+++ b/tests/optimization/test_optimization.py
@@ -1,8 +1,9 @@
 from trilogy.core.optimization import (
     PredicatePushdown,
-    decompose_condition,
-    is_child_of,
+
 )
+from trilogy.core.optimizations.predicate_pushdown import (    decompose_condition,
+    is_child_of)
 from trilogy.core.models import (
     CTE,
     QueryDatasource,

--- a/tests/optimization/test_optimization.py
+++ b/tests/optimization/test_optimization.py
@@ -1,9 +1,10 @@
 from trilogy.core.optimization import (
     PredicatePushdown,
-
 )
-from trilogy.core.optimizations.predicate_pushdown import (    decompose_condition,
-    is_child_of)
+from trilogy.core.optimizations.predicate_pushdown import (
+    decompose_condition,
+    is_child_of,
+)
 from trilogy.core.models import (
     CTE,
     QueryDatasource,

--- a/tests/rendering/test_rendering.py
+++ b/tests/rendering/test_rendering.py
@@ -23,6 +23,7 @@ from trilogy.core.models import (
     MultiSelectStatement,
     AlignClause,
     AlignItem,
+    RawSQLStatement,
 )
 from trilogy import Environment
 from trilogy.core.enums import (
@@ -345,3 +346,13 @@ def test_render_merge():
 
 def test_render_persist_to_source():
     pass
+
+
+def test_render_raw_sqlpersist_to_source():
+    test = Renderer().to_string(
+        RawSQLStatement(
+            text= "SELECT * FROM test",
+        )
+    )
+
+    assert test == "raw_sql('''SELECT * FROM test''');"

--- a/tests/rendering/test_rendering.py
+++ b/tests/rendering/test_rendering.py
@@ -351,7 +351,7 @@ def test_render_persist_to_source():
 def test_render_raw_sqlpersist_to_source():
     test = Renderer().to_string(
         RawSQLStatement(
-            text= "SELECT * FROM test",
+            text="SELECT * FROM test",
         )
     )
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -292,3 +292,16 @@ CASE WHEN dates.year BETWEEN 1883 AND 1900 THEN 'Lost Generation'
     )
 
     assert env2.concepts["dates.generation"].purpose == Purpose.PROPERTY
+
+
+def test_rawsql():
+    env, parsed = parse_text(
+        """
+raw_sql('''select 1''');
+
+select 1 as test;
+
+"""
+    )
+    assert parsed[0].text == "select 1"
+

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -304,4 +304,3 @@ select 1 as test;
 """
     )
     assert parsed[0].text == "select 1"
-

--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -4,6 +4,6 @@ from trilogy.executor import Executor
 from trilogy.parser import parse
 from trilogy.constants import CONFIG
 
-__version__ = "0.0.1.115"
+__version__ = "0.0.1.116"
 
 __all__ = ["parse", "Executor", "Dialects", "Environment", "CONFIG"]

--- a/trilogy/constants.py
+++ b/trilogy/constants.py
@@ -22,6 +22,7 @@ NULL_VALUE = MagicConstants.NULL
 class Optimizations:
     predicate_pushdown: bool = True
     datasource_inlining: bool = True
+    constant_inlining: bool = True
     direct_return: bool = True
 
 

--- a/trilogy/core/optimization.py
+++ b/trilogy/core/optimization.py
@@ -2,155 +2,13 @@ from trilogy.core.models import (
     CTE,
     SelectStatement,
     PersistStatement,
-    Datasource,
     MultiSelectStatement,
     Conditional,
     BooleanOperator,
 )
 from trilogy.core.enums import PurposeLineage
 from trilogy.constants import logger, CONFIG
-from abc import ABC
-
-
-class OptimizationRule(ABC):
-
-    def optimize(self, cte: CTE, inverse_map: dict[str, list[CTE]]) -> bool:
-        raise NotImplementedError
-
-    def log(self, message: str):
-        logger.info(f"[Optimization][{self.__class__.__name__}] {message}")
-
-    def debug(self, message: str):
-        logger.debug(f"[Optimization][{self.__class__.__name__}] {message}")
-
-
-class InlineDatasource(OptimizationRule):
-
-    def optimize(self, cte: CTE, inverse_map: dict[str, list[CTE]]) -> bool:
-        if not cte.parent_ctes:
-            return False
-
-        optimized = False
-        self.log(
-            f"Checking {cte.name} for consolidating inline tables with {len(cte.parent_ctes)} parents"
-        )
-        to_inline: list[CTE] = []
-        force_group = False
-        for parent_cte in cte.parent_ctes:
-            if not parent_cte.is_root_datasource:
-                self.log(f"parent {parent_cte.name} is not root")
-                continue
-            if parent_cte.parent_ctes:
-                self.log(f"parent {parent_cte.name} has parents")
-                continue
-            raw_root = parent_cte.source.datasources[0]
-            if not isinstance(raw_root, Datasource):
-                self.log(f"parent {parent_cte.name} is not datasource")
-                continue
-            root: Datasource = raw_root
-            if not root.can_be_inlined:
-                self.log(f"parent {parent_cte.name} datasource is not inlineable")
-                continue
-            root_outputs = {x.address for x in root.output_concepts}
-            cte_outputs = {x.address for x in parent_cte.output_columns}
-            grain_components = {x.address for x in root.grain.components}
-            if not cte_outputs.issubset(root_outputs):
-                self.log(f"Not all {parent_cte.name} outputs are found on datasource")
-                continue
-            if not grain_components.issubset(cte_outputs):
-                self.log("Not all datasource components in cte outputs, forcing group")
-                force_group = True
-            to_inline.append(parent_cte)
-
-        for replaceable in to_inline:
-
-            result = cte.inline_parent_datasource(replaceable, force_group=force_group)
-            if result:
-                self.log(f"Inlined parent {replaceable.name}")
-            else:
-                self.log(f"Failed to inline {replaceable.name}")
-        return optimized
-
-
-def decompose_condition(conditional: Conditional):
-    chunks = []
-    if conditional.operator == BooleanOperator.AND:
-        for val in [conditional.left, conditional.right]:
-            if isinstance(val, Conditional):
-                chunks.extend(decompose_condition(val))
-            else:
-                chunks.append(val)
-    else:
-        chunks.append(conditional)
-    return chunks
-
-
-def is_child_of(a, comparison):
-    if isinstance(comparison, Conditional):
-        return (
-            is_child_of(a, comparison.left) or is_child_of(a, comparison.right)
-        ) and comparison.operator == BooleanOperator.AND
-    return comparison == a
-
-
-class PredicatePushdown(OptimizationRule):
-
-    def optimize(self, cte: CTE, inverse_map: dict[str, list[CTE]]) -> bool:
-
-        if not cte.parent_ctes:
-            self.debug(f"No parent CTEs for {cte.name}")
-
-            return False
-
-        optimized = False
-        if not cte.condition:
-            self.debug(f"No CTE condition for {cte.name}")
-            return False
-        self.log(
-            f"Checking {cte.name} for predicate pushdown with {len(cte.parent_ctes)} parents"
-        )
-        if isinstance(cte.condition, Conditional):
-            candidates = cte.condition.decompose()
-        else:
-            candidates = [cte.condition]
-        logger.info(f"Have {len(candidates)} candidates to try to push down")
-        for candidate in candidates:
-            conditions = {x.address for x in candidate.concept_arguments}
-            for parent_cte in cte.parent_ctes:
-                materialized = {k for k, v in parent_cte.source_map.items() if v != []}
-                if conditions.issubset(materialized):
-                    if all(
-                        [
-                            is_child_of(candidate, child.condition)
-                            for child in inverse_map[parent_cte.name]
-                        ]
-                    ):
-                        self.log(
-                            f"All concepts are found on {parent_cte.name} and all it's children include same filter; pushing up filter"
-                        )
-                        if parent_cte.condition:
-                            parent_cte.condition = Conditional(
-                                left=parent_cte.condition,
-                                operator=BooleanOperator.AND,
-                                right=candidate,
-                            )
-                        else:
-                            parent_cte.condition = candidate
-                        optimized = True
-                else:
-                    logger.info("conditions not subset of parent materialized")
-
-        if all(
-            [
-                is_child_of(cte.condition, parent_cte.condition)
-                for parent_cte in cte.parent_ctes
-            ]
-        ):
-            self.log("All parents have same filter, removing filter")
-            cte.condition = None
-            optimized = True
-
-        return optimized
+from trilogy.core.optimizations import OptimizationRule, InlineConstant, PredicatePushdown, InlineDatasource
 
 
 def filter_irrelevant_ctes(
@@ -232,7 +90,8 @@ def optimize_ctes(
         REGISTERED_RULES.append(InlineDatasource())
     if CONFIG.optimizations.predicate_pushdown:
         REGISTERED_RULES.append(PredicatePushdown())
-
+    if CONFIG.optimizations.constant_inlining:
+        REGISTERED_RULES.append(InlineConstant())
     while not complete:
         actions_taken = False
         for rule in REGISTERED_RULES:

--- a/trilogy/core/optimizations/__init__.py
+++ b/trilogy/core/optimizations/__init__.py
@@ -1,0 +1,6 @@
+from .inline_constant import InlineConstant
+from .inline_datasource import InlineDatasource
+from .predicate_pushdown import PredicatePushdown
+from .base_optimization import OptimizationRule
+__all__ = [OptimizationRule, InlineConstant, InlineDatasource,PredicatePushdown]
+

--- a/trilogy/core/optimizations/__init__.py
+++ b/trilogy/core/optimizations/__init__.py
@@ -2,5 +2,10 @@ from .inline_constant import InlineConstant
 from .inline_datasource import InlineDatasource
 from .predicate_pushdown import PredicatePushdown
 from .base_optimization import OptimizationRule
-__all__ = [OptimizationRule, InlineConstant, InlineDatasource,PredicatePushdown]
 
+__all__ = [
+    "OptimizationRule",
+    "InlineConstant",
+    "InlineDatasource",
+    "PredicatePushdown",
+]

--- a/trilogy/core/optimizations/base_optimization.py
+++ b/trilogy/core/optimizations/base_optimization.py
@@ -1,0 +1,24 @@
+from trilogy.core.models import (
+    CTE,
+    SelectStatement,
+    PersistStatement,
+    Datasource,
+    MultiSelectStatement,
+    Conditional,
+    BooleanOperator,
+)
+from trilogy.core.enums import PurposeLineage
+from trilogy.constants import logger, CONFIG
+from abc import ABC
+
+
+class OptimizationRule(ABC):
+
+    def optimize(self, cte: CTE, inverse_map: dict[str, list[CTE]]) -> bool:
+        raise NotImplementedError
+
+    def log(self, message: str):
+        logger.info(f"[Optimization][{self.__class__.__name__}] {message}")
+
+    def debug(self, message: str):
+        logger.debug(f"[Optimization][{self.__class__.__name__}] {message}")

--- a/trilogy/core/optimizations/base_optimization.py
+++ b/trilogy/core/optimizations/base_optimization.py
@@ -1,14 +1,7 @@
 from trilogy.core.models import (
     CTE,
-    SelectStatement,
-    PersistStatement,
-    Datasource,
-    MultiSelectStatement,
-    Conditional,
-    BooleanOperator,
 )
-from trilogy.core.enums import PurposeLineage
-from trilogy.constants import logger, CONFIG
+from trilogy.constants import logger
 from abc import ABC
 
 

--- a/trilogy/core/optimizations/inline_constant.py
+++ b/trilogy/core/optimizations/inline_constant.py
@@ -1,0 +1,29 @@
+from trilogy.core.models import (
+    CTE,
+    SelectStatement,
+    PersistStatement,
+    Datasource,
+    MultiSelectStatement,
+    Conditional,
+    BooleanOperator,
+)
+from trilogy.core.enums import PurposeLineage
+from trilogy.constants import logger, CONFIG
+from abc import ABC
+
+from trilogy.core.optimizations.base_optimization import OptimizationRule
+
+class InlineConstant(OptimizationRule):
+
+    def optimize(self, cte: CTE, inverse_map: dict[str, list[CTE]]) -> bool:
+        to_inline = []
+        for x in cte.source.input_concepts:
+            if x.derivation == PurposeLineage.CONSTANT:
+                self.log(f"Found constant {x.address}")
+                to_inline.append(x)
+        
+        if to_inline:
+            for c in to_inline:
+                cte.inline_constant(c)
+            return True
+        return False

--- a/trilogy/core/optimizations/inline_constant.py
+++ b/trilogy/core/optimizations/inline_constant.py
@@ -1,29 +1,29 @@
 from trilogy.core.models import (
     CTE,
-    SelectStatement,
-    PersistStatement,
-    Datasource,
-    MultiSelectStatement,
-    Conditional,
-    BooleanOperator,
+    Concept,
 )
 from trilogy.core.enums import PurposeLineage
-from trilogy.constants import logger, CONFIG
-from abc import ABC
 
 from trilogy.core.optimizations.base_optimization import OptimizationRule
+
 
 class InlineConstant(OptimizationRule):
 
     def optimize(self, cte: CTE, inverse_map: dict[str, list[CTE]]) -> bool:
-        to_inline = []
+
+        to_inline: list[Concept] = []
         for x in cte.source.input_concepts:
+            if x.address not in cte.source_map:
+                continue
             if x.derivation == PurposeLineage.CONSTANT:
-                self.log(f"Found constant {x.address}")
+                self.log(f"Found constant {x.address} on {cte.name}")
                 to_inline.append(x)
-        
         if to_inline:
+            inlined = False
             for c in to_inline:
-                cte.inline_constant(c)
-            return True
+                self.log(f"Inlining constant {c.address} on  {cte.name}")
+                test = cte.inline_constant(c)
+                if test:
+                    inlined = True
+            return inlined
         return False

--- a/trilogy/core/optimizations/inline_datasource.py
+++ b/trilogy/core/optimizations/inline_datasource.py
@@ -1,17 +1,10 @@
 from trilogy.core.models import (
     CTE,
-    SelectStatement,
-    PersistStatement,
     Datasource,
-    MultiSelectStatement,
-    Conditional,
-    BooleanOperator,
 )
-from trilogy.core.enums import PurposeLineage
-from trilogy.constants import logger, CONFIG
-from abc import ABC
 
 from trilogy.core.optimizations.base_optimization import OptimizationRule
+
 
 class InlineDatasource(OptimizationRule):
 

--- a/trilogy/core/optimizations/inline_datasource.py
+++ b/trilogy/core/optimizations/inline_datasource.py
@@ -1,0 +1,61 @@
+from trilogy.core.models import (
+    CTE,
+    SelectStatement,
+    PersistStatement,
+    Datasource,
+    MultiSelectStatement,
+    Conditional,
+    BooleanOperator,
+)
+from trilogy.core.enums import PurposeLineage
+from trilogy.constants import logger, CONFIG
+from abc import ABC
+
+from trilogy.core.optimizations.base_optimization import OptimizationRule
+
+class InlineDatasource(OptimizationRule):
+
+    def optimize(self, cte: CTE, inverse_map: dict[str, list[CTE]]) -> bool:
+        if not cte.parent_ctes:
+            return False
+
+        optimized = False
+        self.log(
+            f"Checking {cte.name} for consolidating inline tables with {len(cte.parent_ctes)} parents"
+        )
+        to_inline: list[CTE] = []
+        force_group = False
+        for parent_cte in cte.parent_ctes:
+            if not parent_cte.is_root_datasource:
+                self.log(f"parent {parent_cte.name} is not root")
+                continue
+            if parent_cte.parent_ctes:
+                self.log(f"parent {parent_cte.name} has parents")
+                continue
+            raw_root = parent_cte.source.datasources[0]
+            if not isinstance(raw_root, Datasource):
+                self.log(f"parent {parent_cte.name} is not datasource")
+                continue
+            root: Datasource = raw_root
+            if not root.can_be_inlined:
+                self.log(f"parent {parent_cte.name} datasource is not inlineable")
+                continue
+            root_outputs = {x.address for x in root.output_concepts}
+            cte_outputs = {x.address for x in parent_cte.output_columns}
+            grain_components = {x.address for x in root.grain.components}
+            if not cte_outputs.issubset(root_outputs):
+                self.log(f"Not all {parent_cte.name} outputs are found on datasource")
+                continue
+            if not grain_components.issubset(cte_outputs):
+                self.log("Not all datasource components in cte outputs, forcing group")
+                force_group = True
+            to_inline.append(parent_cte)
+
+        for replaceable in to_inline:
+
+            result = cte.inline_parent_datasource(replaceable, force_group=force_group)
+            if result:
+                self.log(f"Inlined parent {replaceable.name}")
+            else:
+                self.log(f"Failed to inline {replaceable.name}")
+        return optimized

--- a/trilogy/core/optimizations/predicate_pushdown.py
+++ b/trilogy/core/optimizations/predicate_pushdown.py
@@ -1,16 +1,12 @@
 from trilogy.core.models import (
     CTE,
-    SelectStatement,
-    PersistStatement,
-    Datasource,
-    MultiSelectStatement,
     Conditional,
     BooleanOperator,
 )
-from trilogy.core.enums import PurposeLineage
-from trilogy.constants import logger, CONFIG
-from abc import ABC
+from trilogy.constants import logger
 from trilogy.core.optimizations.base_optimization import OptimizationRule
+
+
 def decompose_condition(conditional: Conditional):
     chunks = []
     if conditional.operator == BooleanOperator.AND:

--- a/trilogy/core/optimizations/predicate_pushdown.py
+++ b/trilogy/core/optimizations/predicate_pushdown.py
@@ -1,0 +1,92 @@
+from trilogy.core.models import (
+    CTE,
+    SelectStatement,
+    PersistStatement,
+    Datasource,
+    MultiSelectStatement,
+    Conditional,
+    BooleanOperator,
+)
+from trilogy.core.enums import PurposeLineage
+from trilogy.constants import logger, CONFIG
+from abc import ABC
+from trilogy.core.optimizations.base_optimization import OptimizationRule
+def decompose_condition(conditional: Conditional):
+    chunks = []
+    if conditional.operator == BooleanOperator.AND:
+        for val in [conditional.left, conditional.right]:
+            if isinstance(val, Conditional):
+                chunks.extend(decompose_condition(val))
+            else:
+                chunks.append(val)
+    else:
+        chunks.append(conditional)
+    return chunks
+
+
+def is_child_of(a, comparison):
+    if isinstance(comparison, Conditional):
+        return (
+            is_child_of(a, comparison.left) or is_child_of(a, comparison.right)
+        ) and comparison.operator == BooleanOperator.AND
+    return comparison == a
+
+
+class PredicatePushdown(OptimizationRule):
+
+    def optimize(self, cte: CTE, inverse_map: dict[str, list[CTE]]) -> bool:
+
+        if not cte.parent_ctes:
+            self.debug(f"No parent CTEs for {cte.name}")
+
+            return False
+
+        optimized = False
+        if not cte.condition:
+            self.debug(f"No CTE condition for {cte.name}")
+            return False
+        self.log(
+            f"Checking {cte.name} for predicate pushdown with {len(cte.parent_ctes)} parents"
+        )
+        if isinstance(cte.condition, Conditional):
+            candidates = cte.condition.decompose()
+        else:
+            candidates = [cte.condition]
+        logger.info(f"Have {len(candidates)} candidates to try to push down")
+        for candidate in candidates:
+            conditions = {x.address for x in candidate.concept_arguments}
+            for parent_cte in cte.parent_ctes:
+                materialized = {k for k, v in parent_cte.source_map.items() if v != []}
+                if conditions.issubset(materialized):
+                    if all(
+                        [
+                            is_child_of(candidate, child.condition)
+                            for child in inverse_map[parent_cte.name]
+                        ]
+                    ):
+                        self.log(
+                            f"All concepts are found on {parent_cte.name} and all it's children include same filter; pushing up filter"
+                        )
+                        if parent_cte.condition:
+                            parent_cte.condition = Conditional(
+                                left=parent_cte.condition,
+                                operator=BooleanOperator.AND,
+                                right=candidate,
+                            )
+                        else:
+                            parent_cte.condition = candidate
+                        optimized = True
+                else:
+                    logger.info("conditions not subset of parent materialized")
+
+        if all(
+            [
+                is_child_of(cte.condition, parent_cte.condition)
+                for parent_cte in cte.parent_ctes
+            ]
+        ):
+            self.log("All parents have same filter, removing filter")
+            cte.condition = None
+            optimized = True
+
+        return optimized

--- a/trilogy/dialect/base.py
+++ b/trilogy/dialect/base.py
@@ -44,6 +44,8 @@ from trilogy.core.models import (
     RowsetDerivationStatement,
     ConceptDeclarationStatement,
     ImportStatement,
+    RawSQLStatement,
+    ProcessedRawSQLStatement,
 )
 from trilogy.core.query_processor import process_query, process_persist
 from trilogy.dialect.common import render_join
@@ -558,11 +560,12 @@ class BaseDialect:
             | RowsetDerivationStatement
             | MergeStatement
             | ImportStatement
+            | RawSQLStatement
         ],
         hooks: Optional[List[BaseHook]] = None,
-    ) -> List[ProcessedQuery | ProcessedQueryPersist | ProcessedShowStatement]:
+    ) -> List[ProcessedQuery | ProcessedQueryPersist | ProcessedShowStatement | RawSQLStatement]:
         output: List[
-            ProcessedQuery | ProcessedQueryPersist | ProcessedShowStatement
+            ProcessedQuery | ProcessedQueryPersist | ProcessedShowStatement | RawSQLStatement
         ] = []
         for statement in statements:
             if isinstance(statement, PersistStatement):
@@ -604,6 +607,8 @@ class BaseDialect:
                     )
                 else:
                     raise NotImplementedError(type(statement))
+            elif isinstance(statement, RawSQLStatement):
+                output.append(ProcessedRawSQLStatement(text=statement.text))
             elif isinstance(
                 statement,
                 (
@@ -619,10 +624,12 @@ class BaseDialect:
         return output
 
     def compile_statement(
-        self, query: ProcessedQuery | ProcessedQueryPersist | ProcessedShowStatement
+        self, query: ProcessedQuery | ProcessedQueryPersist | ProcessedShowStatement | ProcessedRawSQLStatement
     ) -> str:
         if isinstance(query, ProcessedShowStatement):
             return ";\n".join([str(x) for x in query.output_values])
+        elif isinstance(query, ProcessedRawSQLStatement):
+            return query.text
         select_columns: Dict[str, str] = {}
         cte_output_map = {}
         selected = set()

--- a/trilogy/dialect/base.py
+++ b/trilogy/dialect/base.py
@@ -563,9 +563,17 @@ class BaseDialect:
             | RawSQLStatement
         ],
         hooks: Optional[List[BaseHook]] = None,
-    ) -> List[ProcessedQuery | ProcessedQueryPersist | ProcessedShowStatement | RawSQLStatement]:
+    ) -> List[
+        ProcessedQuery
+        | ProcessedQueryPersist
+        | ProcessedShowStatement
+        | ProcessedRawSQLStatement
+    ]:
         output: List[
-            ProcessedQuery | ProcessedQueryPersist | ProcessedShowStatement | RawSQLStatement
+            ProcessedQuery
+            | ProcessedQueryPersist
+            | ProcessedShowStatement
+            | ProcessedRawSQLStatement
         ] = []
         for statement in statements:
             if isinstance(statement, PersistStatement):
@@ -624,7 +632,13 @@ class BaseDialect:
         return output
 
     def compile_statement(
-        self, query: ProcessedQuery | ProcessedQueryPersist | ProcessedShowStatement | ProcessedRawSQLStatement
+        self,
+        query: (
+            ProcessedQuery
+            | ProcessedQueryPersist
+            | ProcessedShowStatement
+            | ProcessedRawSQLStatement
+        ),
     ) -> str:
         if isinstance(query, ProcessedShowStatement):
             return ";\n".join([str(x) for x in query.output_values])

--- a/trilogy/dialect/sql_server.py
+++ b/trilogy/dialect/sql_server.py
@@ -9,6 +9,7 @@ from trilogy.core.models import (
     ProcessedQuery,
     ProcessedQueryPersist,
     ProcessedShowStatement,
+    ProcessedRawSQLStatement,
 )
 from trilogy.dialect.base import BaseDialect
 
@@ -81,7 +82,13 @@ class SqlServerDialect(BaseDialect):
     SQL_TEMPLATE = TSQL_TEMPLATE
 
     def compile_statement(
-        self, query: ProcessedQuery | ProcessedQueryPersist | ProcessedShowStatement
+        self,
+        query: (
+            ProcessedQuery
+            | ProcessedQueryPersist
+            | ProcessedShowStatement
+            | ProcessedRawSQLStatement
+        ),
     ) -> str:
         base = super().compile_statement(query)
         if isinstance(base, (ProcessedQuery, ProcessedQueryPersist)):

--- a/trilogy/executor.py
+++ b/trilogy/executor.py
@@ -113,11 +113,11 @@ class Executor(object):
             self.environment, [query], hooks=self.hooks
         )
         return self.execute_query(sql[0])
-    
+
     @execute_query.register
-    def _(self, query:RawSQLStatement) -> CursorResult:
+    def _(self, query: RawSQLStatement) -> CursorResult:
         return self.execute_raw_sql(query.text)
-    
+
     @execute_query.register
     def _(self, query: ProcessedShowStatement) -> CursorResult:
         return generate_result_set(
@@ -128,10 +128,11 @@ class Executor(object):
                 if isinstance(x, ProcessedQuery)
             ],
         )
+
     @execute_query.register
-    def _(self, query:ProcessedRawSQLStatement) -> CursorResult:
+    def _(self, query: ProcessedRawSQLStatement) -> CursorResult:
         return self.execute_raw_sql(query.text)
-    
+
     @execute_query.register
     def _(self, query: ProcessedQuery) -> CursorResult:
         sql = self.generator.compile_statement(query)
@@ -204,7 +205,12 @@ class Executor(object):
 
     def parse_text(
         self, command: str, persist: bool = False
-    ) -> List[ProcessedQuery | ProcessedQueryPersist | ProcessedShowStatement]:
+    ) -> List[
+        ProcessedQuery
+        | ProcessedQueryPersist
+        | ProcessedShowStatement
+        | ProcessedRawSQLStatement
+    ]:
         """Process a preql text command"""
         _, parsed = parse_text(command, self.environment)
         generatable = [
@@ -232,10 +238,13 @@ class Executor(object):
             sql.append(x)
         return sql
 
-    def parse_text_generator(
-        self, command: str, persist: bool = False
-    ) -> Generator[
-        ProcessedQuery | ProcessedQueryPersist | ProcessedShowStatement | ProcessedRawSQLStatement, None, None
+    def parse_text_generator(self, command: str, persist: bool = False) -> Generator[
+        ProcessedQuery
+        | ProcessedQueryPersist
+        | ProcessedShowStatement
+        | ProcessedRawSQLStatement,
+        None,
+        None,
     ]:
         """Process a preql text command"""
         _, parsed = parse_text(command, self.environment)

--- a/trilogy/parsing/parse_engine.py
+++ b/trilogy/parsing/parse_engine.py
@@ -588,7 +588,7 @@ class ParseToObjects(Transformer):
 
     def MULTILINE_STRING(self, args) -> str:
         return args[3:-3]
-    
+
     def raw_column_assignment(self, args):
         return RawColumnExpr(text=args[0])
 
@@ -761,9 +761,8 @@ class ParseToObjects(Transformer):
         return merge
 
     @v_args(meta=True)
-    def rawsql_statement(self, meta: Meta, args) -> MergeStatement:
-        merge = RawSQLStatement(meta=Metadata(line_number=meta.line), text=args[0])
-        return merge
+    def rawsql_statement(self, meta: Meta, args) -> RawSQLStatement:
+        return RawSQLStatement(meta=Metadata(line_number=meta.line), text=args[0])
 
     def import_statement(self, args: list[str]) -> ImportStatement:
         alias = args[-1]

--- a/trilogy/parsing/parse_engine.py
+++ b/trilogy/parsing/parse_engine.py
@@ -82,6 +82,7 @@ from trilogy.core.models import (
     Parenthetical,
     PersistStatement,
     Query,
+    RawSQLStatement,
     SelectStatement,
     SelectItem,
     WhereClause,
@@ -585,8 +586,11 @@ class ParseToObjects(Transformer):
         #            namespace=self.environment.namespace,
         return Grain(components=[self.environment.concepts[a] for a in args[0]])
 
+    def MULTILINE_STRING(self, args) -> str:
+        return args[3:-3]
+    
     def raw_column_assignment(self, args):
-        return RawColumnExpr(text=args[0][3:-3])
+        return RawColumnExpr(text=args[0])
 
     @v_args(meta=True)
     def datasource(self, meta: Meta, args):
@@ -756,6 +760,11 @@ class ParseToObjects(Transformer):
         self.environment.add_concept(new, meta=meta)
         return merge
 
+    @v_args(meta=True)
+    def rawsql_statement(self, meta: Meta, args) -> MergeStatement:
+        merge = RawSQLStatement(meta=Metadata(line_number=meta.line), text=args[0])
+        return merge
+
     def import_statement(self, args: list[str]) -> ImportStatement:
         alias = args[-1]
         path = args[0].split(".")
@@ -822,7 +831,11 @@ class ParseToObjects(Transformer):
             address=Address(location=address),
             grain=grain,
         )
-        return PersistStatement(select=select, datasource=new_datasource)
+        return PersistStatement(
+            select=select,
+            datasource=new_datasource,
+            meta=Metadata(line_number=meta.line),
+        )
 
     @v_args(meta=True)
     def align_item(self, meta: Meta, args) -> AlignItem:
@@ -864,6 +877,7 @@ class ParseToObjects(Transformer):
             where_clause=where,
             order_by=order_by,
             limit=limit,
+            meta=Metadata(line_number=meta.line),
         )
         for concept in multi.derived_concepts:
             self.environment.add_concept(concept, meta=meta)
@@ -887,7 +901,11 @@ class ParseToObjects(Transformer):
         if not select_items:
             raise ValueError("Malformed select, missing select items")
         output = SelectStatement(
-            selection=select_items, where_clause=where, limit=limit, order_by=order_by
+            selection=select_items,
+            where_clause=where,
+            limit=limit,
+            order_by=order_by,
+            meta=Metadata(line_number=meta.line),
         )
         for item in select_items:
             # we don't know the grain of an aggregate at assignment time
@@ -912,7 +930,7 @@ class ParseToObjects(Transformer):
 
     @v_args(meta=True)
     def query(self, meta: Meta, args):
-        return Query(text=args[0][3:-3])
+        return Query(text=args[0])
 
     def where(self, args):
         root = args[0]
@@ -1692,6 +1710,7 @@ def parse_text(text: str, environment: Optional[Environment] = None) -> Tuple[
         | SelectStatement
         | PersistStatement
         | ShowStatement
+        | RawSQLStatement
         | None
     ],
 ]:

--- a/trilogy/parsing/render.py
+++ b/trilogy/parsing/render.py
@@ -183,11 +183,10 @@ class Renderer:
     @to_string.register
     def _(self, arg: "Address"):
         return f"address {arg.location}"
-    
+
     @to_string.register
     def _(self, arg: "RawSQLStatement"):
         return f"raw_sql('''{arg.text}''');"
-
 
     @to_string.register
     def _(self, arg: "MagicConstants"):

--- a/trilogy/parsing/render.py
+++ b/trilogy/parsing/render.py
@@ -38,6 +38,7 @@ from trilogy.core.models import (
     OrderBy,
     AlignClause,
     AlignItem,
+    RawSQLStatement,
 )
 from trilogy.core.enums import Modifier
 
@@ -182,6 +183,11 @@ class Renderer:
     @to_string.register
     def _(self, arg: "Address"):
         return f"address {arg.location}"
+    
+    @to_string.register
+    def _(self, arg: "RawSQLStatement"):
+        return f"raw_sql('''{arg.text}''');"
+
 
     @to_string.register
     def _(self, arg: "MagicConstants"):

--- a/trilogy/parsing/trilogy.lark
+++ b/trilogy/parsing/trilogy.lark
@@ -9,6 +9,7 @@
     | rowset_derivation_statement
     | import_statement
     | merge_statement
+    | rawsql_statement
     
     _TERMINATOR:  ";"i /\s*/
     
@@ -70,6 +71,9 @@
 
     // merge statemment
     merge_statement: "merge" IDENTIFIER ("," IDENTIFIER)* ","? 
+
+    // raw sql statement
+    rawsql_statement: "raw_sql"i "(" MULTILINE_STRING ")"
 
     // FUNCTION blocks
     function: raw_function


### PR DESCRIPTION
## Description

Inline constants to support better predicate pushdown and query simplification. This helps database engines, especially with constants used for filtering. 

```
const x <- 1;

SELECT
   x+1,
x+2;
````

Would previously have resulted in a cte to define x, that was then referenced twice.

For a straight constant, we can instead directly inline this when creating queries:

```sql
SELECT
 1+1,
1+2
)
```

Also add a 'raw_sql' command that can be used to run arbitrary strings against the backend. Useful fro session settings/config/etc.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
