### PR TITLE
quoted identifiers

### DIFF
--- a/tests/engine/demo/test_demo_duckdb.py
+++ b/tests/engine/demo/test_demo_duckdb.py
@@ -566,5 +566,4 @@ order by
     engine.environment = base_test_env
     results = engine.execute_text(query)
 
-
     assert len(results[0].fetchall()) == 3

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -448,3 +448,46 @@ select
         {"a": 1, "b": 2, "c": 3},
         1,
     )
+
+
+def test_datasource_colon():
+
+    text = """
+key x int;
+key y int;
+
+datasource test (
+x:x,
+y:y)
+grain(x)
+address `abc:def`
+;
+
+
+select x;
+"""
+    env, parsed = parse_text(text)
+
+    results = Dialects.DUCK_DB.default_executor().generate_sql(text)[0]
+
+    assert '"abc:def" as test' in results
+
+    text = """
+key x int;
+key y int;
+
+datasource test (
+x:x,
+y:y)
+grain(x)
+address abcdef
+;
+
+
+select x;
+"""
+    env, parsed = parse_text(text)
+
+    results = Dialects.DUCK_DB.default_executor().generate_sql(text)[0]
+
+    assert "abcdef as test" in results, results

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -160,7 +160,8 @@ address `preqldata.analytics_411641820.events_*`
 ;"""
     )
     query = parsed[-1]
-    assert query.address.location == "`preqldata.analytics_411641820.events_*`"
+    assert query.address.quoted is True
+    assert query.address.location == "preqldata.analytics_411641820.events_*"
 
 
 def test_purpose_and_keys():

--- a/trilogy/core/enums.py
+++ b/trilogy/core/enums.py
@@ -7,6 +7,7 @@ class UnnestMode(Enum):
     DIRECT = "direct"
     CROSS_APPLY = "cross_apply"
     CROSS_JOIN = "cross_join"
+    CROSS_JOIN_ALIAS = "cross_join_alias"
 
 
 class ConceptSource(Enum):

--- a/trilogy/core/models.py
+++ b/trilogy/core/models.py
@@ -1817,6 +1817,7 @@ class MultiSelectStatement(SelectTypeMixin, Mergeable, Namespaced, BaseModel):
 class Address(BaseModel):
     location: str
     is_query: bool = False
+    quoted: bool = False
 
 
 class Query(BaseModel):
@@ -2578,6 +2579,13 @@ class CTE(BaseModel):
         elif self.relevant_base_ctes:
             return self.relevant_base_ctes[0].name
         return self.source.name
+
+    @property
+    def quote_address(self) -> bool:
+        if self.is_root_datasource:
+            if self.source.datasources[0].address.quoted:
+                return True
+        return False
 
     @property
     def base_alias(self) -> str:

--- a/trilogy/core/models.py
+++ b/trilogy/core/models.py
@@ -2583,8 +2583,11 @@ class CTE(BaseModel):
     @property
     def quote_address(self) -> bool:
         if self.is_root_datasource:
-            if self.source.datasources[0].address.quoted:
-                return True
+            candidate = self.source.datasources[0]
+            if isinstance(candidate, Datasource) and isinstance(
+                candidate.address, Address
+            ):
+                return candidate.address.quoted
         return False
 
     @property

--- a/trilogy/dialect/base.py
+++ b/trilogy/dialect/base.py
@@ -499,10 +499,12 @@ class BaseDialect:
                 for c in cte.output_columns
                 if c.address not in [y.address for y in cte.hidden_concepts]
             ]
-        if cte.base_name == cte.base_alias:
-            source = cte.base_name
+        if cte.quote_address:
+            source = f"{self.QUOTE_CHARACTER}{cte.base_name}{self.QUOTE_CHARACTER}"
         else:
-            source = f"{cte.base_name} as {cte.base_alias}"
+            source = cte.base_name
+        if cte.base_name != cte.base_alias:
+            source = f"{source} as {cte.base_alias}"
         return CompiledCTE(
             name=cte.name,
             statement=self.SQL_TEMPLATE.render(

--- a/trilogy/dialect/common.py
+++ b/trilogy/dialect/common.py
@@ -26,7 +26,8 @@ def render_join(
             raise ValueError("must provide a cte to build an unnest joins")
         if unnest_mode == UnnestMode.CROSS_JOIN:
             return f"CROSS JOIN {render_func(join.concept, cte, False)} as {quote_character}{join.concept.safe_address}{quote_character}"
-
+        if unnest_mode == UnnestMode.CROSS_JOIN_ALIAS:
+            return f"CROSS JOIN {render_func(join.concept, cte, False)} as array_unnest ({quote_character}{join.concept.safe_address}{quote_character})"
         return f"FULL JOIN {render_func(join.concept, cte, False)} as unnest_wrapper({quote_character}{join.concept.safe_address}{quote_character})"
     left_name = join.left_name
     right_name = join.right_name

--- a/trilogy/dialect/presto.py
+++ b/trilogy/dialect/presto.py
@@ -5,7 +5,7 @@ from jinja2 import Template
 from trilogy.core.enums import FunctionType, WindowType
 from trilogy.dialect.base import BaseDialect
 from trilogy.core.models import DataType
-
+from trilogy.core.enums import UnnestMode
 
 WINDOW_FUNCTION_MAP: Mapping[WindowType, Callable[[Any, Any, Any], str]] = {}
 
@@ -86,6 +86,7 @@ class PrestoDialect(BaseDialect):
     QUOTE_CHARACTER = '"'
     SQL_TEMPLATE = SQL_TEMPLATE
     DATATYPE_MAP = {**BaseDialect.DATATYPE_MAP, DataType.NUMERIC: "DECIMAL"}
+    UNNEST_MODE = UnnestMode.CROSS_JOIN
 
 
 class TrinoDialect(PrestoDialect):

--- a/trilogy/parsing/parse_engine.py
+++ b/trilogy/parsing/parse_engine.py
@@ -297,8 +297,11 @@ class ParseToObjects(Transformer):
     def concept_lit(self, args) -> Concept:
         return self.environment.concepts.__getitem__(args[0])
 
-    def ADDRESS(self, args) -> str:
-        return args.value
+    def ADDRESS(self, args) -> Address:
+        return Address(location=args.value, quoted=False)
+
+    def QUOTED_ADDRESS(self, args) -> Address:
+        return Address(location=args.value[1:-1], quoted=True)
 
     def STRING_CHARS(self, args) -> str:
         return args.value
@@ -1010,7 +1013,7 @@ class ParseToObjects(Transformer):
 
     @v_args(meta=True)
     def address(self, meta: Meta, args):
-        return Address(location=args[0])
+        return args[0]
 
     @v_args(meta=True)
     def query(self, meta: Meta, args):

--- a/trilogy/parsing/trilogy.lark
+++ b/trilogy/parsing/trilogy.lark
@@ -39,7 +39,7 @@
     
     grain_clause: "grain" "(" column_list ")"
     
-    address: "address" ADDRESS
+    address: "address" (QUOTED_ADDRESS | ADDRESS)
     
     query: "query" MULTILINE_STRING
     
@@ -258,7 +258,8 @@
     // base language constructs
     concept_lit: IDENTIFIER
     IDENTIFIER: /[a-zA-Z\_][a-zA-Z0-9\_\-\.\-]*/
-    ADDRESS: IDENTIFIER | /`[a-zA-Z\_][a-zA-Z0-9\_\-\.\-\*]*`/
+    QUOTED_ADDRESS:  /`[a-zA-Z\_][a-zA-Z0-9\_\-\.\-\*\:]*`/
+    ADDRESS: IDENTIFIER
 
     MULTILINE_STRING: /\'{3}(.*?)\'{3}/s
     


### PR DESCRIPTION
## Description

Added discriminated quoted identifiers - datasources w/ backtick wrapping on identifier can have more characters and this context is now passed through to render correctly with the required quotes of a given backend.

Fix cross-join rendering on presto for unnests to be syntactically valid. 

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
