### PR TITLE
fix to inline constant corruption

### DIFF
--- a/tests/complex/test_aggregate_of_aggregate.py
+++ b/tests/complex/test_aggregate_of_aggregate.py
@@ -57,7 +57,7 @@ select
     generator = BigqueryDialect()
     sql = generator.compile_statement(query)
 
-    assert re.search(r"(count\([A-z0-9\_]+\.`post_id`\) as `user_post_count`)", sql)
+    assert re.search(r"(count\([A-z0-9\_]+\.`id`\) as `user_post_count`)", sql)
     assert re.search(
         r"avg\([A-z0-9\_]+\.`user_post_count`\) as `avg_user_post_count`", sql
     )

--- a/tests/complex/test_complex_source_fetching.py
+++ b/tests/complex/test_complex_source_fetching.py
@@ -130,7 +130,7 @@ def test_aggregate_of_aggregate(stackoverflow_environment):
 
     assert avg_user_post_count in cte.output_columns
     assert user_post_count in parent_cte.output_columns
-    assert len(query.ctes) == 3
+    assert len(query.ctes) == 2
     assert len(cte.parent_ctes) > 0
 
     generator = SqlServerDialect()

--- a/tests/engine/demo/test_demo_duckdb.py
+++ b/tests/engine/demo/test_demo_duckdb.py
@@ -546,3 +546,25 @@ GROUP BY
     raw_data."survived"
 """.strip()
     )
+
+
+def test_demo_averages(base_test_env, engine: Executor):
+    query = """select 
+    passenger.class,
+    max(
+        count(passenger.id) by passenger.last_name
+    ) by passenger.class
+     as max_family_size_per_class,
+     avg(
+        count(passenger.id) by passenger.last_name
+    ) by passenger.class
+    -> avg_family_size_per_class, 
+    
+order by 
+    passenger.class asc
+;"""
+    engine.environment = base_test_env
+    results = engine.execute_text(query)
+
+
+    assert len(results[0].fetchall()) == 3

--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -4,6 +4,6 @@ from trilogy.executor import Executor
 from trilogy.parser import parse
 from trilogy.constants import CONFIG
 
-__version__ = "0.0.2.4"
+__version__ = "0.0.2.5"
 
 __all__ = ["parse", "Executor", "Dialects", "Environment", "CONFIG"]

--- a/trilogy/core/optimizations/inline_datasource.py
+++ b/trilogy/core/optimizations/inline_datasource.py
@@ -43,10 +43,14 @@ class InlineDatasource(OptimizationRule):
                 continue
             root_outputs = {x.address for x in root.output_concepts}
             cte_outputs = {x.address for x in cte.output_columns}
+            inherited = {x for x, v in cte.source_map.items() if v}
             # cte_inherited_outputs = {x.address for x in parent_cte.output_columns if parent_cte.source_map.get(x.address)}
             grain_components = {x.address for x in root.grain.components}
-            if not cte_outputs.issubset(root_outputs):
-                self.log(f"Not all {parent_cte.name} outputs are found on datasource")
+            if not inherited.issubset(root_outputs):
+                cte_missing = inherited - root_outputs
+                self.log(
+                    f"Not all {parent_cte.name} require inputs are found on datasource, missing {cte_missing}"
+                )
                 continue
             if not grain_components.issubset(cte_outputs):
                 self.log("Not all datasource components in cte outputs, forcing group")

--- a/trilogy/dialect/base.py
+++ b/trilogy/dialect/base.py
@@ -188,10 +188,11 @@ FUNCTION_GRAIN_MATCH_MAP = {
 GENERIC_SQL_TEMPLATE = Template(
     """{%- if ctes %}
 WITH {% for cte in ctes %}
-{{cte.name}} as ({{cte.statement}}){% if not loop.last %},{% endif %}{% endfor %}{% endif %}
+{{cte.name}} as (
+{{cte.statement}}){% if not loop.last %},{% endif %}{% endfor %}{% endif %}
 {%- if full_select -%}
 {{full_select}}
-{%- else -%}
+{% else -%}
 SELECT
 {%- if limit is not none %}
 TOP {{ limit }}{% endif %}

--- a/trilogy/dialect/duckdb.py
+++ b/trilogy/dialect/duckdb.py
@@ -49,7 +49,6 @@ WITH {% for cte in ctes %}
 {{cte.name}} as ({{cte.statement}}){% if not loop.last %},{% endif %}{% endfor %}{% endif %}
 {% if full_select -%}{{full_select}}
 {% else -%}
-
 SELECT
 {%- for select in select_columns %}
     {{ select }}{% if not loop.last %},{% endif %}{% endfor %}


### PR DESCRIPTION
## Description

The constant inlining optimization could corrupt subselect nodes because it was returning a Comparison object, not a SubSelectObject.

Improve datasource inlining to further reduce verbosity of some queries.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
