### PR TITLE
Experimental Union Support (part 1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,4 @@ log_cli_level="INFO"
 [tool.ruff]
 # Allow lines to be as long as 200 characters.
 line-length = 200
+lint.extend-select = ["I"]

--- a/tests/adventureworks/conftest.py
+++ b/tests/adventureworks/conftest.py
@@ -47,9 +47,7 @@ def can_bind(hostname, port):
 @fixture(scope="session")
 def local_express_flag():
     if os.environ.get("PYPREQL_INTEGRATION_SQLSERVER_EXPRESS", None) == "true":
-        return create_engine(
-            "mssql://*server_name*\\SQLEXPRESS/*database_name*?trusted_connection=yes;DRIVER={ODBC Driver 18 for SQL Server};"
-        )
+        return create_engine("mssql://*server_name*\\SQLEXPRESS/*database_name*?trusted_connection=yes;DRIVER={ODBC Driver 18 for SQL Server};")
     else:
         return False
 
@@ -62,9 +60,7 @@ def db_must(local_express_flag):
         yield TestConfig.LOCAL
         return
     if not can_bind("localhost", 1433):
-        x = os.system(
-            "docker run -p 1433:1433 --name pyreql-test-sqlserver -d  --rm pyreql-test-sqlserver"
-        )
+        x = os.system("docker run -p 1433:1433 --name pyreql-test-sqlserver -d  --rm pyreql-test-sqlserver")
         if x != 0:
             raise TestDependencyError("Error starting database")
         time.sleep(5)

--- a/tests/adventureworks/conftest.py
+++ b/tests/adventureworks/conftest.py
@@ -47,7 +47,9 @@ def can_bind(hostname, port):
 @fixture(scope="session")
 def local_express_flag():
     if os.environ.get("PYPREQL_INTEGRATION_SQLSERVER_EXPRESS", None) == "true":
-        return create_engine("mssql://*server_name*\\SQLEXPRESS/*database_name*?trusted_connection=yes;DRIVER={ODBC Driver 18 for SQL Server};")
+        return create_engine(
+            "mssql://*server_name*\\SQLEXPRESS/*database_name*?trusted_connection=yes;DRIVER={ODBC Driver 18 for SQL Server};"
+        )
     else:
         return False
 
@@ -60,7 +62,9 @@ def db_must(local_express_flag):
         yield TestConfig.LOCAL
         return
     if not can_bind("localhost", 1433):
-        x = os.system("docker run -p 1433:1433 --name pyreql-test-sqlserver -d  --rm pyreql-test-sqlserver")
+        x = os.system(
+            "docker run -p 1433:1433 --name pyreql-test-sqlserver -d  --rm pyreql-test-sqlserver"
+        )
         if x != 0:
             raise TestDependencyError("Error starting database")
         time.sleep(5)

--- a/tests/adventureworks/test_adventureworks.py
+++ b/tests/adventureworks/test_adventureworks.py
@@ -23,7 +23,9 @@ from trilogy.parser import parse
 
 @pytest.mark.adventureworks
 def test_parsing(environment: Environment):
-    with open(join(dirname(__file__), "finance_queries.preql"), "r", encoding="utf-8") as f:
+    with open(
+        join(dirname(__file__), "finance_queries.preql"), "r", encoding="utf-8"
+    ) as f:
         file = f.read()
     SqlServerDialect()
     environment, statements = parse(file, environment=environment)
@@ -31,7 +33,9 @@ def test_parsing(environment: Environment):
 
 @pytest.mark.adventureworks_execution
 def test_finance_queries(adventureworks_engine: Executor, environment: Environment):
-    with open(join(dirname(__file__), "finance_queries.preql"), "r", encoding="utf-8") as f:
+    with open(
+        join(dirname(__file__), "finance_queries.preql"), "r", encoding="utf-8"
+    ) as f:
         file = f.read()
     generator = SqlServerDialect()
     environment, statements = parse(file, environment=environment)
@@ -47,10 +51,15 @@ def test_finance_queries(adventureworks_engine: Executor, environment: Environme
 
 @pytest.mark.adventureworks
 def test_query_datasources(environment: Environment):
-    with open(join(dirname(__file__), "online_sales_queries.preql"), "r", encoding="utf-8") as f:
+    with open(
+        join(dirname(__file__), "online_sales_queries.preql"), "r", encoding="utf-8"
+    ) as f:
         file = f.read()
     environment, statements = parse(file, environment=environment)
-    assert str(environment.datasources["internet_sales.fact_internet_sales"].grain) == "Grain<internet_sales.order_line_number,internet_sales.order_number>"
+    assert (
+        str(environment.datasources["internet_sales.fact_internet_sales"].grain)
+        == "Grain<internet_sales.order_line_number,internet_sales.order_number>"
+    )
 
     test: SelectStatement = statements[-1]  # multipart join
 
@@ -61,7 +70,11 @@ def test_query_datasources(environment: Environment):
 
     # source query concepts includes extra group by to grain
     customer_node = search_concepts(
-        [environment.concepts["internet_sales.customer.first_name"].with_default_grain()],
+        [
+            environment.concepts[
+                "internet_sales.customer.first_name"
+            ].with_default_grain()
+        ],
         environment=environment,
         g=environment_graph,
         depth=0,
@@ -69,7 +82,10 @@ def test_query_datasources(environment: Environment):
     print_recursive_nodes(customer_node)
     customer_datasource = customer_node.resolve()
 
-    assert customer_datasource.safe_identifier == "internet_sales_customer_customers_at_internet_sales_customer_customer_id_at_internet_sales_customer_first_name"
+    assert (
+        customer_datasource.safe_identifier
+        == "internet_sales_customer_customers_at_internet_sales_customer_customer_id_at_internet_sales_customer_first_name"
+    )
 
     # assert a join before the group by works
     t_grain = Grain(
@@ -93,11 +109,16 @@ def test_query_datasources(environment: Environment):
         depth=0,
     ).resolve()
 
-    assert customer_datasource.safe_identifier == "internet_sales_customer_customers_at_internet_sales_customer_customer_id_at_internet_sales_customer_first_name"
+    assert (
+        customer_datasource.safe_identifier
+        == "internet_sales_customer_customers_at_internet_sales_customer_customer_id_at_internet_sales_customer_first_name"
+    )
 
-    datasource = get_query_datasources(environment=environment, graph=environment_graph, statement=test)
+    datasource = get_query_datasources(
+        environment=environment, graph=environment_graph, statement=test
+    )
 
-    cte = datasource_to_cte(datasource, {})[0]
+    cte = datasource_to_cte(datasource, {})
 
     assert {c.address for c in cte.output_columns} == {
         "internet_sales.customer.first_name",
@@ -120,7 +141,9 @@ def list_to_address(clist: list[Concept]) -> set[str]:
 
 @pytest.mark.adventureworks
 def test_two_properties(environment: Environment):
-    with open(join(dirname(__file__), "online_sales_queries.preql"), "r", encoding="utf-8") as f:
+    with open(
+        join(dirname(__file__), "online_sales_queries.preql"), "r", encoding="utf-8"
+    ) as f:
         file = f.read()
     environment, statements = parse(file, environment=environment)
     test: SelectStatement = statements[-3]
@@ -129,7 +152,8 @@ def test_two_properties(environment: Environment):
 
     # assert a group up to the first name works
     _customer_datasource = search_concepts(
-        [environment.concepts["internet_sales.customer.first_name"]] + test.grain.components_copy,
+        [environment.concepts["internet_sales.customer.first_name"]]
+        + test.grain.components_copy,
         environment=environment,
         g=environment_graph,
         depth=0,
@@ -138,25 +162,40 @@ def test_two_properties(environment: Environment):
     assert _customer_datasource
     customer_datasource = _customer_datasource.resolve()
 
-    assert list_to_address(customer_datasource.output_concepts).issuperset(list_to_address([environment.concepts["internet_sales.customer.first_name"]] + test.grain.components_copy))
+    assert list_to_address(customer_datasource.output_concepts).issuperset(
+        list_to_address(
+            [environment.concepts["internet_sales.customer.first_name"]]
+            + test.grain.components_copy
+        )
+    )
 
     order_date_datasource = search_concepts(
-        [environment.concepts["internet_sales.dates.order_date"]] + test.grain.components_copy,
+        [environment.concepts["internet_sales.dates.order_date"]]
+        + test.grain.components_copy,
         environment=environment,
         g=environment_graph,
         depth=0,
     ).resolve()
 
-    assert list_to_address(order_date_datasource.output_concepts).issuperset(list_to_address([environment.concepts["internet_sales.dates.order_date"]] + test.grain.components_copy))
+    assert list_to_address(order_date_datasource.output_concepts).issuperset(
+        list_to_address(
+            [environment.concepts["internet_sales.dates.order_date"]]
+            + test.grain.components_copy
+        )
+    )
 
-    get_query_datasources(environment=environment, graph=environment_graph, statement=test)
+    get_query_datasources(
+        environment=environment, graph=environment_graph, statement=test
+    )
 
 
 @pytest.mark.adventureworks
 def test_grain(environment: Environment):
     from trilogy.core.processing.concept_strategies_v3 import search_concepts
 
-    with open(join(dirname(__file__), "online_sales_queries.preql"), "r", encoding="utf-8") as f:
+    with open(
+        join(dirname(__file__), "online_sales_queries.preql"), "r", encoding="utf-8"
+    ) as f:
         file = f.read()
     environment, statements = parse(file, environment=environment)
     environment_graph = generate_graph(environment)
@@ -171,8 +210,14 @@ def test_grain(environment: Environment):
     )
     assert isinstance(test, SelectNode)
     assert len(test.parents) == 0
-    assert test.grain.set == Grain(components=[environment.concepts["dates.order_key"]]).set
-    assert environment.datasources["dates.order_dates"].grain.set == Grain(components=[environment.concepts["dates.order_key"]]).set
+    assert (
+        test.grain.set
+        == Grain(components=[environment.concepts["dates.order_key"]]).set
+    )
+    assert (
+        environment.datasources["dates.order_dates"].grain.set
+        == Grain(components=[environment.concepts["dates.order_key"]]).set
+    )
     resolved = test.resolve()
     assert resolved.grain == Grain(components=[environment.concepts["dates.order_key"]])
     assert test.grain == resolved.grain
@@ -183,11 +228,20 @@ def test_grain(environment: Environment):
 def test_group_to_grain(environment: Environment):
     from trilogy.core.processing.concept_strategies_v3 import search_concepts
 
-    with open(join(dirname(__file__), "online_sales_queries.preql"), "r", encoding="utf-8") as f:
+    with open(
+        join(dirname(__file__), "online_sales_queries.preql"), "r", encoding="utf-8"
+    ) as f:
         file = f.read()
     environment, statements = parse(file, environment=environment)
     environment_graph = generate_graph(environment)
-    assert len(environment.concepts["internet_sales.total_sales_amount_debug"].grain.components) == 2
+    assert (
+        len(
+            environment.concepts[
+                "internet_sales.total_sales_amount_debug"
+            ].grain.components
+        )
+        == 2
+    )
     test = search_concepts(
         [
             environment.concepts["internet_sales.total_sales_amount_debug"],
@@ -218,12 +272,21 @@ def test_two_properties_query(environment: Environment):
     from trilogy.core.processing.concept_strategies_v3 import search_concepts
     from trilogy.core.processing.node_generators import gen_group_node
 
-    with open(join(dirname(__file__), "online_sales_queries.preql"), "r", encoding="utf-8") as f:
+    with open(
+        join(dirname(__file__), "online_sales_queries.preql"), "r", encoding="utf-8"
+    ) as f:
         file = f.read()
     environment, statements = parse(file, environment=environment)
     assert "local.total_sales_amount_debug_2" in set(list(environment.concepts.keys()))
     environment_graph = generate_graph(environment)
-    assert len(environment.concepts["internet_sales.total_sales_amount_debug"].grain.components) == 2
+    assert (
+        len(
+            environment.concepts[
+                "internet_sales.total_sales_amount_debug"
+            ].grain.components
+        )
+        == 2
+    )
     test = gen_group_node(
         environment.concepts["total_sales_amount_debug_2"],
         local_optional=[environment.concepts["internet_sales.dates.order_date"]],
@@ -240,8 +303,12 @@ def test_two_properties_query(environment: Environment):
 
 
 @pytest.mark.adventureworks_execution
-def test_online_sales_queries(adventureworks_engine: Executor, environment: Environment):
-    with open(join(dirname(__file__), "online_sales_queries.preql"), "r", encoding="utf-8") as f:
+def test_online_sales_queries(
+    adventureworks_engine: Executor, environment: Environment
+):
+    with open(
+        join(dirname(__file__), "online_sales_queries.preql"), "r", encoding="utf-8"
+    ) as f:
         file = f.read()
     generator = SqlServerDialect()
     environment, statements = parse(file, environment=environment)

--- a/tests/complex/test_aggregate_at_grain.py
+++ b/tests/complex/test_aggregate_at_grain.py
@@ -1,8 +1,8 @@
-from trilogy.core.models import SelectStatement, Grain
+from trilogy.core.enums import Granularity
+from trilogy.core.models import Grain, SelectStatement
 from trilogy.core.query_processor import process_query
 from trilogy.dialect.bigquery import BigqueryDialect
 from trilogy.hooks.query_debugger import DebuggingHook
-from trilogy.core.enums import Granularity
 from trilogy.parser import parse
 
 

--- a/tests/complex/test_aggregate_of_aggregate.py
+++ b/tests/complex/test_aggregate_of_aggregate.py
@@ -1,9 +1,10 @@
+import re
+
 from trilogy.core.models import SelectStatement
 from trilogy.core.query_processor import process_query
 from trilogy.dialect.bigquery import BigqueryDialect
 from trilogy.hooks.query_debugger import DebuggingHook
 from trilogy.parser import parse
-import re
 
 
 def test_select():
@@ -58,6 +59,4 @@ select
     sql = generator.compile_statement(query)
 
     assert re.search(r"(count\([A-z0-9\_]+\.`id`\) as `user_post_count`)", sql)
-    assert re.search(
-        r"avg\([A-z0-9\_]+\.`user_post_count`\) as `avg_user_post_count`", sql
-    )
+    assert re.search(r"avg\([A-z0-9\_]+\.`user_post_count`\) as `avg_user_post_count`", sql)

--- a/tests/complex/test_aggregate_of_aggregate.py
+++ b/tests/complex/test_aggregate_of_aggregate.py
@@ -59,4 +59,6 @@ select
     sql = generator.compile_statement(query)
 
     assert re.search(r"(count\([A-z0-9\_]+\.`id`\) as `user_post_count`)", sql)
-    assert re.search(r"avg\([A-z0-9\_]+\.`user_post_count`\) as `avg_user_post_count`", sql)
+    assert re.search(
+        r"avg\([A-z0-9\_]+\.`user_post_count`\) as `avg_user_post_count`", sql
+    )

--- a/tests/complex/test_complex_source_fetching.py
+++ b/tests/complex/test_complex_source_fetching.py
@@ -86,11 +86,15 @@ def test_aggregate_of_aggregate(stackoverflow_environment):
 
     assert posts.grain == post_grain
 
-    assert set(expected_parent.source_map.keys()) == set(["local.user_post_count", "local.user_id", "local.post_id"])
+    assert set(expected_parent.source_map.keys()) == set(
+        ["local.user_post_count", "local.user_id", "local.post_id"]
+    )
 
     assert user_post_count in expected_parent.output_concepts
 
-    datasource = search_concepts([avg_user_post_count], environment=env, depth=0, g=generate_graph(env)).resolve()
+    datasource = search_concepts(
+        [avg_user_post_count], environment=env, depth=0, g=generate_graph(env)
+    ).resolve()
 
     assert isinstance(datasource, QueryDatasource)
     assert datasource.grain == Grain()
@@ -103,7 +107,9 @@ def test_aggregate_of_aggregate(stackoverflow_environment):
     assert isinstance(parent, QueryDatasource)
     assert user_post_count in parent.output_concepts
 
-    assert set([x.address for x in parent.output_concepts]) == set(["local.user_post_count", "local.user_id"])
+    assert set([x.address for x in parent.output_concepts]) == set(
+        ["local.user_post_count", "local.user_id"]
+    )
 
     root = parent.datasources[0].datasources[0]
     assert isinstance(root, Datasource)
@@ -112,7 +118,7 @@ def test_aggregate_of_aggregate(stackoverflow_environment):
 
     ctes = datasource_to_cte(datasource, {})
 
-    final_cte = ctes[0]
+    final_cte = ctes
     assert len(final_cte.parent_ctes) > 0
 
     # now validate

--- a/tests/complex/test_complex_source_fetching.py
+++ b/tests/complex/test_complex_source_fetching.py
@@ -2,21 +2,22 @@
 
 
 # from trilogy.compiler import compile
+import re
+
+from trilogy.core.enums import Purpose
 from trilogy.core.models import (
-    SelectStatement,
-    Grain,
     Datasource,
-    QueryDatasource,
     Environment,
+    Grain,
+    QueryDatasource,
+    SelectStatement,
 )
 from trilogy.core.processing.concept_strategies_v3 import (
-    search_concepts,
     generate_graph,
+    search_concepts,
 )
-from trilogy.core.query_processor import process_query, datasource_to_ctes
+from trilogy.core.query_processor import datasource_to_cte, process_query
 from trilogy.dialect.sql_server import SqlServerDialect
-from trilogy.core.enums import Purpose
-import re
 
 
 def test_aggregate_of_property_function(stackoverflow_environment: Environment) -> None:
@@ -85,15 +86,11 @@ def test_aggregate_of_aggregate(stackoverflow_environment):
 
     assert posts.grain == post_grain
 
-    assert set(expected_parent.source_map.keys()) == set(
-        ["local.user_post_count", "local.user_id", "local.post_id"]
-    )
+    assert set(expected_parent.source_map.keys()) == set(["local.user_post_count", "local.user_id", "local.post_id"])
 
     assert user_post_count in expected_parent.output_concepts
 
-    datasource = search_concepts(
-        [avg_user_post_count], environment=env, depth=0, g=generate_graph(env)
-    ).resolve()
+    datasource = search_concepts([avg_user_post_count], environment=env, depth=0, g=generate_graph(env)).resolve()
 
     assert isinstance(datasource, QueryDatasource)
     assert datasource.grain == Grain()
@@ -106,16 +103,14 @@ def test_aggregate_of_aggregate(stackoverflow_environment):
     assert isinstance(parent, QueryDatasource)
     assert user_post_count in parent.output_concepts
 
-    assert set([x.address for x in parent.output_concepts]) == set(
-        ["local.user_post_count", "local.user_id"]
-    )
+    assert set([x.address for x in parent.output_concepts]) == set(["local.user_post_count", "local.user_id"])
 
     root = parent.datasources[0].datasources[0]
     assert isinstance(root, Datasource)
     assert posts == root
     assert post_id in root.concepts
 
-    ctes = datasource_to_ctes(datasource, {})
+    ctes = datasource_to_cte(datasource, {})
 
     final_cte = ctes[0]
     assert len(final_cte.parent_ctes) > 0

--- a/tests/complex/test_structs.py
+++ b/tests/complex/test_structs.py
@@ -30,10 +30,18 @@ SELECT
     
                                     """
     )
-    assert isinstance(executor.environment.concepts["unnest_array"].datatype, StructType)
+    assert isinstance(
+        executor.environment.concepts["unnest_array"].datatype, StructType
+    )
     b_side = executor.environment.concepts["b"]
-    assert "unnest_array.b" in executor.environment.concepts["b"].pseudonyms, b_side.pseudonyms
-    assert "unnest_array.b" in executor.environment.concepts["local.b"].pseudonyms is not None, b_side.pseudonyms
+    assert (
+        "unnest_array.b" in executor.environment.concepts["b"].pseudonyms
+    ), b_side.pseudonyms
+    assert (
+        "unnest_array.b"
+        in executor.environment.concepts["local.b"].pseudonyms
+        is not None
+    ), b_side.pseudonyms
     for x in results[-1].output_columns:
         assert len(list(x.pseudonyms)) == 1, x.pseudonyms
     results = executor.execute_text(

--- a/tests/complex/test_structs.py
+++ b/tests/complex/test_structs.py
@@ -30,18 +30,10 @@ SELECT
     
                                     """
     )
-    assert isinstance(
-        executor.environment.concepts["unnest_array"].datatype, StructType
-    )
+    assert isinstance(executor.environment.concepts["unnest_array"].datatype, StructType)
     b_side = executor.environment.concepts["b"]
-    assert (
-        "unnest_array.b" in executor.environment.concepts["b"].pseudonyms
-    ), b_side.pseudonyms
-    assert (
-        "unnest_array.b"
-        in executor.environment.concepts["local.b"].pseudonyms
-        is not None
-    ), b_side.pseudonyms
+    assert "unnest_array.b" in executor.environment.concepts["b"].pseudonyms, b_side.pseudonyms
+    assert "unnest_array.b" in executor.environment.concepts["local.b"].pseudonyms is not None, b_side.pseudonyms
     for x in results[-1].output_columns:
         assert len(list(x.pseudonyms)) == 1, x.pseudonyms
     results = executor.execute_text(

--- a/tests/complex/test_window_function_parsing.py
+++ b/tests/complex/test_window_function_parsing.py
@@ -128,7 +128,9 @@ limit 100
     select: SelectStatement = parsed[-1]
 
     assert env.concepts["rank_derived"].keys == (env.concepts["user_id"],)
-    assert concept_to_relevant_joins([env.concepts[x] for x in ["user_id", "rank_derived"]]) == [env.concepts["user_id"]]
+    assert concept_to_relevant_joins(
+        [env.concepts[x] for x in ["user_id", "rank_derived"]]
+    ) == [env.concepts["user_id"]]
     assert isinstance(env.concepts["user_country_rank"].lineage, WindowItem)
 
     get_query_datasources(environment=env, statement=select)
@@ -164,7 +166,9 @@ order by x asc;"""
     )
     assert z.keys == (x,)
 
-    ds = search_concepts([z.with_grain(x), x], environment=env, g=generate_graph(env), depth=0).resolve()
+    ds = search_concepts(
+        [z.with_grain(x), x], environment=env, g=generate_graph(env), depth=0
+    ).resolve()
 
     assert x in ds.output_concepts
     assert z in ds.output_concepts

--- a/tests/complex/test_window_function_parsing.py
+++ b/tests/complex/test_window_function_parsing.py
@@ -1,15 +1,15 @@
-from trilogy.core.models import SelectStatement, WindowItem
-from trilogy.core.enums import PurposeLineage, Granularity, Purpose
-from trilogy.core.processing.concept_strategies_v3 import (
-    search_concepts,
-    generate_graph,
-)
-from trilogy.core.query_processor import process_query, get_query_datasources
-from trilogy.core.processing.utility import concept_to_relevant_joins
-from trilogy.dialect.bigquery import BigqueryDialect
-from trilogy.dialect import duckdb
-from trilogy.parser import parse
 from trilogy import Dialects
+from trilogy.core.enums import Granularity, Purpose, PurposeLineage
+from trilogy.core.models import SelectStatement, WindowItem
+from trilogy.core.processing.concept_strategies_v3 import (
+    generate_graph,
+    search_concepts,
+)
+from trilogy.core.processing.utility import concept_to_relevant_joins
+from trilogy.core.query_processor import get_query_datasources, process_query
+from trilogy.dialect import duckdb
+from trilogy.dialect.bigquery import BigqueryDialect
+from trilogy.parser import parse
 
 
 def test_select() -> None:
@@ -128,9 +128,7 @@ limit 100
     select: SelectStatement = parsed[-1]
 
     assert env.concepts["rank_derived"].keys == (env.concepts["user_id"],)
-    assert concept_to_relevant_joins(
-        [env.concepts[x] for x in ["user_id", "rank_derived"]]
-    ) == [env.concepts["user_id"]]
+    assert concept_to_relevant_joins([env.concepts[x] for x in ["user_id", "rank_derived"]]) == [env.concepts["user_id"]]
     assert isinstance(env.concepts["user_country_rank"].lineage, WindowItem)
 
     get_query_datasources(environment=env, statement=select)
@@ -166,9 +164,7 @@ order by x asc;"""
     )
     assert z.keys == (x,)
 
-    ds = search_concepts(
-        [z.with_grain(x), x], environment=env, g=generate_graph(env), depth=0
-    ).resolve()
+    ds = search_concepts([z.with_grain(x), x], environment=env, g=generate_graph(env), depth=0).resolve()
 
     assert x in ds.output_concepts
     assert z in ds.output_concepts

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,9 @@ def test_environment():
     env = Environment()
     order_id = Concept(name="order_id", datatype=DataType.INTEGER, purpose=Purpose.KEY)
 
-    order_timestamp = Concept(name="order_timestamp", datatype=DataType.TIMESTAMP, purpose=Purpose.PROPERTY)
+    order_timestamp = Concept(
+        name="order_timestamp", datatype=DataType.TIMESTAMP, purpose=Purpose.PROPERTY
+    )
 
     order_count = Concept(
         name="order_count",
@@ -78,11 +80,15 @@ def test_environment():
             operator=FunctionType.SUM,
         ),
     )
-    product_id = Concept(name="product_id", datatype=DataType.INTEGER, purpose=Purpose.KEY)
+    product_id = Concept(
+        name="product_id", datatype=DataType.INTEGER, purpose=Purpose.KEY
+    )
 
     assert product_id.grain.components[0].name == "product_id"
 
-    category_id = Concept(name="category_id", datatype=DataType.INTEGER, purpose=Purpose.KEY)
+    category_id = Concept(
+        name="category_id", datatype=DataType.INTEGER, purpose=Purpose.KEY
+    )
     category_name = Concept(
         name="category_name",
         datatype=DataType.STRING,
@@ -125,7 +131,9 @@ def test_environment():
         lineage=WindowItem(
             type=WindowType.RANK,
             content=product_id,
-            order_by=[OrderItem(expr=total_revenue.with_grain(product_id), order="desc")],
+            order_by=[
+                OrderItem(expr=total_revenue.with_grain(product_id), order="desc")
+            ],
         ),
         grain=product_id,
         keys=(product_id,),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,25 +2,25 @@ from pytest import fixture
 
 from trilogy import Environment
 from trilogy.core.enums import (
-    Purpose,
-    FunctionType,
     ComparisonOperator,
+    FunctionType,
+    Purpose,
     WindowType,
 )
 from trilogy.core.env_processor import generate_graph
 from trilogy.core.functions import Count, CountDistinct, Max, Min
 from trilogy.core.models import (
-    Concept,
-    DataType,
-    Datasource,
     ColumnAssignment,
+    Comparison,
+    Concept,
+    Datasource,
+    DataType,
+    FilterItem,
     Function,
     Grain,
-    WindowItem,
-    FilterItem,
     OrderItem,
     WhereClause,
-    Comparison,
+    WindowItem,
 )
 
 
@@ -29,9 +29,7 @@ def test_environment():
     env = Environment()
     order_id = Concept(name="order_id", datatype=DataType.INTEGER, purpose=Purpose.KEY)
 
-    order_timestamp = Concept(
-        name="order_timestamp", datatype=DataType.TIMESTAMP, purpose=Purpose.PROPERTY
-    )
+    order_timestamp = Concept(name="order_timestamp", datatype=DataType.TIMESTAMP, purpose=Purpose.PROPERTY)
 
     order_count = Concept(
         name="order_count",
@@ -80,15 +78,11 @@ def test_environment():
             operator=FunctionType.SUM,
         ),
     )
-    product_id = Concept(
-        name="product_id", datatype=DataType.INTEGER, purpose=Purpose.KEY
-    )
+    product_id = Concept(name="product_id", datatype=DataType.INTEGER, purpose=Purpose.KEY)
 
     assert product_id.grain.components[0].name == "product_id"
 
-    category_id = Concept(
-        name="category_id", datatype=DataType.INTEGER, purpose=Purpose.KEY
-    )
+    category_id = Concept(name="category_id", datatype=DataType.INTEGER, purpose=Purpose.KEY)
     category_name = Concept(
         name="category_name",
         datatype=DataType.STRING,
@@ -131,9 +125,7 @@ def test_environment():
         lineage=WindowItem(
             type=WindowType.RANK,
             content=product_id,
-            order_by=[
-                OrderItem(expr=total_revenue.with_grain(product_id), order="desc")
-            ],
+            order_by=[OrderItem(expr=total_revenue.with_grain(product_id), order="desc")],
         ),
         grain=product_id,
         keys=(product_id,),

--- a/tests/custom/test_custom_types.py
+++ b/tests/custom/test_custom_types.py
@@ -1,9 +1,10 @@
+import pytest
+
 from trilogy.core.models import Parenthetical
+from trilogy.dialect.base import BaseDialect
 from trilogy.parsing.parse_engine import (
     parse_text,
 )
-from trilogy.dialect.base import BaseDialect
-import pytest
 
 
 # not implemented yet

--- a/tests/engine/conftest.py
+++ b/tests/engine/conftest.py
@@ -18,7 +18,9 @@ def mock_factory(conf: DialectConfig, config_type, **kwargs):
     from sqlalchemy import create_engine
 
     if not isinstance(conf, config_type):
-        raise TypeError(f"Invalid dialect configuration for type {type(config_type).__name__}")
+        raise TypeError(
+            f"Invalid dialect configuration for type {type(config_type).__name__}"
+        )
     assert conf.connection_string()
     if conf.connect_args:
         return create_engine("duckdb:///:memory:", future=True)
@@ -76,19 +78,33 @@ def duckdb_engine(duckdb_model) -> Generator[Executor, None, None]:
     engine = create_engine("duckdb:///:memory:", future=True)
 
     with engine.connect() as connection:
-        connection.execute(text("CREATE TABLE items(item VARCHAR, value DECIMAL(10,2), count INTEGER, store_id INTEGER)"))
+        connection.execute(
+            text(
+                "CREATE TABLE items(item VARCHAR, value DECIMAL(10,2), count INTEGER, store_id INTEGER)"
+            )
+        )
         connection.commit()
         # insert two items into the table
-        connection.execute(text("INSERT INTO items VALUES ('jeans', 20.0, 1, 1), ('hammer', 42.2, 2,1 ), ('hammer', 42.2, 2,2 ), ('hammer', 42.2, 2,3 )"))
+        connection.execute(
+            text(
+                "INSERT INTO items VALUES ('jeans', 20.0, 1, 1), ('hammer', 42.2, 2,1 ), ('hammer', 42.2, 2,2 ), ('hammer', 42.2, 2,3 )"
+            )
+        )
         connection.commit()
         # validate connection
         connection.execute(text("select 1")).one_or_none()
 
-        connection.execute(text("CREATE TABLE items_extra_discount(item VARCHAR, value DECIMAL(10,2) )"))
+        connection.execute(
+            text(
+                "CREATE TABLE items_extra_discount(item VARCHAR, value DECIMAL(10,2) )"
+            )
+        )
 
         connection.commit()
         # insert extra items
-        connection.execute(text("INSERT INTO items_extra_discount VALUES ('jeans', -10.0)"))
+        connection.execute(
+            text("INSERT INTO items_extra_discount VALUES ('jeans', -10.0)")
+        )
         connection.commit()
         connection.execute(text("select 1")).one_or_none()
 
@@ -184,7 +200,9 @@ class PostgresEngine(ExecutionEngine):
 def postgres_engine(presto_model) -> Generator[Executor, None, None]:
     engine = PostgresEngine()
 
-    executor = Executor(dialect=Dialects.POSTGRES, engine=engine, environment=presto_model)
+    executor = Executor(
+        dialect=Dialects.POSTGRES, engine=engine, environment=presto_model
+    )
     yield executor
 
 
@@ -195,7 +213,9 @@ def snowflake_engine(presto_model) -> Generator[Executor, None, None]:
     with fakesnow.patch():
         executor = Dialects.SNOWFLAKE.default_executor(
             environment=presto_model,
-            conf=SnowflakeConfig(account="account", username="user", password="password"),
+            conf=SnowflakeConfig(
+                account="account", username="user", password="password"
+            ),
         )
         yield executor
 

--- a/tests/engine/demo/conftest.py
+++ b/tests/engine/demo/conftest.py
@@ -1,25 +1,27 @@
-import pandas as pd
-from trilogy import Executor, Dialects
-from trilogy.core.models import Environment
-from sqlalchemy import create_engine
-from trilogy.core.models import (
-    Datasource,
-    Concept,
-    ColumnAssignment,
-    Grain,
-    DataType,
-    Function,
-    Metadata,
-)
-from trilogy.core.enums import Purpose, FunctionType, Modifier
+from logging import INFO
 from os.path import dirname
 from pathlib import PurePath
-from trilogy.hooks.query_debugger import DebuggingHook
-from logging import INFO
 from typing import Optional
-from trilogy.core.functions import function_args_to_output_purpose, arg_to_datatype
-from trilogy.parsing.common import function_to_concept
+
+import pandas as pd
 from pytest import fixture
+from sqlalchemy import create_engine
+
+from trilogy import Dialects, Executor
+from trilogy.core.enums import FunctionType, Modifier, Purpose
+from trilogy.core.functions import arg_to_datatype, function_args_to_output_purpose
+from trilogy.core.models import (
+    ColumnAssignment,
+    Concept,
+    Datasource,
+    DataType,
+    Environment,
+    Function,
+    Grain,
+    Metadata,
+)
+from trilogy.hooks.query_debugger import DebuggingHook
+from trilogy.parsing.common import function_to_concept
 
 
 def create_passenger_dimension(exec: Executor, name: str):
@@ -70,12 +72,9 @@ def create_fact(
 
 
 def setup_normalized_engine() -> Executor:
-
     engine = create_engine(r"duckdb:///:memory:", future=True)
     csv = PurePath(dirname(__file__)) / "train.csv"
-    output = Executor(
-        engine=engine, dialect=Dialects.DUCK_DB, hooks=[DebuggingHook(level=INFO)]
-    )
+    output = Executor(engine=engine, dialect=Dialects.DUCK_DB, hooks=[DebuggingHook(level=INFO)])
     df = pd.read_csv(csv)
     output.execute_raw_sql("register(:name, :df)", {"name": "df", "df": df})
     output.execute_raw_sql("CREATE TABLE raw_data AS SELECT * FROM df")
@@ -128,14 +127,8 @@ def create_function_derived_concept(
     output_purpose: Optional[Purpose] = None,
     metadata: Optional[Metadata] = None,
 ) -> Concept:
-    purpose = (
-        function_args_to_output_purpose(arguments)
-        if output_purpose is None
-        else output_purpose
-    )
-    output_type = (
-        arg_to_datatype(arguments[0]).data_type if output_type is None else output_type
-    )
+    purpose = function_args_to_output_purpose(arguments) if output_purpose is None else output_purpose
+    output_type = arg_to_datatype(arguments[0]).data_type if output_type is None else output_type
     return Concept(
         name=name,
         namespace=namespace,
@@ -213,9 +206,7 @@ def setup_richest_environment(env: Environment):
 
 def setup_titanic_distributed(env: Environment):
     namespace = "passenger"
-    id = Concept(
-        name="id", namespace=namespace, datatype=DataType.INTEGER, purpose=Purpose.KEY
-    )
+    id = Concept(name="id", namespace=namespace, datatype=DataType.INTEGER, purpose=Purpose.KEY)
     age = Concept(
         name="age",
         namespace=namespace,
@@ -382,9 +373,7 @@ def setup_titanic_distributed(env: Environment):
 
 def setup_titanic(env: Environment):
     namespace = "passenger"
-    id = Concept(
-        name="id", namespace=namespace, datatype=DataType.INTEGER, purpose=Purpose.KEY
-    )
+    id = Concept(name="id", namespace=namespace, datatype=DataType.INTEGER, purpose=Purpose.KEY)
     age = Concept(
         name="age",
         namespace=namespace,

--- a/tests/engine/demo/conftest.py
+++ b/tests/engine/demo/conftest.py
@@ -74,7 +74,9 @@ def create_fact(
 def setup_normalized_engine() -> Executor:
     engine = create_engine(r"duckdb:///:memory:", future=True)
     csv = PurePath(dirname(__file__)) / "train.csv"
-    output = Executor(engine=engine, dialect=Dialects.DUCK_DB, hooks=[DebuggingHook(level=INFO)])
+    output = Executor(
+        engine=engine, dialect=Dialects.DUCK_DB, hooks=[DebuggingHook(level=INFO)]
+    )
     df = pd.read_csv(csv)
     output.execute_raw_sql("register(:name, :df)", {"name": "df", "df": df})
     output.execute_raw_sql("CREATE TABLE raw_data AS SELECT * FROM df")
@@ -127,8 +129,14 @@ def create_function_derived_concept(
     output_purpose: Optional[Purpose] = None,
     metadata: Optional[Metadata] = None,
 ) -> Concept:
-    purpose = function_args_to_output_purpose(arguments) if output_purpose is None else output_purpose
-    output_type = arg_to_datatype(arguments[0]).data_type if output_type is None else output_type
+    purpose = (
+        function_args_to_output_purpose(arguments)
+        if output_purpose is None
+        else output_purpose
+    )
+    output_type = (
+        arg_to_datatype(arguments[0]).data_type if output_type is None else output_type
+    )
     return Concept(
         name=name,
         namespace=namespace,
@@ -206,7 +214,9 @@ def setup_richest_environment(env: Environment):
 
 def setup_titanic_distributed(env: Environment):
     namespace = "passenger"
-    id = Concept(name="id", namespace=namespace, datatype=DataType.INTEGER, purpose=Purpose.KEY)
+    id = Concept(
+        name="id", namespace=namespace, datatype=DataType.INTEGER, purpose=Purpose.KEY
+    )
     age = Concept(
         name="age",
         namespace=namespace,
@@ -373,7 +383,9 @@ def setup_titanic_distributed(env: Environment):
 
 def setup_titanic(env: Environment):
     namespace = "passenger"
-    id = Concept(name="id", namespace=namespace, datatype=DataType.INTEGER, purpose=Purpose.KEY)
+    id = Concept(
+        name="id", namespace=namespace, datatype=DataType.INTEGER, purpose=Purpose.KEY
+    )
     age = Concept(
         name="age",
         namespace=namespace,

--- a/tests/engine/demo/test_demo_duckdb.py
+++ b/tests/engine/demo/test_demo_duckdb.py
@@ -15,7 +15,9 @@ from trilogy.core.models import (
 
 def setup_titanic(env: Environment):
     namespace = "passenger"
-    id = Concept(name="id", namespace=namespace, datatype=DataType.INTEGER, purpose=Purpose.KEY)
+    id = Concept(
+        name="id", namespace=namespace, datatype=DataType.INTEGER, purpose=Purpose.KEY
+    )
     age = Concept(
         name="age",
         namespace=namespace,
@@ -187,14 +189,26 @@ select
     assert set(x.address for x in env.concepts["survivors"].keys) == {
         "passenger.class",
     }
-    assert len(Grain(components=[env.concepts["survivors"], env.concepts["passenger.class"]]).components) == 1
+    assert (
+        len(
+            Grain(
+                components=[env.concepts["survivors"], env.concepts["passenger.class"]]
+            ).components
+        )
+        == 1
+    )
 
-    testc = function_to_concept(parent=env.concepts["ratio"].lineage, name="test", namespace="test")
+    testc = function_to_concept(
+        parent=env.concepts["ratio"].lineage, name="test", namespace="test"
+    )
     assert set(x.address for x in testc.keys) == {
         "passenger.class",
     }
 
-    assert LooseConceptList(concepts=env.concepts["survivors"].grain.components).addresses == LooseConceptList(concepts=[env.concepts["passenger.class"]]).addresses
+    assert (
+        LooseConceptList(concepts=env.concepts["survivors"].grain.components).addresses
+        == LooseConceptList(concepts=[env.concepts["passenger.class"]]).addresses
+    )
     results = executor.execute_text(test)
 
     for row in results[0]:
@@ -321,8 +335,12 @@ order by passenger.decade desc
 ;"""
     # raw = executor.generate_sql(test)
     results = executor.execute_text(test)[-1].fetchall()
-    assert executor.environment.concepts["passenger.age"].modifiers == [Modifier.NULLABLE], "age should be nullable"
-    assert executor.environment.concepts["passenger.decade"].modifiers == [Modifier.NULLABLE], "decade should be nullable"
+    assert executor.environment.concepts["passenger.age"].modifiers == [
+        Modifier.NULLABLE
+    ], "age should be nullable"
+    assert executor.environment.concepts["passenger.decade"].modifiers == [
+        Modifier.NULLABLE
+    ], "decade should be nullable"
 
     assert len(results) == 10
 

--- a/tests/engine/demo/test_demo_duckdb.py
+++ b/tests/engine/demo/test_demo_duckdb.py
@@ -1,23 +1,21 @@
 from trilogy import Executor
-from trilogy.core.models import Environment
+from trilogy.core.enums import FunctionType, Modifier, Purpose
 from trilogy.core.models import (
-    Datasource,
-    Concept,
     ColumnAssignment,
-    Grain,
+    Concept,
+    Datasource,
     DataType,
+    Environment,
     Function,
+    Grain,
     LooseConceptList,
     SelectContext,
 )
-from trilogy.core.enums import Purpose, FunctionType, Modifier
 
 
 def setup_titanic(env: Environment):
     namespace = "passenger"
-    id = Concept(
-        name="id", namespace=namespace, datatype=DataType.INTEGER, purpose=Purpose.KEY
-    )
+    id = Concept(name="id", namespace=namespace, datatype=DataType.INTEGER, purpose=Purpose.KEY)
     age = Concept(
         name="age",
         namespace=namespace,
@@ -189,26 +187,14 @@ select
     assert set(x.address for x in env.concepts["survivors"].keys) == {
         "passenger.class",
     }
-    assert (
-        len(
-            Grain(
-                components=[env.concepts["survivors"], env.concepts["passenger.class"]]
-            ).components
-        )
-        == 1
-    )
+    assert len(Grain(components=[env.concepts["survivors"], env.concepts["passenger.class"]]).components) == 1
 
-    testc = function_to_concept(
-        parent=env.concepts["ratio"].lineage, name="test", namespace="test"
-    )
+    testc = function_to_concept(parent=env.concepts["ratio"].lineage, name="test", namespace="test")
     assert set(x.address for x in testc.keys) == {
         "passenger.class",
     }
 
-    assert (
-        LooseConceptList(concepts=env.concepts["survivors"].grain.components).addresses
-        == LooseConceptList(concepts=[env.concepts["passenger.class"]]).addresses
-    )
+    assert LooseConceptList(concepts=env.concepts["survivors"].grain.components).addresses == LooseConceptList(concepts=[env.concepts["passenger.class"]]).addresses
     results = executor.execute_text(test)
 
     for row in results[0]:
@@ -335,12 +321,8 @@ order by passenger.decade desc
 ;"""
     # raw = executor.generate_sql(test)
     results = executor.execute_text(test)[-1].fetchall()
-    assert executor.environment.concepts["passenger.age"].modifiers == [
-        Modifier.NULLABLE
-    ], "age should be nullable"
-    assert executor.environment.concepts["passenger.decade"].modifiers == [
-        Modifier.NULLABLE
-    ], "decade should be nullable"
+    assert executor.environment.concepts["passenger.age"].modifiers == [Modifier.NULLABLE], "age should be nullable"
+    assert executor.environment.concepts["passenger.decade"].modifiers == [Modifier.NULLABLE], "decade should be nullable"
 
     assert len(results) == 10
 

--- a/tests/engine/demo/test_demo_duckdb_import.py
+++ b/tests/engine/demo/test_demo_duckdb_import.py
@@ -1,14 +1,13 @@
+from trilogy.core.env_processor import concept_to_node, generate_graph
 from trilogy.core.models import Environment
-from trilogy.core.processing.node_generators.node_merge_node import (
-    gen_merge_node,
-    determine_induced_minimal_nodes,
-)
 from trilogy.core.processing.concept_strategies_v3 import search_concepts
-from trilogy.core.env_processor import generate_graph, concept_to_node
+from trilogy.core.processing.node_generators.node_merge_node import (
+    determine_induced_minimal_nodes,
+    gen_merge_node,
+)
 
 
 def test_demo_merge(normalized_engine, test_env: Environment):
-
     assert "passenger.last_name" in test_env.concepts
     normalized_engine.environment = test_env
     concepts = set(list(normalized_engine.environment.concepts.keys()))
@@ -35,7 +34,6 @@ and passenger.last_name is not null;
 
 
 def test_demo_merge_rowset(normalized_engine, test_env: Environment):
-
     assert "passenger.last_name" in test_env.concepts
     normalized_engine.environment = test_env
     concepts = set(list(normalized_engine.environment.concepts.keys()))
@@ -92,7 +90,6 @@ merge rich_info.last_name into ~passenger.last_name;
 
 
 def test_demo_merge_rowset_with_condition(normalized_engine, test_env: Environment):
-
     assert "passenger.last_name" in test_env.concepts
     normalized_engine.environment = test_env
     concepts = set(list(normalized_engine.environment.concepts.keys()))
@@ -100,9 +97,7 @@ def test_demo_merge_rowset_with_condition(normalized_engine, test_env: Environme
     assert "passenger.last_name" in concepts
 
     assert "rich_info.last_name" in set([x for x in concepts if x.startswith("r")])
-    assert "rich_info.net_worth_1918_dollars" in set(
-        [x for x in concepts if x.startswith("r")]
-    )
+    assert "rich_info.net_worth_1918_dollars" in set([x for x in concepts if x.startswith("r")])
 
     test_pre = """merge rich_info.last_name into ~passenger.last_name;"""
     normalized_engine.parse_text(test_pre)
@@ -110,10 +105,7 @@ def test_demo_merge_rowset_with_condition(normalized_engine, test_env: Environme
     g = generate_graph(test_env)
     # from trilogy.hooks.graph_hook import GraphHook
     # GraphHook().query_graph_built(g)
-    target_select_concepts = [
-        test_env.concepts[c]
-        for c in ["passenger.last_name", "rich_info.net_worth_1918_dollars"]
-    ]
+    target_select_concepts = [test_env.concepts[c] for c in ["passenger.last_name", "rich_info.net_worth_1918_dollars"]]
 
     path = determine_induced_minimal_nodes(
         g,
@@ -155,6 +147,7 @@ def test_demo_merge_rowset_with_condition(normalized_engine, test_env: Environme
 def test_demo_merge_rowset_e2e(normalized_engine, test_env: Environment):
     # assert test_env.concept_links[test_env.concepts["passenger.last_name"]][0] == test_env.concepts["rich_info.last_name"]
     from logging import DEBUG
+
     from trilogy.constants import logger
 
     logger.setLevel(DEBUG)

--- a/tests/engine/demo/test_demo_duckdb_import.py
+++ b/tests/engine/demo/test_demo_duckdb_import.py
@@ -97,7 +97,9 @@ def test_demo_merge_rowset_with_condition(normalized_engine, test_env: Environme
     assert "passenger.last_name" in concepts
 
     assert "rich_info.last_name" in set([x for x in concepts if x.startswith("r")])
-    assert "rich_info.net_worth_1918_dollars" in set([x for x in concepts if x.startswith("r")])
+    assert "rich_info.net_worth_1918_dollars" in set(
+        [x for x in concepts if x.startswith("r")]
+    )
 
     test_pre = """merge rich_info.last_name into ~passenger.last_name;"""
     normalized_engine.parse_text(test_pre)
@@ -105,7 +107,10 @@ def test_demo_merge_rowset_with_condition(normalized_engine, test_env: Environme
     g = generate_graph(test_env)
     # from trilogy.hooks.graph_hook import GraphHook
     # GraphHook().query_graph_built(g)
-    target_select_concepts = [test_env.concepts[c] for c in ["passenger.last_name", "rich_info.net_worth_1918_dollars"]]
+    target_select_concepts = [
+        test_env.concepts[c]
+        for c in ["passenger.last_name", "rich_info.net_worth_1918_dollars"]
+    ]
 
     path = determine_induced_minimal_nodes(
         g,

--- a/tests/engine/demo/test_demo_duckdb_multi_table.py
+++ b/tests/engine/demo/test_demo_duckdb_multi_table.py
@@ -7,7 +7,9 @@ from trilogy.core.processing.nodes.base_node import StrategyNode
 
 
 def fingerprint(node: StrategyNode) -> str:
-    base = node.__class__.__name__ + ",".join([fingerprint(node) for node in node.parents])
+    base = node.__class__.__name__ + ",".join(
+        [fingerprint(node) for node in node.parents]
+    )
     if isinstance(node, SelectNode):
         base += node.datasource.name
     base += str(node.conditions)

--- a/tests/engine/demo/test_demo_duckdb_multi_table.py
+++ b/tests/engine/demo/test_demo_duckdb_multi_table.py
@@ -1,15 +1,13 @@
+from trilogy.core.enums import Purpose
 from trilogy.core.models import (
     CTE,
 )
-from trilogy.core.processing.nodes.base_node import StrategyNode
 from trilogy.core.processing.nodes import SelectNode
-from trilogy.core.enums import Purpose
+from trilogy.core.processing.nodes.base_node import StrategyNode
 
 
 def fingerprint(node: StrategyNode) -> str:
-    base = node.__class__.__name__ + ",".join(
-        [fingerprint(node) for node in node.parents]
-    )
+    base = node.__class__.__name__ + ",".join([fingerprint(node) for node in node.parents])
     if isinstance(node, SelectNode):
         base += node.datasource.name
     base += str(node.conditions)

--- a/tests/engine/test_bigquery.py
+++ b/tests/engine/test_bigquery.py
@@ -29,7 +29,6 @@ def test_date_diff_rendering():
     sys.version_info >= (3, 13), reason="BigQuery not supported on 3.13"
 )
 def test_readme():
-
     environment = Environment()
     from trilogy.hooks.query_debugger import DebuggingHook
 
@@ -53,9 +52,7 @@ def test_readme():
 
     """
     )
-    executor = Dialects.BIGQUERY.default_executor(
-        environment=environment, hooks=[DebuggingHook()]
-    )
+    executor = Dialects.BIGQUERY.default_executor(environment=environment, hooks=[DebuggingHook()])
 
     results = executor.execute_text(
         """SELECT

--- a/tests/engine/test_bigquery.py
+++ b/tests/engine/test_bigquery.py
@@ -52,7 +52,9 @@ def test_readme():
 
     """
     )
-    executor = Dialects.BIGQUERY.default_executor(environment=environment, hooks=[DebuggingHook()])
+    executor = Dialects.BIGQUERY.default_executor(
+        environment=environment, hooks=[DebuggingHook()]
+    )
 
     results = executor.execute_text(
         """SELECT

--- a/tests/engine/test_bigquery.py
+++ b/tests/engine/test_bigquery.py
@@ -1,6 +1,8 @@
-from trilogy import Dialects, Environment
-import pytest
 import sys
+
+import pytest
+
+from trilogy import Dialects, Environment
 
 
 # bigquery is not supported on 13 yet

--- a/tests/engine/test_duckdb.py
+++ b/tests/engine/test_duckdb.py
@@ -71,7 +71,9 @@ def test_render_query(duckdb_engine: Executor, expected_results):
 
 
 def test_aggregate_at_grain(duckdb_engine: Executor, expected_results):
-    results = duckdb_engine.execute_text("""select avg_count_per_product;""")[0].fetchall()
+    results = duckdb_engine.execute_text("""select avg_count_per_product;""")[
+        0
+    ].fetchall()
     assert results[0].avg_count_per_product == expected_results["avg_count_per_product"]
 
 
@@ -107,8 +109,13 @@ def test_constants(duckdb_engine: Executor, expected_results):
     # expected_results["converted_total_count"]
     scaled_metric = duckdb_engine.environment.concepts["converted_total_count"]
     assert scaled_metric.purpose == Purpose.METRIC
-    assert duckdb_engine.environment.concepts["usd_conversion"].granularity == Granularity.SINGLE_ROW
-    parent_arg: Concept = [x for x in scaled_metric.lineage.arguments if x.name == "total_count"][0]
+    assert (
+        duckdb_engine.environment.concepts["usd_conversion"].granularity
+        == Granularity.SINGLE_ROW
+    )
+    parent_arg: Concept = [
+        x for x in scaled_metric.lineage.arguments if x.name == "total_count"
+    ][0]
     assert len(parent_arg.lineage.arguments[0].grain.components) == 2
     # assert Grain(components = [duckdb_engine.environment.concepts['usd_conversion']]) == Grain()
     assert results[0].converted_total_count == expected_results["converted_total_count"]
@@ -185,7 +192,10 @@ def test_basic(duckdb_engine: Executor):
   ;
     """
     duckdb_engine.parse_text(test)
-    assert duckdb_engine.environment.concepts["tomorrow"].granularity == Granularity.SINGLE_ROW
+    assert (
+        duckdb_engine.environment.concepts["tomorrow"].granularity
+        == Granularity.SINGLE_ROW
+    )
     results = duckdb_engine.execute_text(test)[0].fetchall()
     assert len(results[0]) == 3
 
@@ -373,16 +383,24 @@ select
 
     customer_orders = default_duckdb_engine.environment.concepts["customer_orders"]
     assert set([x.address for x in customer_orders.keys]) == {"local.customer"}
-    assert set([x.address for x in customer_orders.grain.components]) == {"local.customer"}
+    assert set([x.address for x in customer_orders.grain.components]) == {
+        "local.customer"
+    }
 
     customer_orders_2 = customer_orders.with_select_context(Grain())
     assert set([x.address for x in customer_orders_2.keys]) == {"local.customer"}
-    assert set([x.address for x in customer_orders_2.grain.components]) == {"local.customer"}
+    assert set([x.address for x in customer_orders_2.grain.components]) == {
+        "local.customer"
+    }
 
-    count_by_customer = default_duckdb_engine.environment.concepts["avg_customer_orders"].lineage.arguments[0]
+    count_by_customer = default_duckdb_engine.environment.concepts[
+        "avg_customer_orders"
+    ].lineage.arguments[0]
     # assert isinstance(count_by_customer, AggregateWrapper)
     assert set([x.address for x in count_by_customer.keys]) == {"local.customer"}
-    assert set([x.address for x in count_by_customer.grain.components]) == {"local.customer"}
+    assert set([x.address for x in count_by_customer.grain.components]) == {
+        "local.customer"
+    }
     assert len(results) == 1
     assert results[0].avg_customer_orders == 2
     assert round(results[0].avg_store_orders, 2) == 1.33
@@ -432,7 +450,9 @@ select
     cased = default_duckdb_engine.environment.concepts["cased"]
     total = default_duckdb_engine.environment.concepts["total_mod_two"]
     assert cased.purpose == Purpose.PROPERTY
-    assert LooseConceptList(concepts=cased.keys) == LooseConceptList(concepts=[default_duckdb_engine.environment.concepts["orid"]])
+    assert LooseConceptList(concepts=cased.keys) == LooseConceptList(
+        concepts=[default_duckdb_engine.environment.concepts["orid"]]
+    )
 
     assert total.derivation == PurposeLineage.AGGREGATE
     x = resolve_function_parent_concepts(total)
@@ -736,7 +756,9 @@ order by
     parsed: SelectStatement = duckdb_engine.parse_text(test)[0]
     row_args = parsed.where_clause.row_arguments
     assert parsed.having_clause
-    assert parsed.grain == Grain(components=[duckdb_engine.environment.concepts["item"]])
+    assert parsed.grain == Grain(
+        components=[duckdb_engine.environment.concepts["item"]]
+    )
     assert len(row_args) == 1
     # assert target.grain.components == [duckdb_engine.environment.concepts["item"]]
     results = duckdb_engine.execute_text(test)[0].fetchall()

--- a/tests/engine/test_presto.py
+++ b/tests/engine/test_presto.py
@@ -5,16 +5,14 @@ def test_render_query(presto_engine):
 
 
 def test_numeric_query(presto_engine):
-    results = presto_engine.generate_sql(
-        """select cast(1.235 as NUMERIC(12,2))->decimal_name;"""
-    )[0]
+    results = presto_engine.generate_sql("""select cast(1.235 as NUMERIC(12,2))->decimal_name;""")[0]
 
     assert "DECIMAL(12,2)" in results
 
 
 def test_unnest_query(presto_engine):
-    from trilogy.hooks.query_debugger import DebuggingHook
     from trilogy.constants import CONFIG
+    from trilogy.hooks.query_debugger import DebuggingHook
 
     presto_engine.hooks = [DebuggingHook()]
     current = CONFIG.rendering.parameters

--- a/tests/engine/test_presto.py
+++ b/tests/engine/test_presto.py
@@ -5,7 +5,9 @@ def test_render_query(presto_engine):
 
 
 def test_numeric_query(presto_engine):
-    results = presto_engine.generate_sql("""select cast(1.235 as NUMERIC(12,2))->decimal_name;""")[0]
+    results = presto_engine.generate_sql(
+        """select cast(1.235 as NUMERIC(12,2))->decimal_name;"""
+    )[0]
 
     assert "DECIMAL(12,2)" in results
 

--- a/tests/generators/conftest.py
+++ b/tests/generators/conftest.py
@@ -31,7 +31,9 @@ def test_environment():
     env = Environment()
     order_id = Concept(name="order_id", datatype=DataType.INTEGER, purpose=Purpose.KEY)
 
-    order_timestamp = Concept(name="order_timestamp", datatype=DataType.TIMESTAMP, purpose=Purpose.PROPERTY)
+    order_timestamp = Concept(
+        name="order_timestamp", datatype=DataType.TIMESTAMP, purpose=Purpose.PROPERTY
+    )
 
     order_count = Concept(
         name="order_count",
@@ -74,7 +76,9 @@ def test_environment():
             operator=FunctionType.SUM,
         ),
     )
-    product_id = Concept(name="product_id", datatype=DataType.INTEGER, purpose=Purpose.KEY)
+    product_id = Concept(
+        name="product_id", datatype=DataType.INTEGER, purpose=Purpose.KEY
+    )
     constant_one = Concept(
         name="constant_one",
         datatype=DataType.INTEGER,
@@ -113,7 +117,9 @@ def test_environment():
 
     assert product_id.grain.components[0].name == "product_id"
 
-    category_id = Concept(name="category_id", datatype=DataType.INTEGER, purpose=Purpose.KEY)
+    category_id = Concept(
+        name="category_id", datatype=DataType.INTEGER, purpose=Purpose.KEY
+    )
     category_name = Concept(
         name="category_name",
         datatype=DataType.STRING,
@@ -178,7 +184,9 @@ def test_environment():
         name="category_top_50_revenue_products",
         datatype=DataType.INTEGER,
         purpose=Purpose.METRIC,
-        lineage=AggregateWrapper(function=Count([products_with_revenue_over_50]), by=[category_id]),
+        lineage=AggregateWrapper(
+            function=Count([products_with_revenue_over_50]), by=[category_id]
+        ),
         grain=Grain(components=[category_id]),
     )
 
@@ -194,7 +202,9 @@ def test_environment():
         columns=[
             ColumnAssignment(alias="revenue", concept=revenue),
             ColumnAssignment(alias="order_id", concept=order_id),
-            ColumnAssignment(alias="product_id", concept=product_id, modifiers=[Modifier.PARTIAL]),
+            ColumnAssignment(
+                alias="product_id", concept=product_id, modifiers=[Modifier.PARTIAL]
+            ),
             ColumnAssignment(alias="order_timestamp", concept=order_timestamp),
         ],
         address="tblRevenue",
@@ -205,7 +215,9 @@ def test_environment():
         name="products",
         columns=[
             ColumnAssignment(alias="product_id", concept=product_id),
-            ColumnAssignment(alias="category_id", concept=category_id, modifiers=[Modifier.PARTIAL]),
+            ColumnAssignment(
+                alias="category_id", concept=category_id, modifiers=[Modifier.PARTIAL]
+            ),
         ],
         address="tblProducts",
         grain=Grain(components=[product_id]),

--- a/tests/generators/conftest.py
+++ b/tests/generators/conftest.py
@@ -2,28 +2,27 @@ from pytest import fixture
 
 from trilogy import Environment
 from trilogy.core.enums import (
-    Purpose,
-    FunctionType,
     ComparisonOperator,
-    WindowType,
+    FunctionType,
     Modifier,
+    Purpose,
+    WindowType,
 )
 from trilogy.core.env_processor import generate_graph
 from trilogy.core.functions import Count, CountDistinct, Max, Min
-from trilogy.core.models import AggregateWrapper
-
 from trilogy.core.models import (
-    Concept,
-    DataType,
-    Datasource,
+    AggregateWrapper,
     ColumnAssignment,
+    Comparison,
+    Concept,
+    Datasource,
+    DataType,
+    FilterItem,
     Function,
     Grain,
-    WindowItem,
-    FilterItem,
     OrderItem,
     WhereClause,
-    Comparison,
+    WindowItem,
 )
 
 
@@ -32,9 +31,7 @@ def test_environment():
     env = Environment()
     order_id = Concept(name="order_id", datatype=DataType.INTEGER, purpose=Purpose.KEY)
 
-    order_timestamp = Concept(
-        name="order_timestamp", datatype=DataType.TIMESTAMP, purpose=Purpose.PROPERTY
-    )
+    order_timestamp = Concept(name="order_timestamp", datatype=DataType.TIMESTAMP, purpose=Purpose.PROPERTY)
 
     order_count = Concept(
         name="order_count",
@@ -77,9 +74,7 @@ def test_environment():
             operator=FunctionType.SUM,
         ),
     )
-    product_id = Concept(
-        name="product_id", datatype=DataType.INTEGER, purpose=Purpose.KEY
-    )
+    product_id = Concept(name="product_id", datatype=DataType.INTEGER, purpose=Purpose.KEY)
     constant_one = Concept(
         name="constant_one",
         datatype=DataType.INTEGER,
@@ -118,9 +113,7 @@ def test_environment():
 
     assert product_id.grain.components[0].name == "product_id"
 
-    category_id = Concept(
-        name="category_id", datatype=DataType.INTEGER, purpose=Purpose.KEY
-    )
+    category_id = Concept(name="category_id", datatype=DataType.INTEGER, purpose=Purpose.KEY)
     category_name = Concept(
         name="category_name",
         datatype=DataType.STRING,
@@ -185,9 +178,7 @@ def test_environment():
         name="category_top_50_revenue_products",
         datatype=DataType.INTEGER,
         purpose=Purpose.METRIC,
-        lineage=AggregateWrapper(
-            function=Count([products_with_revenue_over_50]), by=[category_id]
-        ),
+        lineage=AggregateWrapper(function=Count([products_with_revenue_over_50]), by=[category_id]),
         grain=Grain(components=[category_id]),
     )
 
@@ -203,9 +194,7 @@ def test_environment():
         columns=[
             ColumnAssignment(alias="revenue", concept=revenue),
             ColumnAssignment(alias="order_id", concept=order_id),
-            ColumnAssignment(
-                alias="product_id", concept=product_id, modifiers=[Modifier.PARTIAL]
-            ),
+            ColumnAssignment(alias="product_id", concept=product_id, modifiers=[Modifier.PARTIAL]),
             ColumnAssignment(alias="order_timestamp", concept=order_timestamp),
         ],
         address="tblRevenue",
@@ -216,9 +205,7 @@ def test_environment():
         name="products",
         columns=[
             ColumnAssignment(alias="product_id", concept=product_id),
-            ColumnAssignment(
-                alias="category_id", concept=category_id, modifiers=[Modifier.PARTIAL]
-            ),
+            ColumnAssignment(alias="category_id", concept=category_id, modifiers=[Modifier.PARTIAL]),
         ],
         address="tblProducts",
         grain=Grain(components=[product_id]),

--- a/tests/generators/test_enrichment_node_generators.py
+++ b/tests/generators/test_enrichment_node_generators.py
@@ -1,6 +1,6 @@
+from trilogy.core.processing.concept_strategies_v3 import search_concepts
 from trilogy.core.processing.node_generators.common import gen_property_enrichment_node
 from trilogy.core.processing.node_generators.group_node import gen_group_node
-from trilogy.core.processing.concept_strategies_v3 import search_concepts
 
 
 def address_set(concepts):
@@ -8,7 +8,6 @@ def address_set(concepts):
 
 
 def test_gen_property_enrichment_node(test_environment, test_environment_graph):
-
     prod = test_environment.concepts["category_id"]
     prod_r = test_environment.concepts["total_revenue"]
     gnode = gen_group_node(

--- a/tests/generators/test_filter_node_generator.py
+++ b/tests/generators/test_filter_node_generator.py
@@ -1,10 +1,10 @@
-from trilogy.core.processing.node_generators import gen_filter_node
+from trilogy.core.enums import ComparisonOperator, PurposeLineage
+from trilogy.core.models import Comparison, Environment
 from trilogy.core.processing.concept_strategies_v3 import search_concepts
+from trilogy.core.processing.node_generators import gen_filter_node
 from trilogy.core.processing.node_generators.common import (
     resolve_filter_parent_concepts,
 )
-from trilogy.core.models import Environment, Comparison
-from trilogy.core.enums import PurposeLineage, ComparisonOperator
 
 
 def test_gen_filter_node_parents(test_environment: Environment, test_environment_graph):
@@ -42,14 +42,8 @@ def test_gen_filter_node_same_concept(test_environment, test_environment_graph):
         right="%abc%",
     )
     node = gen_filter_node(
-        concept=test_environment.concepts["product_id"].with_filter(
-            conditional, test_environment
-        ),
-        local_optional=[
-            test_environment.concepts["category_id"].with_filter(
-                conditional, test_environment
-            )
-        ],
+        concept=test_environment.concepts["product_id"].with_filter(conditional, test_environment),
+        local_optional=[test_environment.concepts["category_id"].with_filter(conditional, test_environment)],
         environment=test_environment,
         g=test_environment_graph,
         depth=0,
@@ -65,14 +59,8 @@ def test_gen_filter_node_include_all(test_environment, test_environment_graph):
         right="%abc%",
     )
     node = gen_filter_node(
-        concept=test_environment.concepts["product_id"].with_filter(
-            conditional, test_environment
-        ),
-        local_optional=[
-            test_environment.concepts["category_id"].with_filter(
-                conditional, test_environment
-            )
-        ],
+        concept=test_environment.concepts["product_id"].with_filter(conditional, test_environment),
+        local_optional=[test_environment.concepts["category_id"].with_filter(conditional, test_environment)],
         environment=test_environment,
         g=test_environment_graph,
         depth=0,

--- a/tests/generators/test_filter_node_generator.py
+++ b/tests/generators/test_filter_node_generator.py
@@ -42,8 +42,14 @@ def test_gen_filter_node_same_concept(test_environment, test_environment_graph):
         right="%abc%",
     )
     node = gen_filter_node(
-        concept=test_environment.concepts["product_id"].with_filter(conditional, test_environment),
-        local_optional=[test_environment.concepts["category_id"].with_filter(conditional, test_environment)],
+        concept=test_environment.concepts["product_id"].with_filter(
+            conditional, test_environment
+        ),
+        local_optional=[
+            test_environment.concepts["category_id"].with_filter(
+                conditional, test_environment
+            )
+        ],
         environment=test_environment,
         g=test_environment_graph,
         depth=0,
@@ -59,8 +65,14 @@ def test_gen_filter_node_include_all(test_environment, test_environment_graph):
         right="%abc%",
     )
     node = gen_filter_node(
-        concept=test_environment.concepts["product_id"].with_filter(conditional, test_environment),
-        local_optional=[test_environment.concepts["category_id"].with_filter(conditional, test_environment)],
+        concept=test_environment.concepts["product_id"].with_filter(
+            conditional, test_environment
+        ),
+        local_optional=[
+            test_environment.concepts["category_id"].with_filter(
+                conditional, test_environment
+            )
+        ],
         environment=test_environment,
         g=test_environment_graph,
         depth=0,

--- a/tests/generators/test_group_generator.py
+++ b/tests/generators/test_group_generator.py
@@ -47,7 +47,9 @@ def test_gen_group_node(test_environment: Environment, test_environment_graph):
     DebuggingHook()
     cat = test_environment.concepts["category_id"]
     test_environment.concepts["category_top_50_revenue_products"]
-    immediate_aggregate_input = test_environment.concepts["products_with_revenue_over_50"]
+    immediate_aggregate_input = test_environment.concepts[
+        "products_with_revenue_over_50"
+    ]
     gnode = gen_group_node(
         concept=test_environment.concepts["category_top_50_revenue_products"],
         local_optional=[],

--- a/tests/generators/test_group_generator.py
+++ b/tests/generators/test_group_generator.py
@@ -1,12 +1,11 @@
-from trilogy.core.processing.node_generators import gen_group_node
-from trilogy.core.processing.nodes import GroupNode
+from trilogy.core.enums import FunctionType, Purpose, PurposeLineage
+from trilogy.core.models import AggregateWrapper, DataType, Environment, Function
 from trilogy.core.processing.concept_strategies_v3 import search_concepts
+from trilogy.core.processing.node_generators import gen_group_node
 from trilogy.core.processing.node_generators.common import (
     resolve_function_parent_concepts,
 )
-from trilogy.core.processing.nodes import MergeNode
-from trilogy.core.models import Environment, AggregateWrapper, Function, DataType
-from trilogy.core.enums import PurposeLineage, FunctionType, Purpose
+from trilogy.core.processing.nodes import GroupNode, MergeNode
 from trilogy.parsing.common import agg_wrapper_to_concept, function_to_concept
 
 
@@ -48,9 +47,7 @@ def test_gen_group_node(test_environment: Environment, test_environment_graph):
     DebuggingHook()
     cat = test_environment.concepts["category_id"]
     test_environment.concepts["category_top_50_revenue_products"]
-    immediate_aggregate_input = test_environment.concepts[
-        "products_with_revenue_over_50"
-    ]
+    immediate_aggregate_input = test_environment.concepts["products_with_revenue_over_50"]
     gnode = gen_group_node(
         concept=test_environment.concepts["category_top_50_revenue_products"],
         local_optional=[],

--- a/tests/generators/test_merge_concept_node.py
+++ b/tests/generators/test_merge_concept_node.py
@@ -1,5 +1,5 @@
-from trilogy.core.models import Environment
 from trilogy import parse
+from trilogy.core.models import Environment
 from trilogy.dialect.base import BaseDialect
 
 
@@ -74,25 +74,17 @@ address num1;
     env1.add_import("env2", env2)
     env1.parse("""merge one into env2.one;""")
     # assert key_candidate.model_dump() == env1.concepts["env2.one"].model_dump()
-    assert env1.concepts["name"].keys == (env1.concepts["env2.one"],), [
-        x.address for x in env1.concepts["name"].keys
-    ]
+    assert env1.concepts["name"].keys == (env1.concepts["env2.one"],), [x.address for x in env1.concepts["name"].keys]
 
     assert env1.datasources["num1"].grain.components == [
         env1.concepts["env2.one"],
     ], [x.address for x in env1.datasources["num1"].grain.components]
 
-    assert env1.concepts["env2.one"].address in [
-        y.address for y in env1.datasources["num1"].output_concepts
-    ]
+    assert env1.concepts["env2.one"].address in [y.address for y in env1.datasources["num1"].output_concepts]
 
-    assert (
-        len({x.alias: x.concept.address for x in env1.datasources["num1"].columns}) == 2
-    )
+    assert len({x.alias: x.concept.address for x in env1.datasources["num1"].columns}) == 2
 
-    assert str(env1.concepts["name"].with_grain(env1.concepts["env2.one"])) in [
-        str(x) for x in env1.datasources["num1"].concepts
-    ]
+    assert str(env1.concepts["name"].with_grain(env1.concepts["env2.one"])) in [str(x) for x in env1.datasources["num1"].concepts]
     bd = BaseDialect()
     _, queries = env1.parse(
         """

--- a/tests/generators/test_merge_concept_node.py
+++ b/tests/generators/test_merge_concept_node.py
@@ -74,17 +74,25 @@ address num1;
     env1.add_import("env2", env2)
     env1.parse("""merge one into env2.one;""")
     # assert key_candidate.model_dump() == env1.concepts["env2.one"].model_dump()
-    assert env1.concepts["name"].keys == (env1.concepts["env2.one"],), [x.address for x in env1.concepts["name"].keys]
+    assert env1.concepts["name"].keys == (env1.concepts["env2.one"],), [
+        x.address for x in env1.concepts["name"].keys
+    ]
 
     assert env1.datasources["num1"].grain.components == [
         env1.concepts["env2.one"],
     ], [x.address for x in env1.datasources["num1"].grain.components]
 
-    assert env1.concepts["env2.one"].address in [y.address for y in env1.datasources["num1"].output_concepts]
+    assert env1.concepts["env2.one"].address in [
+        y.address for y in env1.datasources["num1"].output_concepts
+    ]
 
-    assert len({x.alias: x.concept.address for x in env1.datasources["num1"].columns}) == 2
+    assert (
+        len({x.alias: x.concept.address for x in env1.datasources["num1"].columns}) == 2
+    )
 
-    assert str(env1.concepts["name"].with_grain(env1.concepts["env2.one"])) in [str(x) for x in env1.datasources["num1"].concepts]
+    assert str(env1.concepts["name"].with_grain(env1.concepts["env2.one"])) in [
+        str(x) for x in env1.datasources["num1"].concepts
+    ]
     bd = BaseDialect()
     _, queries = env1.parse(
         """

--- a/tests/generators/test_merge_node.py
+++ b/tests/generators/test_merge_node.py
@@ -1,9 +1,9 @@
-from trilogy.core.processing.nodes import MergeNode
-from trilogy.core.processing.nodes import NodeJoin, ConstantNode
-from trilogy.core.models import Environment
-from trilogy.core.enums import JoinType
-from trilogy.core.processing.graph_utils import extract_required_subgraphs
 from collections import defaultdict
+
+from trilogy.core.enums import JoinType
+from trilogy.core.models import Environment
+from trilogy.core.processing.graph_utils import extract_required_subgraphs
+from trilogy.core.processing.nodes import ConstantNode, MergeNode, NodeJoin
 
 
 def test_same_join_fails(test_environment: Environment, test_environment_graph):
@@ -53,9 +53,7 @@ def test_graph_resolution():
         "c~rich_info.full_name@Grain<rich_info.full_name>",
         "c~rich_info.last_name@Grain<Abstract>",
     ]
-    assert assocs[
-        "ds~local.__virtual_bridge_passenger_last_name_rich_info_last_name"
-    ] == [
+    assert assocs["ds~local.__virtual_bridge_passenger_last_name_rich_info_last_name"] == [
         "c~rich_info.last_name@Grain<Abstract>",
         "c~passenger.last_name@Grain<Abstract>",
         "c~passenger.last_name@Grain<passenger.id>",
@@ -85,7 +83,6 @@ def test_graph_rez_bridge():
             "c~rich_info.net_worth_1918_dollars@Grain<rich_info.full_name>",
         ],
     }.items():
-
         extract_required_subgraphs(assocs, v)
 
     assert set(assocs["ds~rich_info.rich_info"]) == set(

--- a/tests/generators/test_merge_node.py
+++ b/tests/generators/test_merge_node.py
@@ -53,7 +53,9 @@ def test_graph_resolution():
         "c~rich_info.full_name@Grain<rich_info.full_name>",
         "c~rich_info.last_name@Grain<Abstract>",
     ]
-    assert assocs["ds~local.__virtual_bridge_passenger_last_name_rich_info_last_name"] == [
+    assert assocs[
+        "ds~local.__virtual_bridge_passenger_last_name_rich_info_last_name"
+    ] == [
         "c~rich_info.last_name@Grain<Abstract>",
         "c~passenger.last_name@Grain<Abstract>",
         "c~passenger.last_name@Grain<passenger.id>",

--- a/tests/generators/test_multiselect_node_generator.py
+++ b/tests/generators/test_multiselect_node_generator.py
@@ -55,7 +55,7 @@ ALIGN
     resolved = gnode.resolve()
     assert len(resolved.source_map["local.one_key"]) == 2
 
-    cte = datasource_to_cte(resolved, {})[0]
+    cte = datasource_to_cte(resolved, {})
     assert len(cte.source_map["local.one_key"]) == 2
 
 

--- a/tests/generators/test_multiselect_node_generator.py
+++ b/tests/generators/test_multiselect_node_generator.py
@@ -1,10 +1,9 @@
-from trilogy.core.processing.node_generators import gen_multiselect_node
-from trilogy.core.processing.concept_strategies_v3 import search_concepts
-
-from trilogy.core.models import Environment
 from trilogy import parse
 from trilogy.core.env_processor import generate_graph
-from trilogy.core.query_processor import datasource_to_ctes
+from trilogy.core.models import Environment
+from trilogy.core.processing.concept_strategies_v3 import search_concepts
+from trilogy.core.processing.node_generators import gen_multiselect_node
+from trilogy.core.query_processor import datasource_to_cte
 
 
 def test_multi_select(test_environment: Environment, test_environment_graph):
@@ -56,7 +55,7 @@ ALIGN
     resolved = gnode.resolve()
     assert len(resolved.source_map["local.one_key"]) == 2
 
-    cte = datasource_to_ctes(resolved, {})[0]
+    cte = datasource_to_cte(resolved, {})[0]
     assert len(cte.source_map["local.one_key"]) == 2
 
 

--- a/tests/generators/test_select_node_generator.py
+++ b/tests/generators/test_select_node_generator.py
@@ -1,6 +1,6 @@
+from trilogy.core.env_processor import generate_graph
 from trilogy.core.models import Environment, PersistStatement
 from trilogy.core.processing.node_generators import gen_select_node
-from trilogy.core.env_processor import generate_graph
 from trilogy.core.processing.nodes import ConstantNode, SelectNode
 from trilogy.hooks.query_debugger import DebuggingHook
 

--- a/tests/generators/test_unnest_node_generator.py
+++ b/tests/generators/test_unnest_node_generator.py
@@ -1,6 +1,6 @@
-from trilogy.core.processing.node_generators import gen_unnest_node
-from trilogy.core.processing.concept_strategies_v3 import search_concepts
 from trilogy.core.models import Environment
+from trilogy.core.processing.concept_strategies_v3 import search_concepts
+from trilogy.core.processing.node_generators import gen_unnest_node
 
 
 def test_gen_unnest_node_parents(test_environment: Environment, test_environment_graph):

--- a/tests/generators/test_utility.py
+++ b/tests/generators/test_utility.py
@@ -29,7 +29,9 @@ property product_id.price float;
     orders = env.concepts["order_id"]
     price = env.concepts["price"]
     product = env.concepts["product_id"]
-    left = StrategyNode(input_concepts=[orders], output_concepts=[orders], environment=env, g=g)
+    left = StrategyNode(
+        input_concepts=[orders], output_concepts=[orders], environment=env, g=g
+    )
     right = StrategyNode(
         input_concepts=[orders, product],
         output_concepts=[orders, product],

--- a/tests/generators/test_utility.py
+++ b/tests/generators/test_utility.py
@@ -1,14 +1,15 @@
+from networkx import Graph
+
+from trilogy import parse
+from trilogy.core.enums import JoinType
+from trilogy.core.env_processor import generate_graph
 from trilogy.core.processing.node_generators.common import (
-    resolve_join_order,
     # resolve_join_order_v2,
     NodeJoin,
     StrategyNode,
+    resolve_join_order,
 )
-from trilogy.core.processing.utility import resolve_join_order_v2, JoinOrderOutput
-from trilogy import parse
-from trilogy.core.env_processor import generate_graph
-from trilogy.core.enums import JoinType
-from networkx import Graph
+from trilogy.core.processing.utility import JoinOrderOutput, resolve_join_order_v2
 
 
 def test_resolve_join_order():
@@ -28,9 +29,7 @@ property product_id.price float;
     orders = env.concepts["order_id"]
     price = env.concepts["price"]
     product = env.concepts["product_id"]
-    left = StrategyNode(
-        input_concepts=[orders], output_concepts=[orders], environment=env, g=g
-    )
+    left = StrategyNode(input_concepts=[orders], output_concepts=[orders], environment=env, g=g)
     right = StrategyNode(
         input_concepts=[orders, product],
         output_concepts=[orders, product],
@@ -76,7 +75,6 @@ property product_id.price float;
 
 
 def test_resolve_join_order_v2():
-
     g = Graph()
 
     g.add_edge("ds~orders", "c~order_id")

--- a/tests/hooks/test_hooks.py
+++ b/tests/hooks/test_hooks.py
@@ -48,4 +48,6 @@ select
     """
     env, parsed = parse(declarations)
     select: SelectStatement = parsed[-1]
-    BaseHook().process_rowset_info(RowsetDerivationStatement(name="test", select=select, namespace="test"))
+    BaseHook().process_rowset_info(
+        RowsetDerivationStatement(name="test", select=select, namespace="test")
+    )

--- a/tests/hooks/test_hooks.py
+++ b/tests/hooks/test_hooks.py
@@ -1,6 +1,6 @@
-from trilogy.hooks.base_hook import BaseHook, SelectStatement
-from trilogy.core.models import RowsetDerivationStatement
 from trilogy import parse
+from trilogy.core.models import RowsetDerivationStatement
+from trilogy.hooks.base_hook import BaseHook, SelectStatement
 
 
 def test_base():
@@ -48,6 +48,4 @@ select
     """
     env, parsed = parse(declarations)
     select: SelectStatement = parsed[-1]
-    BaseHook().process_rowset_info(
-        RowsetDerivationStatement(name="test", select=select, namespace="test")
-    )
+    BaseHook().process_rowset_info(RowsetDerivationStatement(name="test", select=select, namespace="test"))

--- a/tests/modeling/aggregates/conftest.py
+++ b/tests/modeling/aggregates/conftest.py
@@ -1,11 +1,11 @@
-from pytest import fixture
-
-from trilogy import Environment
-from trilogy.core.env_processor import generate_graph
-from trilogy import Dialects
-from trilogy.hooks.query_debugger import DebuggingHook
 from logging import INFO
 from pathlib import Path
+
+from pytest import fixture
+
+from trilogy import Dialects, Environment
+from trilogy.core.env_processor import generate_graph
+from trilogy.hooks.query_debugger import DebuggingHook
 
 
 @fixture(scope="session")
@@ -17,9 +17,7 @@ def test_environment():
 
 @fixture(scope="session")
 def test_executor(test_environment: Environment):
-    yield Dialects.DUCK_DB.default_executor(
-        environment=test_environment, hooks=[DebuggingHook(level=INFO)]
-    )
+    yield Dialects.DUCK_DB.default_executor(environment=test_environment, hooks=[DebuggingHook(level=INFO)])
 
 
 @fixture(scope="session")

--- a/tests/modeling/aggregates/conftest.py
+++ b/tests/modeling/aggregates/conftest.py
@@ -17,7 +17,9 @@ def test_environment():
 
 @fixture(scope="session")
 def test_executor(test_environment: Environment):
-    yield Dialects.DUCK_DB.default_executor(environment=test_environment, hooks=[DebuggingHook(level=INFO)])
+    yield Dialects.DUCK_DB.default_executor(
+        environment=test_environment, hooks=[DebuggingHook(level=INFO)]
+    )
 
 
 @fixture(scope="session")

--- a/tests/modeling/aggregates/test_cardinality.py
+++ b/tests/modeling/aggregates/test_cardinality.py
@@ -1,5 +1,5 @@
+from trilogy import Executor, parse
 from trilogy.core.models import Environment, Grain
-from trilogy import parse, Executor
 
 
 def test_key_fetch_cardinality(test_environment: Environment, test_executor: Executor):
@@ -40,9 +40,7 @@ SELECT
     assert results[0] == (3,)
 
 
-def test_filtered_key_count_cardinality(
-    test_environment: Environment, test_executor: Executor
-):
+def test_filtered_key_count_cardinality(test_environment: Environment, test_executor: Executor):
     # test keys
     test_select = """
 auto aspen_store <- filter stores.name where stores.name = 'aspen';
@@ -53,9 +51,7 @@ SELECT
 ;"""
 
     _, statements = parse(test_select, test_environment)
-    assert test_environment.concepts["aspen_store"].grain == Grain(
-        components=[test_environment.concepts["stores.id"]]
-    )
+    assert test_environment.concepts["aspen_store"].grain == Grain(components=[test_environment.concepts["stores.id"]])
 
     results = test_executor.execute_text(test_select)[0].fetchall()
 

--- a/tests/modeling/aggregates/test_cardinality.py
+++ b/tests/modeling/aggregates/test_cardinality.py
@@ -40,7 +40,9 @@ SELECT
     assert results[0] == (3,)
 
 
-def test_filtered_key_count_cardinality(test_environment: Environment, test_executor: Executor):
+def test_filtered_key_count_cardinality(
+    test_environment: Environment, test_executor: Executor
+):
     # test keys
     test_select = """
 auto aspen_store <- filter stores.name where stores.name = 'aspen';
@@ -51,7 +53,9 @@ SELECT
 ;"""
 
     _, statements = parse(test_select, test_environment)
-    assert test_environment.concepts["aspen_store"].grain == Grain(components=[test_environment.concepts["stores.id"]])
+    assert test_environment.concepts["aspen_store"].grain == Grain(
+        components=[test_environment.concepts["stores.id"]]
+    )
 
     results = test_executor.execute_text(test_select)[0].fetchall()
 

--- a/tests/modeling/conftest.py
+++ b/tests/modeling/conftest.py
@@ -95,7 +95,9 @@ where
 
 @fixture(scope="session")
 def test_executor(test_environment: Environment):
-    yield Dialects.DUCK_DB.default_executor(environment=test_environment, hooks=[DebuggingHook(level=INFO)])
+    yield Dialects.DUCK_DB.default_executor(
+        environment=test_environment, hooks=[DebuggingHook(level=INFO)]
+    )
 
 
 @fixture(scope="session")

--- a/tests/modeling/conftest.py
+++ b/tests/modeling/conftest.py
@@ -1,10 +1,10 @@
+from logging import INFO
+
 from pytest import fixture
 
-from trilogy import Environment
+from trilogy import Dialects, Environment, parse
 from trilogy.core.env_processor import generate_graph
-from trilogy import parse, Dialects
 from trilogy.hooks.query_debugger import DebuggingHook
-from logging import INFO
 
 
 @fixture(scope="session")
@@ -95,9 +95,7 @@ where
 
 @fixture(scope="session")
 def test_executor(test_environment: Environment):
-    yield Dialects.DUCK_DB.default_executor(
-        environment=test_environment, hooks=[DebuggingHook(level=INFO)]
-    )
+    yield Dialects.DUCK_DB.default_executor(environment=test_environment, hooks=[DebuggingHook(level=INFO)])
 
 
 @fixture(scope="session")

--- a/tests/modeling/google_analytics/test_sane_ga_rendering.py
+++ b/tests/modeling/google_analytics/test_sane_ga_rendering.py
@@ -36,11 +36,15 @@ def test_sane_rendering():
     with open(Path(__file__).parent / "daily_visits.preql") as f:
         sql = f.read()
 
-    env, statements = parse(sql, environment=Environment(working_path=Path(__file__).parent))
+    env, statements = parse(
+        sql, environment=Environment(working_path=Path(__file__).parent)
+    )
     enrich_environment(env)
     local_static = env.concepts["local.static"]
     assert local_static.granularity == Granularity.SINGLE_ROW
-    engine: Executor = Dialects.DUCK_DB.default_executor(environment=env, hooks=[DebuggingHook(INFO)])
+    engine: Executor = Dialects.DUCK_DB.default_executor(
+        environment=env, hooks=[DebuggingHook(INFO)]
+    )
     statements[-1].select.selection.append(SelectItem(content=local_static))
     pstatements = engine.generator.generate_queries(env, statements)
     select: ProcessedQuery = pstatements[-1]
@@ -70,7 +74,9 @@ def test_daily_job():
     with open(Path(__file__).parent / "daily_analytics.preql") as f:
         sql = f.read()
 
-    env, statements = parse(sql, environment=Environment(working_path=Path(__file__).parent))
+    env, statements = parse(
+        sql, environment=Environment(working_path=Path(__file__).parent)
+    )
     enrich_environment(env)
     local_static = env.concepts["local.static"]
     assert local_static.granularity == Granularity.SINGLE_ROW
@@ -94,7 +100,9 @@ def test_daily_job():
     for x in parents:
         assert x.namespace == "all_sites"
 
-    engine: Executor = Dialects.DUCK_DB.default_executor(environment=env, hooks=[DebuggingHook(INFO)])
+    engine: Executor = Dialects.DUCK_DB.default_executor(
+        environment=env, hooks=[DebuggingHook(INFO)]
+    )
     statements[-1].select.selection.append(SelectItem(content=local_static))
     pstatements = engine.generator.generate_queries(env, statements)
     select: ProcessedQuery = pstatements[-1]
@@ -105,11 +113,17 @@ def test_rolling_analytics():
     with open(Path(__file__).parent / "rolling_analytics.preql") as f:
         sql = f.read()
 
-    env, statements = parse(sql, environment=Environment(working_path=Path(__file__).parent))
+    env, statements = parse(
+        sql, environment=Environment(working_path=Path(__file__).parent)
+    )
 
     engine: Executor = Dialects.DUCK_DB.default_executor(
         environment=env,
-        hooks=[DebuggingHook(INFO, process_other=False, process_ctes=False, process_datasources=False)],
+        hooks=[
+            DebuggingHook(
+                INFO, process_other=False, process_ctes=False, process_datasources=False
+            )
+        ],
     )
     pstatements = engine.generator.generate_queries(env, statements)
     select: ProcessedQuery = pstatements[-1]
@@ -123,7 +137,9 @@ def test_counts():
     with open(Path(__file__).parent / "daily_visits.preql") as f:
         sql = f.read()
 
-    env, statements = parse(sql, environment=Environment(working_path=Path(__file__).parent))
+    env, statements = parse(
+        sql, environment=Environment(working_path=Path(__file__).parent)
+    )
     enrich_environment(env)
     local_static = env.concepts["local.static"]
     assert local_static.granularity == Granularity.SINGLE_ROW
@@ -147,7 +163,9 @@ def test_counts():
     for x in parents:
         assert x.namespace == "all_sites"
 
-    engine: Executor = Dialects.DUCK_DB.default_executor(environment=env, hooks=[DebuggingHook(INFO)])
+    engine: Executor = Dialects.DUCK_DB.default_executor(
+        environment=env, hooks=[DebuggingHook(INFO)]
+    )
     statements[-1].select.selection.append(SelectItem(content=local_static))
     pstatements = engine.generator.generate_queries(env, statements)
     select: ProcessedQuery = pstatements[-1]

--- a/tests/modeling/join_resolution/conftest.py
+++ b/tests/modeling/join_resolution/conftest.py
@@ -136,7 +136,9 @@ where
 
 @fixture(scope="session")
 def test_executor(test_environment: Environment):
-    yield Dialects.DUCK_DB.default_executor(environment=test_environment, hooks=[DebuggingHook(level=INFO)])
+    yield Dialects.DUCK_DB.default_executor(
+        environment=test_environment, hooks=[DebuggingHook(level=INFO)]
+    )
 
 
 @fixture(scope="session")

--- a/tests/modeling/join_resolution/conftest.py
+++ b/tests/modeling/join_resolution/conftest.py
@@ -1,10 +1,10 @@
+from logging import INFO
+
 from pytest import fixture
 
-from trilogy import Environment
+from trilogy import Dialects, Environment, parse
 from trilogy.core.env_processor import generate_graph
-from trilogy import parse, Dialects
 from trilogy.hooks.query_debugger import DebuggingHook
-from logging import INFO
 
 
 @fixture(scope="session")
@@ -136,9 +136,7 @@ where
 
 @fixture(scope="session")
 def test_executor(test_environment: Environment):
-    yield Dialects.DUCK_DB.default_executor(
-        environment=test_environment, hooks=[DebuggingHook(level=INFO)]
-    )
+    yield Dialects.DUCK_DB.default_executor(environment=test_environment, hooks=[DebuggingHook(level=INFO)])
 
 
 @fixture(scope="session")

--- a/tests/modeling/join_resolution/test_join_resolution.py
+++ b/tests/modeling/join_resolution/test_join_resolution.py
@@ -21,7 +21,9 @@ SELECT
         list(test_executor.execute_text(test_select)[0].fetchall())
 
 
-def test_ambiguous_error_with_forced_join(test_environment: Environment, test_executor: Executor):
+def test_ambiguous_error_with_forced_join(
+    test_environment: Environment, test_executor: Executor
+):
     # check we can resolve it
     test_select = """
 property store_by_warehouse <- group(store_id) by wh_id;
@@ -52,7 +54,9 @@ SELECT
     assert len(results) == 3
 
 
-def test_ambiguous_error_with_forced_join_order(test_environment: Environment, test_executor: Executor):
+def test_ambiguous_error_with_forced_join_order(
+    test_environment: Environment, test_executor: Executor
+):
     # check we can resolve it
     test_select = """
 property store_by_warehouse <- group(store_id) by wh_id;

--- a/tests/modeling/join_resolution/test_join_resolution.py
+++ b/tests/modeling/join_resolution/test_join_resolution.py
@@ -1,8 +1,9 @@
-from trilogy.core.models import Environment, Grain
+import pytest
+
+from trilogy import Executor, parse
 from trilogy.core.enums import Purpose
 from trilogy.core.exceptions import AmbiguousRelationshipResolutionException
-from trilogy import parse, Executor
-import pytest
+from trilogy.core.models import Environment, Grain
 
 
 def test_ambiguous_error(test_environment: Environment, test_executor: Executor):
@@ -20,9 +21,7 @@ SELECT
         list(test_executor.execute_text(test_select)[0].fetchall())
 
 
-def test_ambiguous_error_with_forced_join(
-    test_environment: Environment, test_executor: Executor
-):
+def test_ambiguous_error_with_forced_join(test_environment: Environment, test_executor: Executor):
     # check we can resolve it
     test_select = """
 property store_by_warehouse <- group(store_id) by wh_id;
@@ -53,9 +52,7 @@ SELECT
     assert len(results) == 3
 
 
-def test_ambiguous_error_with_forced_join_order(
-    test_environment: Environment, test_executor: Executor
-):
+def test_ambiguous_error_with_forced_join_order(test_environment: Environment, test_executor: Executor):
     # check we can resolve it
     test_select = """
 property store_by_warehouse <- group(store_id) by wh_id;

--- a/tests/modeling/nyc_citibike/test_nyc.py
+++ b/tests/modeling/nyc_citibike/test_nyc.py
@@ -1,5 +1,6 @@
-from trilogy import Environment
 from pathlib import Path
+
+from trilogy import Environment
 from trilogy.core.models import Function
 
 

--- a/tests/modeling/stocks/test_stocks.py
+++ b/tests/modeling/stocks/test_stocks.py
@@ -1,9 +1,9 @@
-from trilogy import Environment, Dialects
 from pathlib import Path
+
+from trilogy import Dialects, Environment
 
 
 def test_query():
-
     env = Environment.from_file(Path(__file__).parent / "entrypoint.preql")
 
     duckdb = Dialects.DUCK_DB.default_executor(environment=env)

--- a/tests/modeling/test_complex.py
+++ b/tests/modeling/test_complex.py
@@ -43,7 +43,9 @@ def test_rowset_with_addition(test_environment: Environment, test_executor: Exec
     assert results[3] == (4, 4, 2)
 
 
-def test_rowset_with_aggregation(test_environment: Environment, test_executor: Executor):
+def test_rowset_with_aggregation(
+    test_environment: Environment, test_executor: Executor
+):
     test_select = """
 
     rowset even_orders <- select order_id, store_id, revenue where (order_id % 2) = 0;
@@ -72,7 +74,9 @@ def test_rowset_with_aggregation(test_environment: Environment, test_executor: E
 
     for count in [
         test_environment.concepts["local.even_order_count"],
-        [x for x in statements[-1].output_components if x.name == "even_order_count"][0],
+        [x for x in statements[-1].output_components if x.name == "even_order_count"][
+            0
+        ],
     ]:
         assert count.derivation == PurposeLineage.AGGREGATE
         assert count.purpose == Purpose.METRIC
@@ -105,7 +109,9 @@ def test_in_select(test_environment: Environment, test_executor: Executor):
     _, statements = parse(test_select, test_environment)
 
     select: SelectStatement = statements[-1]
-    assert select.where_clause.conditional.existence_arguments, str(select.where_clause.conditional.__class__) + str(select.where_clause.conditional)
+    assert select.where_clause.conditional.existence_arguments, str(
+        select.where_clause.conditional.__class__
+    ) + str(select.where_clause.conditional)
     assert select.where_clause.existence_arguments
 
     results = list(test_executor.execute_text(test_select)[0].fetchall())

--- a/tests/modeling/test_complex.py
+++ b/tests/modeling/test_complex.py
@@ -1,10 +1,9 @@
-from trilogy.core.models import Environment, SelectStatement
-from trilogy import parse, Executor, Dialects
+from trilogy import Dialects, Executor, parse
 from trilogy.core.enums import Purpose, PurposeLineage
+from trilogy.core.models import Environment, LooseConceptList, SelectStatement
 from trilogy.core.processing.node_generators.common import (
     resolve_function_parent_concepts,
 )
-from trilogy.core.models import LooseConceptList
 
 
 def test_rowset(test_environment: Environment, test_executor: Executor):
@@ -44,9 +43,7 @@ def test_rowset_with_addition(test_environment: Environment, test_executor: Exec
     assert results[3] == (4, 4, 2)
 
 
-def test_rowset_with_aggregation(
-    test_environment: Environment, test_executor: Executor
-):
+def test_rowset_with_aggregation(test_environment: Environment, test_executor: Executor):
     test_select = """
 
     rowset even_orders <- select order_id, store_id, revenue where (order_id % 2) = 0;
@@ -75,11 +72,8 @@ def test_rowset_with_aggregation(
 
     for count in [
         test_environment.concepts["local.even_order_count"],
-        [x for x in statements[-1].output_components if x.name == "even_order_count"][
-            0
-        ],
+        [x for x in statements[-1].output_components if x.name == "even_order_count"][0],
     ]:
-
         assert count.derivation == PurposeLineage.AGGREGATE
         assert count.purpose == Purpose.METRIC
         count_grain_lcl = LooseConceptList(concepts=count.grain.components_copy)
@@ -111,9 +105,7 @@ def test_in_select(test_environment: Environment, test_executor: Executor):
     _, statements = parse(test_select, test_environment)
 
     select: SelectStatement = statements[-1]
-    assert select.where_clause.conditional.existence_arguments, str(
-        select.where_clause.conditional.__class__
-    ) + str(select.where_clause.conditional)
+    assert select.where_clause.conditional.existence_arguments, str(select.where_clause.conditional.__class__) + str(select.where_clause.conditional)
     assert select.where_clause.existence_arguments
 
     results = list(test_executor.execute_text(test_select)[0].fetchall())
@@ -162,7 +154,6 @@ def test_window_alt(test_environment: Environment, test_executor: Executor):
 
 
 def test_maps():
-
     test_executor = Dialects.DUCK_DB.default_executor()
     test_select = """
     const num_map <- {1: 10, 2: 20};
@@ -177,7 +168,6 @@ def test_maps():
 
 
 def test_anon_agg():
-
     test_executor = Dialects.DUCK_DB.default_executor()
     test_select = """
     auto nums <- [1,2];

--- a/tests/modeling/test_core_concepts.py
+++ b/tests/modeling/test_core_concepts.py
@@ -1,9 +1,10 @@
-from trilogy.core.models import Environment
-from trilogy.core.enums import Purpose
-from trilogy import parse, Executor
-from trilogy.core.processing.node_generators import gen_select_node
-from trilogy.core.env_processor import generate_graph
 import pytest
+
+from trilogy import Executor, parse
+from trilogy.core.enums import Purpose
+from trilogy.core.env_processor import generate_graph
+from trilogy.core.models import Environment
+from trilogy.core.processing.node_generators import gen_select_node
 
 
 def test_key_assignments(test_environment: Environment):
@@ -46,12 +47,8 @@ def test_auto_property_assignments(test_environment: Environment):
 
     for candidate in [store_name, upper_store_name, upper_store_name_2]:
         assert candidate.purpose == Purpose.PROPERTY
-        assert candidate.keys == (
-            store_id,
-        ), f"keys for {candidate.address}: {candidate.keys} should be store_id"
-        assert {x.address for x in candidate.grain.components} == set(
-            [store_id.address]
-        ), f"grain for {candidate.address}: {candidate.keys} should be store_id"
+        assert candidate.keys == (store_id,), f"keys for {candidate.address}: {candidate.keys} should be store_id"
+        assert {x.address for x in candidate.grain.components} == set([store_id.address]), f"grain for {candidate.address}: {candidate.keys} should be store_id"
 
 
 def test_metric_assignments(test_environment: Environment):
@@ -165,9 +162,7 @@ SELECT
 ;"""
     _, statements = parse(test_select, test_environment)
     statement = statements[-1]
-    assert set([x.address for x in statement.grain.components]) == {
-        "local.even_order_id"
-    }
+    assert set([x.address for x in statement.grain.components]) == {"local.even_order_id"}
 
     results = list(test_executor.execute_text(test_select)[0].fetchall())
     assert len(results) == 2
@@ -202,9 +197,7 @@ def test_filter_grain_different(test_environment: Environment, test_executor: Ex
     assert len(results) == 5
 
 
-def test_inline_source_derivation(
-    test_environment: Environment, test_executor: Executor
-):
+def test_inline_source_derivation(test_environment: Environment, test_executor: Executor):
     test_select = """
 
     SELECT

--- a/tests/modeling/test_core_concepts.py
+++ b/tests/modeling/test_core_concepts.py
@@ -47,8 +47,12 @@ def test_auto_property_assignments(test_environment: Environment):
 
     for candidate in [store_name, upper_store_name, upper_store_name_2]:
         assert candidate.purpose == Purpose.PROPERTY
-        assert candidate.keys == (store_id,), f"keys for {candidate.address}: {candidate.keys} should be store_id"
-        assert {x.address for x in candidate.grain.components} == set([store_id.address]), f"grain for {candidate.address}: {candidate.keys} should be store_id"
+        assert candidate.keys == (
+            store_id,
+        ), f"keys for {candidate.address}: {candidate.keys} should be store_id"
+        assert {x.address for x in candidate.grain.components} == set(
+            [store_id.address]
+        ), f"grain for {candidate.address}: {candidate.keys} should be store_id"
 
 
 def test_metric_assignments(test_environment: Environment):
@@ -162,7 +166,9 @@ SELECT
 ;"""
     _, statements = parse(test_select, test_environment)
     statement = statements[-1]
-    assert set([x.address for x in statement.grain.components]) == {"local.even_order_id"}
+    assert set([x.address for x in statement.grain.components]) == {
+        "local.even_order_id"
+    }
 
     results = list(test_executor.execute_text(test_select)[0].fetchall())
     assert len(results) == 2
@@ -197,7 +203,9 @@ def test_filter_grain_different(test_environment: Environment, test_executor: Ex
     assert len(results) == 5
 
 
-def test_inline_source_derivation(test_environment: Environment, test_executor: Executor):
+def test_inline_source_derivation(
+    test_environment: Environment, test_executor: Executor
+):
     test_select = """
 
     SELECT

--- a/tests/modeling/test_merge_discovery.py
+++ b/tests/modeling/test_merge_discovery.py
@@ -1,6 +1,5 @@
+from trilogy import Dialects, Executor
 from trilogy.core.models import Environment
-from trilogy import Executor
-from trilogy import Dialects
 from trilogy.hooks.query_debugger import DebuggingHook
 
 

--- a/tests/modeling/test_nullability.py
+++ b/tests/modeling/test_nullability.py
@@ -1,5 +1,5 @@
-from trilogy.core.models import Environment
 from trilogy import Executor
+from trilogy.core.models import Environment
 
 
 def test_statement_grains(test_environment: Environment, test_executor: Executor):

--- a/tests/modeling/tpc_ds/test_queries.py
+++ b/tests/modeling/tpc_ds/test_queries.py
@@ -1,7 +1,6 @@
-from trilogy import parse
 from pathlib import Path
 
-from trilogy import Environment, Dialects
+from trilogy import Dialects, Environment, parse
 from trilogy.hooks.query_debugger import DebuggingHook
 
 working_path = Path(__file__).parent
@@ -13,9 +12,7 @@ def test_one():
     with open(test) as f:
         text = f.read()
         env, queries = parse(text, env)
-    exec = Dialects.DUCK_DB.default_executor(
-        environment=env, hooks=[DebuggingHook(process_other=False, process_ctes=False)]
-    )
+    exec = Dialects.DUCK_DB.default_executor(environment=env, hooks=[DebuggingHook(process_other=False, process_ctes=False)])
 
     env, queries = parse("""import store_returns as returns;""", env)
 
@@ -35,16 +32,7 @@ def test_one():
     assert found
     assert env.concepts["returns.return_date.year"].address in env.materialized_concepts
     assert len(env.datasources["returns.store_returns"].concepts) == 7
-    assert (
-        len(
-            list(
-                set(
-                    x.address for x in env.datasources["returns.store_returns"].concepts
-                )
-            )
-        )
-        == 7
-    )
+    assert len(list(set(x.address for x in env.datasources["returns.store_returns"].concepts))) == 7
 
     sql = exec.generate_sql(
         """import customer as customer;
@@ -87,9 +75,7 @@ def test_three():
     select = queries[-1]
 
     # g = generate_graph(env)
-    exec = Dialects.DUCK_DB.default_executor(
-        environment=env, hooks=[DebuggingHook(process_other=False, process_ctes=False)]
-    )
+    exec = Dialects.DUCK_DB.default_executor(environment=env, hooks=[DebuggingHook(process_other=False, process_ctes=False)])
     sql = exec.generate_sql(select)
     assert "SELECT" in sql[-1]
     # assert sql[0] == '123'
@@ -104,9 +90,7 @@ def test_three_alt():
     select = queries[-1]
 
     # g = generate_graph(env)
-    exec = Dialects.DUCK_DB.default_executor(
-        environment=env, hooks=[DebuggingHook(process_other=False, process_ctes=False)]
-    )
+    exec = Dialects.DUCK_DB.default_executor(environment=env, hooks=[DebuggingHook(process_other=False, process_ctes=False)])
     sql = exec.generate_sql(select)
     assert "SELECT" in sql[-1]
     # assert sql[0] == '123'

--- a/tests/modeling/tpc_ds/test_queries.py
+++ b/tests/modeling/tpc_ds/test_queries.py
@@ -12,7 +12,9 @@ def test_one():
     with open(test) as f:
         text = f.read()
         env, queries = parse(text, env)
-    exec = Dialects.DUCK_DB.default_executor(environment=env, hooks=[DebuggingHook(process_other=False, process_ctes=False)])
+    exec = Dialects.DUCK_DB.default_executor(
+        environment=env, hooks=[DebuggingHook(process_other=False, process_ctes=False)]
+    )
 
     env, queries = parse("""import store_returns as returns;""", env)
 
@@ -32,7 +34,16 @@ def test_one():
     assert found
     assert env.concepts["returns.return_date.year"].address in env.materialized_concepts
     assert len(env.datasources["returns.store_returns"].concepts) == 7
-    assert len(list(set(x.address for x in env.datasources["returns.store_returns"].concepts))) == 7
+    assert (
+        len(
+            list(
+                set(
+                    x.address for x in env.datasources["returns.store_returns"].concepts
+                )
+            )
+        )
+        == 7
+    )
 
     sql = exec.generate_sql(
         """import customer as customer;
@@ -75,7 +86,9 @@ def test_three():
     select = queries[-1]
 
     # g = generate_graph(env)
-    exec = Dialects.DUCK_DB.default_executor(environment=env, hooks=[DebuggingHook(process_other=False, process_ctes=False)])
+    exec = Dialects.DUCK_DB.default_executor(
+        environment=env, hooks=[DebuggingHook(process_other=False, process_ctes=False)]
+    )
     sql = exec.generate_sql(select)
     assert "SELECT" in sql[-1]
     # assert sql[0] == '123'
@@ -90,7 +103,9 @@ def test_three_alt():
     select = queries[-1]
 
     # g = generate_graph(env)
-    exec = Dialects.DUCK_DB.default_executor(environment=env, hooks=[DebuggingHook(process_other=False, process_ctes=False)])
+    exec = Dialects.DUCK_DB.default_executor(
+        environment=env, hooks=[DebuggingHook(process_other=False, process_ctes=False)]
+    )
     sql = exec.generate_sql(select)
     assert "SELECT" in sql[-1]
     # assert sql[0] == '123'

--- a/tests/modeling/tpc_ds_duckdb/README.md
+++ b/tests/modeling/tpc_ds_duckdb/README.md
@@ -1,0 +1,16 @@
+
+
+### New Test Case
+
+Go [here](https://github.com/duckdb/duckdb/tree/main/extension/tpcds/dsdgen/queries).
+
+Copy SQL to query.sql.
+
+Use that to create query.preql.
+
+You may need to expand the .preql input models.
+
+While iterating, if the first row is a mismatch, you're generally pretty far off.
+
+If a later row is a mismatch, some common error patterns are:
+- implicit null dropping on joins [trilogy will join on field and null matching] - explicitly filter out nulls if needed

--- a/tests/modeling/tpc_ds_duckdb/analyze_test_results.py
+++ b/tests/modeling/tpc_ds_duckdb/analyze_test_results.py
@@ -1,10 +1,11 @@
-from pathlib import Path
-import os
-import pandas as pd
 import json
-import matplotlib.pyplot as plt
-import tomllib
+import os
 from os import environ
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import tomllib
 
 # https://github.com/python/cpython/issues/125235#issuecomment-2412948604
 if not environ.get("TCL_LIBRARY"):
@@ -12,7 +13,6 @@ if not environ.get("TCL_LIBRARY"):
 
 
 def analyze(show: bool = False):
-
     results = []
     root = Path(__file__).parent
     for filename in os.listdir(root):
@@ -40,9 +40,7 @@ def analyze(show: bool = False):
 
     df = df.sort_values("query_id")
 
-    ax.boxplot(
-        [df["exec_time"], df["comp_time"]], tick_labels=["Trilogy", "DuckDBDefault"]
-    )
+    ax.boxplot([df["exec_time"], df["comp_time"]], tick_labels=["Trilogy", "DuckDBDefault"])
     if show:
         plt.show()
     else:

--- a/tests/modeling/tpc_ds_duckdb/analyze_test_results.py
+++ b/tests/modeling/tpc_ds_duckdb/analyze_test_results.py
@@ -40,7 +40,9 @@ def analyze(show: bool = False):
 
     df = df.sort_values("query_id")
 
-    ax.boxplot([df["exec_time"], df["comp_time"]], tick_labels=["Trilogy", "DuckDBDefault"])
+    ax.boxplot(
+        [df["exec_time"], df["comp_time"]], tick_labels=["Trilogy", "DuckDBDefault"]
+    )
     if show:
         plt.show()
     else:

--- a/tests/modeling/tpc_ds_duckdb/conftest.py
+++ b/tests/modeling/tpc_ds_duckdb/conftest.py
@@ -1,10 +1,12 @@
+from logging import INFO
+from pathlib import Path
+
+import pytest
+
+from tests.modeling.tpc_ds_duckdb.analyze_test_results import analyze
 from trilogy import Dialects, Environment, Executor
 from trilogy.dialect.config import DuckDBConfig
-import pytest
 from trilogy.hooks.query_debugger import DebuggingHook
-from pathlib import Path
-from logging import INFO
-from tests.modeling.tpc_ds_duckdb.analyze_test_results import analyze
 
 working_path = Path(__file__).parent
 

--- a/tests/modeling/tpc_ds_duckdb/test_non_benchmark_queries.py
+++ b/tests/modeling/tpc_ds_duckdb/test_non_benchmark_queries.py
@@ -1,6 +1,7 @@
-from trilogy.core.models import Environment
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
+
+from trilogy.core.models import Environment
 
 working_path = Path(__file__).parent
 

--- a/tests/modeling/tpc_ds_duckdb/test_queries.py
+++ b/tests/modeling/tpc_ds_duckdb/test_queries.py
@@ -37,9 +37,13 @@ def run_query(engine: Executor, idx: int, sql_override: bool = False):
 
     # # check we got it
     if len(base_results) != len(comp_results):
-        assert False, f"Row count mismatch: expected {len(base_results)}, got {len(comp_results)}"
+        assert (
+            False
+        ), f"Row count mismatch: expected {len(base_results)}, got {len(comp_results)}"
     for qidx, row in enumerate(base_results):
-        assert row == comp_results[qidx], f"Row mismatch in row {qidx} (expected v actual): {row} != {comp_results[qidx]}"
+        assert (
+            row == comp_results[qidx]
+        ), f"Row mismatch in row {qidx} (expected v actual): {row} != {comp_results[qidx]}"
 
     with open(working_path / f"zquery{idx:02d}.log", "w") as f:
         f.write(
@@ -159,7 +163,9 @@ def run_adhoc(number: int, text: str | None = None):
     from trilogy.hooks.query_debugger import DebuggingHook
 
     env = Environment(working_path=Path(__file__).parent)
-    engine: Executor = Dialects.DUCK_DB.default_executor(environment=env, hooks=[DebuggingHook(INFO)])
+    engine: Executor = Dialects.DUCK_DB.default_executor(
+        environment=env, hooks=[DebuggingHook(INFO)]
+    )
     engine.execute_raw_sql(
         """INSTALL tpcds;
 LOAD tpcds;

--- a/tests/modeling/tpc_ds_duckdb/test_queries.py
+++ b/tests/modeling/tpc_ds_duckdb/test_queries.py
@@ -159,8 +159,6 @@ def run_adhoc(number: int, text: str | None = None):
     from trilogy.hooks.query_debugger import DebuggingHook
     from logging import INFO
 
-    from trilogy import Dialects, Environment
-    from trilogy.hooks.query_debugger import DebuggingHook
 
     env = Environment(working_path=Path(__file__).parent)
     engine: Executor = Dialects.DUCK_DB.default_executor(

--- a/tests/modeling/tpc_ds_duckdb/test_queries.py
+++ b/tests/modeling/tpc_ds_duckdb/test_queries.py
@@ -155,9 +155,10 @@ def test_thirty(engine):
 
 
 def run_adhoc(number: int, text: str | None = None):
-    from trilogy import Environment, Dialects
-    from trilogy.hooks.query_debugger import DebuggingHook
     from logging import INFO
+
+    from trilogy import Dialects, Environment
+    from trilogy.hooks.query_debugger import DebuggingHook
 
 
     env = Environment(working_path=Path(__file__).parent)

--- a/tests/modeling/tpc_ds_duckdb/test_queries.py
+++ b/tests/modeling/tpc_ds_duckdb/test_queries.py
@@ -1,9 +1,10 @@
+from datetime import datetime
 from pathlib import Path
 
-from trilogy import Executor, Environment
 import pytest
-from datetime import datetime
 import tomli_w
+
+from trilogy import Environment, Executor
 
 working_path = Path(__file__).parent
 
@@ -36,13 +37,9 @@ def run_query(engine: Executor, idx: int, sql_override: bool = False):
 
     # # check we got it
     if len(base_results) != len(comp_results):
-        assert (
-            False
-        ), f"Row count mismatch: expected {len(base_results)}, got {len(comp_results)}"
+        assert False, f"Row count mismatch: expected {len(base_results)}, got {len(comp_results)}"
     for qidx, row in enumerate(base_results):
-        assert (
-            row == comp_results[qidx]
-        ), f"Row mismatch in row {qidx} (expected v actual): {row} != {comp_results[qidx]}"
+        assert row == comp_results[qidx], f"Row mismatch in row {qidx} (expected v actual): {row} != {comp_results[qidx]}"
 
     with open(working_path / f"zquery{idx:02d}.log", "w") as f:
         f.write(
@@ -158,10 +155,11 @@ def run_adhoc(number: int, text: str | None = None):
     from trilogy.hooks.query_debugger import DebuggingHook
     from logging import INFO
 
+    from trilogy import Dialects, Environment
+    from trilogy.hooks.query_debugger import DebuggingHook
+
     env = Environment(working_path=Path(__file__).parent)
-    engine: Executor = Dialects.DUCK_DB.default_executor(
-        environment=env, hooks=[DebuggingHook(INFO)]
-    )
+    engine: Executor = Dialects.DUCK_DB.default_executor(environment=env, hooks=[DebuggingHook(INFO)])
     engine.execute_raw_sql(
         """INSTALL tpcds;
 LOAD tpcds;

--- a/tests/modeling/tpc_ds_duckdb/timing_debug.py
+++ b/tests/modeling/tpc_ds_duckdb/timing_debug.py
@@ -1,16 +1,12 @@
+from datetime import datetime
 from pathlib import Path
 
-from trilogy import Environment
-from trilogy import Executor
-from trilogy import Dialects
-from datetime import datetime
-
+from trilogy import Dialects, Environment, Executor
 
 working_path = Path(__file__).parent
 
 
 def run_query(engine: Executor, start, idx: int):
-
     with open(working_path / f"query{idx:02d}.preql") as f:
         text = f.read()
 
@@ -33,9 +29,7 @@ def run_query(engine: Executor, start, idx: int):
 
 
 if __name__ == "__main__":
-    engine = Dialects.DUCK_DB.default_executor(
-        environment=Environment(working_path=working_path), hooks=[]
-    )
+    engine = Dialects.DUCK_DB.default_executor(environment=Environment(working_path=working_path), hooks=[])
     # TODO: Detect if loaded
     start = datetime.now()
     #     engine.execute_raw_sql('''

--- a/tests/modeling/tpc_ds_duckdb/timing_debug.py
+++ b/tests/modeling/tpc_ds_duckdb/timing_debug.py
@@ -29,7 +29,9 @@ def run_query(engine: Executor, start, idx: int):
 
 
 if __name__ == "__main__":
-    engine = Dialects.DUCK_DB.default_executor(environment=Environment(working_path=working_path), hooks=[])
+    engine = Dialects.DUCK_DB.default_executor(
+        environment=Environment(working_path=working_path), hooks=[]
+    )
     # TODO: Detect if loaded
     start = datetime.now()
     #     engine.execute_raw_sql('''

--- a/tests/nodes/test_base_node.py
+++ b/tests/nodes/test_base_node.py
@@ -1,13 +1,11 @@
-from trilogy.core.processing.nodes.base_node import StrategyNode, get_all_parent_partial
-from trilogy.core.models import Environment
 from trilogy.core.env_processor import generate_graph
+from trilogy.core.models import Environment
+from trilogy.core.processing.nodes.base_node import StrategyNode, get_all_parent_partial
 
 
 def test_base_node_copy():
     env = Environment()
-    x = StrategyNode(
-        input_concepts=[], output_concepts=[], environment=env, g=generate_graph(env)
-    )
+    x = StrategyNode(input_concepts=[], output_concepts=[], environment=env, g=generate_graph(env))
 
     y = x.copy()
 

--- a/tests/nodes/test_base_node.py
+++ b/tests/nodes/test_base_node.py
@@ -5,7 +5,9 @@ from trilogy.core.processing.nodes.base_node import StrategyNode, get_all_parent
 
 def test_base_node_copy():
     env = Environment()
-    x = StrategyNode(input_concepts=[], output_concepts=[], environment=env, g=generate_graph(env))
+    x = StrategyNode(
+        input_concepts=[], output_concepts=[], environment=env, g=generate_graph(env)
+    )
 
     y = x.copy()
 

--- a/tests/nodes/test_window_node.py
+++ b/tests/nodes/test_window_node.py
@@ -1,13 +1,11 @@
-from trilogy.core.processing.nodes.window_node import WindowNode
-from trilogy.core.models import Environment
 from trilogy.core.env_processor import generate_graph
+from trilogy.core.models import Environment
+from trilogy.core.processing.nodes.window_node import WindowNode
 
 
 def test_window_node_copy():
     env = Environment()
-    x = WindowNode(
-        input_concepts=[], output_concepts=[], environment=env, g=generate_graph(env)
-    )
+    x = WindowNode(input_concepts=[], output_concepts=[], environment=env, g=generate_graph(env))
 
     y = x.copy()
 

--- a/tests/nodes/test_window_node.py
+++ b/tests/nodes/test_window_node.py
@@ -5,7 +5,9 @@ from trilogy.core.processing.nodes.window_node import WindowNode
 
 def test_window_node_copy():
     env = Environment()
-    x = WindowNode(input_concepts=[], output_concepts=[], environment=env, g=generate_graph(env))
+    x = WindowNode(
+        input_concepts=[], output_concepts=[], environment=env, g=generate_graph(env)
+    )
 
     y = x.copy()
 

--- a/tests/nodes/utility/test_joins.py
+++ b/tests/nodes/utility/test_joins.py
@@ -1,7 +1,7 @@
-from trilogy.dialect.common import render_join_concept
-from trilogy.dialect.base import BaseDialect
-from trilogy.core.models import CTE, Grain, QueryDatasource
 from trilogy import parse
+from trilogy.core.models import CTE, Grain, QueryDatasource
+from trilogy.dialect.base import BaseDialect
+from trilogy.dialect.common import render_join_concept
 
 
 def test_render_join_concept():

--- a/tests/nodes/utility/test_nullability.py
+++ b/tests/nodes/utility/test_nullability.py
@@ -1,11 +1,10 @@
-from trilogy.core.processing.utility import find_nullable_concepts
-from trilogy.core.models import QueryDatasource, BaseJoin, Grain, JoinType, ConceptPair
 from trilogy import parse
 from trilogy.core.enums import Modifier
+from trilogy.core.models import BaseJoin, ConceptPair, Grain, JoinType, QueryDatasource
+from trilogy.core.processing.utility import find_nullable_concepts
 
 
 def test_find_nullable_concepts():
-
     env, _ = parse(
         """
 key order_id int;
@@ -77,11 +76,7 @@ select 1 as customer_id
         right_datasource=product_qds,
         join_type=JoinType.LEFT_OUTER,
         concepts=[],
-        concept_pairs=[
-            ConceptPair(
-                left=product_id, right=product_id, existing_datasource=order_qds
-            )
-        ],
+        concept_pairs=[ConceptPair(left=product_id, right=product_id, existing_datasource=order_qds)],
     )
     source_map = {
         order_id.address: {order_qds},
@@ -89,9 +84,7 @@ select 1 as customer_id
         product_name.address: {product_qds},
     }
     assert join.concept_pairs[0].left in join.left_datasource.nullable_concepts
-    nullable = find_nullable_concepts(
-        source_map=source_map, datasources=[order_qds, product_qds], joins=[join]
-    )
+    nullable = find_nullable_concepts(source_map=source_map, datasources=[order_qds, product_qds], joins=[join])
     assert nullable == [product_id.address, product_name.address], nullable
     order_qds
 
@@ -112,9 +105,7 @@ select 1 as customer_id
         },
     )
 
-    nullable = find_nullable_concepts(
-        source_map=source_map, datasources=[order_qds, customer_qds], joins=[]
-    )
+    nullable = find_nullable_concepts(source_map=source_map, datasources=[order_qds, customer_qds], joins=[])
     assert nullable == [product_id.address], nullable
 
 

--- a/tests/nodes/utility/test_nullability.py
+++ b/tests/nodes/utility/test_nullability.py
@@ -76,7 +76,11 @@ select 1 as customer_id
         right_datasource=product_qds,
         join_type=JoinType.LEFT_OUTER,
         concepts=[],
-        concept_pairs=[ConceptPair(left=product_id, right=product_id, existing_datasource=order_qds)],
+        concept_pairs=[
+            ConceptPair(
+                left=product_id, right=product_id, existing_datasource=order_qds
+            )
+        ],
     )
     source_map = {
         order_id.address: {order_qds},
@@ -84,7 +88,9 @@ select 1 as customer_id
         product_name.address: {product_qds},
     }
     assert join.concept_pairs[0].left in join.left_datasource.nullable_concepts
-    nullable = find_nullable_concepts(source_map=source_map, datasources=[order_qds, product_qds], joins=[join])
+    nullable = find_nullable_concepts(
+        source_map=source_map, datasources=[order_qds, product_qds], joins=[join]
+    )
     assert nullable == [product_id.address, product_name.address], nullable
     order_qds
 
@@ -105,7 +111,9 @@ select 1 as customer_id
         },
     )
 
-    nullable = find_nullable_concepts(source_map=source_map, datasources=[order_qds, customer_qds], joins=[])
+    nullable = find_nullable_concepts(
+        source_map=source_map, datasources=[order_qds, customer_qds], joins=[]
+    )
     assert nullable == [product_id.address], nullable
 
 

--- a/tests/optimization/conftest.py
+++ b/tests/optimization/conftest.py
@@ -2,25 +2,25 @@ from pytest import fixture
 
 from trilogy import Environment
 from trilogy.core.enums import (
-    Purpose,
-    FunctionType,
     ComparisonOperator,
+    FunctionType,
+    Purpose,
     WindowType,
 )
 from trilogy.core.env_processor import generate_graph
 from trilogy.core.functions import Count, CountDistinct, Max, Min
 from trilogy.core.models import (
-    Concept,
-    DataType,
-    Datasource,
     ColumnAssignment,
+    Comparison,
+    Concept,
+    Datasource,
+    DataType,
+    FilterItem,
     Function,
     Grain,
-    WindowItem,
-    FilterItem,
     OrderItem,
     WhereClause,
-    Comparison,
+    WindowItem,
 )
 
 
@@ -29,9 +29,7 @@ def test_environment():
     env = Environment()
     order_id = Concept(name="order_id", datatype=DataType.INTEGER, purpose=Purpose.KEY)
 
-    order_timestamp = Concept(
-        name="order_timestamp", datatype=DataType.TIMESTAMP, purpose=Purpose.PROPERTY
-    )
+    order_timestamp = Concept(name="order_timestamp", datatype=DataType.TIMESTAMP, purpose=Purpose.PROPERTY)
 
     order_count = Concept(
         name="order_count",
@@ -80,15 +78,11 @@ def test_environment():
             operator=FunctionType.SUM,
         ),
     )
-    product_id = Concept(
-        name="product_id", datatype=DataType.INTEGER, purpose=Purpose.KEY
-    )
+    product_id = Concept(name="product_id", datatype=DataType.INTEGER, purpose=Purpose.KEY)
 
     assert product_id.grain.components[0].name == "product_id"
 
-    category_id = Concept(
-        name="category_id", datatype=DataType.INTEGER, purpose=Purpose.KEY
-    )
+    category_id = Concept(name="category_id", datatype=DataType.INTEGER, purpose=Purpose.KEY)
     category_name = Concept(
         name="category_name",
         datatype=DataType.STRING,
@@ -131,9 +125,7 @@ def test_environment():
         lineage=WindowItem(
             type=WindowType.RANK,
             content=product_id,
-            order_by=[
-                OrderItem(expr=total_revenue.with_grain(product_id), order="desc")
-            ],
+            order_by=[OrderItem(expr=total_revenue.with_grain(product_id), order="desc")],
         ),
         grain=product_id,
     )

--- a/tests/optimization/conftest.py
+++ b/tests/optimization/conftest.py
@@ -29,7 +29,9 @@ def test_environment():
     env = Environment()
     order_id = Concept(name="order_id", datatype=DataType.INTEGER, purpose=Purpose.KEY)
 
-    order_timestamp = Concept(name="order_timestamp", datatype=DataType.TIMESTAMP, purpose=Purpose.PROPERTY)
+    order_timestamp = Concept(
+        name="order_timestamp", datatype=DataType.TIMESTAMP, purpose=Purpose.PROPERTY
+    )
 
     order_count = Concept(
         name="order_count",
@@ -78,11 +80,15 @@ def test_environment():
             operator=FunctionType.SUM,
         ),
     )
-    product_id = Concept(name="product_id", datatype=DataType.INTEGER, purpose=Purpose.KEY)
+    product_id = Concept(
+        name="product_id", datatype=DataType.INTEGER, purpose=Purpose.KEY
+    )
 
     assert product_id.grain.components[0].name == "product_id"
 
-    category_id = Concept(name="category_id", datatype=DataType.INTEGER, purpose=Purpose.KEY)
+    category_id = Concept(
+        name="category_id", datatype=DataType.INTEGER, purpose=Purpose.KEY
+    )
     category_name = Concept(
         name="category_name",
         datatype=DataType.STRING,
@@ -125,7 +131,9 @@ def test_environment():
         lineage=WindowItem(
             type=WindowType.RANK,
             content=product_id,
-            order_by=[OrderItem(expr=total_revenue.with_grain(product_id), order="desc")],
+            order_by=[
+                OrderItem(expr=total_revenue.with_grain(product_id), order="desc")
+            ],
         ),
         grain=product_id,
     )

--- a/tests/optimization/test_constant_optimization.py
+++ b/tests/optimization/test_constant_optimization.py
@@ -2,7 +2,6 @@ from trilogy import Dialects
 
 
 def test_constant_optimization():
-
     test_query = """
     const x <- 1;
 

--- a/tests/optimization/test_optimization.py
+++ b/tests/optimization/test_optimization.py
@@ -1,3 +1,20 @@
+from trilogy import parse
+from trilogy.core.enums import (
+    BooleanOperator,
+    ComparisonOperator,
+    FunctionType,
+    Purpose,
+)
+from trilogy.core.models import (
+    CTE,
+    Comparison,
+    Conditional,
+    DataType,
+    Environment,
+    Function,
+    Grain,
+    QueryDatasource,
+)
 from trilogy.core.optimization import (
     PredicatePushdown,
     PredicatePushdownRemove,
@@ -6,25 +23,6 @@ from trilogy.core.optimizations.predicate_pushdown import (
     is_child_of,
 )
 from trilogy.core.processing.utility import decompose_condition
-from trilogy.core.models import (
-    CTE,
-    QueryDatasource,
-    Conditional,
-    Environment,
-    Grain,
-    Comparison,
-    Function,
-    DataType,
-)
-
-from trilogy import parse
-
-from trilogy.core.enums import (
-    BooleanOperator,
-    ComparisonOperator,
-    FunctionType,
-    Purpose,
-)
 
 
 def test_is_child_function():
@@ -33,42 +31,12 @@ def test_is_child_function():
         right=Comparison(left=3, right=4, operator=ComparisonOperator.EQ),
         operator=BooleanOperator.AND,
     )
-    assert (
-        is_child_of(
-            Comparison(left=1, right=2, operator=ComparisonOperator.EQ), condition
-        )
-        is True
-    )
-    assert (
-        is_child_of(
-            Comparison(left=3, right=4, operator=ComparisonOperator.EQ), condition
-        )
-        is True
-    )
-    assert (
-        is_child_of(
-            Comparison(left=1, right=2, operator=ComparisonOperator.EQ), condition.left
-        )
-        is True
-    )
-    assert (
-        is_child_of(
-            Comparison(left=3, right=4, operator=ComparisonOperator.EQ), condition.right
-        )
-        is True
-    )
-    assert (
-        is_child_of(
-            Comparison(left=1, right=2, operator=ComparisonOperator.EQ), condition.right
-        )
-        is False
-    )
-    assert (
-        is_child_of(
-            Comparison(left=3, right=4, operator=ComparisonOperator.EQ), condition.left
-        )
-        is False
-    )
+    assert is_child_of(Comparison(left=1, right=2, operator=ComparisonOperator.EQ), condition) is True
+    assert is_child_of(Comparison(left=3, right=4, operator=ComparisonOperator.EQ), condition) is True
+    assert is_child_of(Comparison(left=1, right=2, operator=ComparisonOperator.EQ), condition.left) is True
+    assert is_child_of(Comparison(left=3, right=4, operator=ComparisonOperator.EQ), condition.right) is True
+    assert is_child_of(Comparison(left=1, right=2, operator=ComparisonOperator.EQ), condition.right) is False
+    assert is_child_of(Comparison(left=3, right=4, operator=ComparisonOperator.EQ), condition.left) is False
 
 
 def test_child_of_complex():
@@ -88,9 +56,7 @@ key year int;
                 right=10,
                 operator=ComparisonOperator.GT,
             ),
-            right=Comparison(
-                left=env.concepts["year"], right=2001, operator=ComparisonOperator.EQ
-            ),
+            right=Comparison(left=env.concepts["year"], right=2001, operator=ComparisonOperator.EQ),
             operator=BooleanOperator.AND,
         ),
         right=Comparison(
@@ -156,9 +122,7 @@ def test_basic_pushdown(test_environment: Environment, test_environment_graph):
         ),
         output_columns=[],
         parent_ctes=[parent],
-        condition=Comparison(
-            left=outputs[0], right=outputs[0], operator=ComparisonOperator.EQ
-        ),
+        condition=Comparison(left=outputs[0], right=outputs[0], operator=ComparisonOperator.EQ),
         grain=Grain(),
         source_map=cte_source_map,
         existence_source_map={},
@@ -169,9 +133,7 @@ def test_basic_pushdown(test_environment: Environment, test_environment_graph):
     assert rule.optimize(cte2, inverse_map) is True
     assert rule.optimize(cte2, inverse_map) is False
     assert rule2.optimize(cte2, inverse_map) is True
-    assert (
-        cte2.condition is None
-    ), f"{cte2.condition}, {parent.condition}, {is_child_of(cte2.condition, parent.condition)}"
+    assert cte2.condition is None, f"{cte2.condition}, {parent.condition}, {is_child_of(cte2.condition, parent.condition)}"
 
 
 def test_invalid_pushdown(test_environment: Environment, test_environment_graph):
@@ -221,9 +183,7 @@ def test_invalid_pushdown(test_environment: Environment, test_environment_graph)
         ),
         output_columns=[],
         parent_ctes=[parent],
-        condition=Comparison(
-            left=outputs[0], right=outputs[0], operator=ComparisonOperator.EQ
-        ),
+        condition=Comparison(left=outputs[0], right=outputs[0], operator=ComparisonOperator.EQ),
         grain=Grain(),
         source_map=cte_source_map,
         existence_source_map={},
@@ -237,9 +197,7 @@ def test_invalid_pushdown(test_environment: Environment, test_environment_graph)
     assert cte2.condition is not None
 
 
-def test_invalid_aggregate_pushdown(
-    test_environment: Environment, test_environment_graph
-):
+def test_invalid_aggregate_pushdown(test_environment: Environment, test_environment_graph):
     datasource = list(test_environment.datasources.values())[0]
     outputs = [c.concept for c in datasource.columns]
     cte_source_map = {outputs[0].address: [datasource.name]}
@@ -294,7 +252,6 @@ def test_invalid_aggregate_pushdown(
 
 
 def test_decomposition_pushdown(test_environment: Environment, test_environment_graph):
-
     category_ds = test_environment.datasources["category"]
     products = test_environment.datasources["products"]
     product_id = test_environment.concepts["product_id"]
@@ -358,12 +315,8 @@ def test_decomposition_pushdown(test_environment: Environment, test_environment_
         output_columns=[],
         parent_ctes=[parent1, parent2],
         condition=Conditional(
-            left=Comparison(
-                left=product_id, right=product_id, operator=ComparisonOperator.EQ
-            ),
-            right=Comparison(
-                left=category_name, right=category_name, operator=ComparisonOperator.EQ
-            ),
+            left=Comparison(left=product_id, right=product_id, operator=ComparisonOperator.EQ),
+            right=Comparison(left=category_name, right=category_name, operator=ComparisonOperator.EQ),
             operator=BooleanOperator.AND,
         ),
         grain=Grain(),
@@ -383,20 +336,14 @@ def test_decomposition_pushdown(test_environment: Environment, test_environment_
     assert rule.optimize(cte1, inverse_map) is False
     assert parent1.condition == Conditional(
         left=Comparison(left=product_id, right=1, operator=ComparisonOperator.EQ),
-        right=Comparison(
-            left=product_id, right=product_id, operator=ComparisonOperator.EQ
-        ),
+        right=Comparison(left=product_id, right=product_id, operator=ComparisonOperator.EQ),
         operator=BooleanOperator.AND,
     )
     assert isinstance(parent2.condition, Comparison)
     assert parent2.condition.left == category_name
     assert parent2.condition.right == category_name
     assert parent2.condition.operator == ComparisonOperator.EQ
-    assert str(parent2.condition) == str(
-        Comparison(
-            left=category_name, right=category_name, operator=ComparisonOperator.EQ
-        )
-    )
+    assert str(parent2.condition) == str(Comparison(left=category_name, right=category_name, operator=ComparisonOperator.EQ))
     # we cannot safely remove this condition
     # as not all parents have both
     assert cte1.condition is not None

--- a/tests/optimization/test_optimization.py
+++ b/tests/optimization/test_optimization.py
@@ -31,12 +31,42 @@ def test_is_child_function():
         right=Comparison(left=3, right=4, operator=ComparisonOperator.EQ),
         operator=BooleanOperator.AND,
     )
-    assert is_child_of(Comparison(left=1, right=2, operator=ComparisonOperator.EQ), condition) is True
-    assert is_child_of(Comparison(left=3, right=4, operator=ComparisonOperator.EQ), condition) is True
-    assert is_child_of(Comparison(left=1, right=2, operator=ComparisonOperator.EQ), condition.left) is True
-    assert is_child_of(Comparison(left=3, right=4, operator=ComparisonOperator.EQ), condition.right) is True
-    assert is_child_of(Comparison(left=1, right=2, operator=ComparisonOperator.EQ), condition.right) is False
-    assert is_child_of(Comparison(left=3, right=4, operator=ComparisonOperator.EQ), condition.left) is False
+    assert (
+        is_child_of(
+            Comparison(left=1, right=2, operator=ComparisonOperator.EQ), condition
+        )
+        is True
+    )
+    assert (
+        is_child_of(
+            Comparison(left=3, right=4, operator=ComparisonOperator.EQ), condition
+        )
+        is True
+    )
+    assert (
+        is_child_of(
+            Comparison(left=1, right=2, operator=ComparisonOperator.EQ), condition.left
+        )
+        is True
+    )
+    assert (
+        is_child_of(
+            Comparison(left=3, right=4, operator=ComparisonOperator.EQ), condition.right
+        )
+        is True
+    )
+    assert (
+        is_child_of(
+            Comparison(left=1, right=2, operator=ComparisonOperator.EQ), condition.right
+        )
+        is False
+    )
+    assert (
+        is_child_of(
+            Comparison(left=3, right=4, operator=ComparisonOperator.EQ), condition.left
+        )
+        is False
+    )
 
 
 def test_child_of_complex():
@@ -56,7 +86,9 @@ key year int;
                 right=10,
                 operator=ComparisonOperator.GT,
             ),
-            right=Comparison(left=env.concepts["year"], right=2001, operator=ComparisonOperator.EQ),
+            right=Comparison(
+                left=env.concepts["year"], right=2001, operator=ComparisonOperator.EQ
+            ),
             operator=BooleanOperator.AND,
         ),
         right=Comparison(
@@ -122,7 +154,9 @@ def test_basic_pushdown(test_environment: Environment, test_environment_graph):
         ),
         output_columns=[],
         parent_ctes=[parent],
-        condition=Comparison(left=outputs[0], right=outputs[0], operator=ComparisonOperator.EQ),
+        condition=Comparison(
+            left=outputs[0], right=outputs[0], operator=ComparisonOperator.EQ
+        ),
         grain=Grain(),
         source_map=cte_source_map,
         existence_source_map={},
@@ -133,7 +167,9 @@ def test_basic_pushdown(test_environment: Environment, test_environment_graph):
     assert rule.optimize(cte2, inverse_map) is True
     assert rule.optimize(cte2, inverse_map) is False
     assert rule2.optimize(cte2, inverse_map) is True
-    assert cte2.condition is None, f"{cte2.condition}, {parent.condition}, {is_child_of(cte2.condition, parent.condition)}"
+    assert (
+        cte2.condition is None
+    ), f"{cte2.condition}, {parent.condition}, {is_child_of(cte2.condition, parent.condition)}"
 
 
 def test_invalid_pushdown(test_environment: Environment, test_environment_graph):
@@ -183,7 +219,9 @@ def test_invalid_pushdown(test_environment: Environment, test_environment_graph)
         ),
         output_columns=[],
         parent_ctes=[parent],
-        condition=Comparison(left=outputs[0], right=outputs[0], operator=ComparisonOperator.EQ),
+        condition=Comparison(
+            left=outputs[0], right=outputs[0], operator=ComparisonOperator.EQ
+        ),
         grain=Grain(),
         source_map=cte_source_map,
         existence_source_map={},
@@ -197,7 +235,9 @@ def test_invalid_pushdown(test_environment: Environment, test_environment_graph)
     assert cte2.condition is not None
 
 
-def test_invalid_aggregate_pushdown(test_environment: Environment, test_environment_graph):
+def test_invalid_aggregate_pushdown(
+    test_environment: Environment, test_environment_graph
+):
     datasource = list(test_environment.datasources.values())[0]
     outputs = [c.concept for c in datasource.columns]
     cte_source_map = {outputs[0].address: [datasource.name]}
@@ -315,8 +355,12 @@ def test_decomposition_pushdown(test_environment: Environment, test_environment_
         output_columns=[],
         parent_ctes=[parent1, parent2],
         condition=Conditional(
-            left=Comparison(left=product_id, right=product_id, operator=ComparisonOperator.EQ),
-            right=Comparison(left=category_name, right=category_name, operator=ComparisonOperator.EQ),
+            left=Comparison(
+                left=product_id, right=product_id, operator=ComparisonOperator.EQ
+            ),
+            right=Comparison(
+                left=category_name, right=category_name, operator=ComparisonOperator.EQ
+            ),
             operator=BooleanOperator.AND,
         ),
         grain=Grain(),
@@ -336,14 +380,20 @@ def test_decomposition_pushdown(test_environment: Environment, test_environment_
     assert rule.optimize(cte1, inverse_map) is False
     assert parent1.condition == Conditional(
         left=Comparison(left=product_id, right=1, operator=ComparisonOperator.EQ),
-        right=Comparison(left=product_id, right=product_id, operator=ComparisonOperator.EQ),
+        right=Comparison(
+            left=product_id, right=product_id, operator=ComparisonOperator.EQ
+        ),
         operator=BooleanOperator.AND,
     )
     assert isinstance(parent2.condition, Comparison)
     assert parent2.condition.left == category_name
     assert parent2.condition.right == category_name
     assert parent2.condition.operator == ComparisonOperator.EQ
-    assert str(parent2.condition) == str(Comparison(left=category_name, right=category_name, operator=ComparisonOperator.EQ))
+    assert str(parent2.condition) == str(
+        Comparison(
+            left=category_name, right=category_name, operator=ComparisonOperator.EQ
+        )
+    )
     # we cannot safely remove this condition
     # as not all parents have both
     assert cte1.condition is not None

--- a/tests/optimization/test_pushdown_optimization.py
+++ b/tests/optimization/test_pushdown_optimization.py
@@ -1,31 +1,27 @@
-from trilogy import parse, Dialects
-
 from pathlib import Path
 
+from trilogy import Dialects, parse
 from trilogy.core.enums import Purpose
-from trilogy.core.optimizations.predicate_pushdown import (
-    is_child_of,
-)
 from trilogy.core.models import (
-    Conditional,
+    BooleanOperator,
     Comparison,
     ComparisonOperator,
-    BooleanOperator,
+    Conditional,
     SubselectComparison,
+)
+from trilogy.core.optimizations.predicate_pushdown import (
+    is_child_of,
 )
 from trilogy.core.processing.utility import decompose_condition
 
 
 def test_pushdown():
-
     with open(Path(__file__).parent / "pushdown.preql") as f:
         text = f.read()
 
     env, queries = parse(text)
 
-    generated = Dialects.DUCK_DB.default_executor(environment=env).generate_sql(
-        queries[-1]
-    )[0]
+    generated = Dialects.DUCK_DB.default_executor(environment=env).generate_sql(queries[-1])[0]
 
     print(generated)
     test_str = """ = '2024-01-01' """.strip()
@@ -55,17 +51,13 @@ def test_child_of():
     env, queries = parse(text)
 
     test = Conditional(
-        left=SubselectComparison(
-            left=env.concepts["uuid"], right="a", operator=ComparisonOperator.EQ
-        ),
+        left=SubselectComparison(left=env.concepts["uuid"], right="a", operator=ComparisonOperator.EQ),
         right=Comparison(left=3, right=4, operator=ComparisonOperator.EQ),
         operator=BooleanOperator.AND,
     )
 
     test2 = Conditional(
-        left=SubselectComparison(
-            left=env.concepts["uuid"], right="a", operator=ComparisonOperator.EQ
-        ),
+        left=SubselectComparison(left=env.concepts["uuid"], right="a", operator=ComparisonOperator.EQ),
         right=Comparison(left=3, right=4, operator=ComparisonOperator.EQ),
         operator=BooleanOperator.AND,
     )

--- a/tests/optimization/test_pushdown_optimization.py
+++ b/tests/optimization/test_pushdown_optimization.py
@@ -21,7 +21,9 @@ def test_pushdown():
 
     env, queries = parse(text)
 
-    generated = Dialects.DUCK_DB.default_executor(environment=env).generate_sql(queries[-1])[0]
+    generated = Dialects.DUCK_DB.default_executor(environment=env).generate_sql(
+        queries[-1]
+    )[0]
 
     print(generated)
     test_str = """ = '2024-01-01' """.strip()
@@ -51,13 +53,17 @@ def test_child_of():
     env, queries = parse(text)
 
     test = Conditional(
-        left=SubselectComparison(left=env.concepts["uuid"], right="a", operator=ComparisonOperator.EQ),
+        left=SubselectComparison(
+            left=env.concepts["uuid"], right="a", operator=ComparisonOperator.EQ
+        ),
         right=Comparison(left=3, right=4, operator=ComparisonOperator.EQ),
         operator=BooleanOperator.AND,
     )
 
     test2 = Conditional(
-        left=SubselectComparison(left=env.concepts["uuid"], right="a", operator=ComparisonOperator.EQ),
+        left=SubselectComparison(
+            left=env.concepts["uuid"], right="a", operator=ComparisonOperator.EQ
+        ),
         right=Comparison(left=3, right=4, operator=ComparisonOperator.EQ),
         operator=BooleanOperator.AND,
     )

--- a/tests/persistence/test_basic_persistence.py
+++ b/tests/persistence/test_basic_persistence.py
@@ -88,7 +88,9 @@ def test_derivations():
         persist: PersistStatement = parsed[-2]
         select: SelectStatement = parsed[-1]
         assert persist.select.grain == Grain(components=[test_concept])
-        assert select.output_components == [test_concept.with_grain(Grain(components=[test_concept]))]
+        assert select.output_components == [
+            test_concept.with_grain(Grain(components=[test_concept]))
+        ]
         assert len(compiled) == 2
 
         g = generate_graph(env)
@@ -114,7 +116,9 @@ def test_derivations():
         assert "CASE" not in compiled[-1]
 
         assert test_concept.purpose == Purpose.PROPERTY
-        assert env.datasources["bool_is_upper_name"].grain == Grain(components=[test_concept])
+        assert env.datasources["bool_is_upper_name"].grain == Grain(
+            components=[test_concept]
+        )
 
         # test that we can resolve a select
         test = SelectNode(

--- a/tests/persistence/test_basic_persistence.py
+++ b/tests/persistence/test_basic_persistence.py
@@ -1,31 +1,30 @@
 # from trilogy.compiler import compile
-from trilogy.core.enums import Purpose
+import networkx as nx
+
+from trilogy.core.enums import ConceptSource, Purpose, PurposeLineage
+from trilogy.core.env_processor import (
+    concept_to_node,
+    datasource_to_node,
+    generate_graph,
+)
 from trilogy.core.models import (
     Grain,
+    PersistStatement,
     ProcessedQueryPersist,
     SelectStatement,
-    PersistStatement,
 )
+from trilogy.core.processing.node_generators import (
+    gen_select_node,
+)
+from trilogy.core.processing.nodes.select_node_v2 import SelectNode
 from trilogy.core.query_processor import process_auto
 from trilogy.dialect.base import BaseDialect
 from trilogy.dialect.bigquery import BigqueryDialect
 from trilogy.dialect.duckdb import DuckDBDialect
-from trilogy.dialect.sql_server import SqlServerDialect
 from trilogy.dialect.snowflake import SnowflakeDialect
-from trilogy.core.enums import PurposeLineage, ConceptSource
-from trilogy.parser import parse
-from trilogy.core.processing.nodes.select_node_v2 import SelectNode
-from trilogy.core.processing.node_generators import (
-    gen_select_node,
-)
-from trilogy.core.env_processor import (
-    generate_graph,
-    datasource_to_node,
-    concept_to_node,
-)
+from trilogy.dialect.sql_server import SqlServerDialect
 from trilogy.hooks.query_debugger import DebuggingHook
-
-import networkx as nx
+from trilogy.parser import parse
 
 TEST_DIALECTS: list[BaseDialect] = [
     BaseDialect(),
@@ -89,9 +88,7 @@ def test_derivations():
         persist: PersistStatement = parsed[-2]
         select: SelectStatement = parsed[-1]
         assert persist.select.grain == Grain(components=[test_concept])
-        assert select.output_components == [
-            test_concept.with_grain(Grain(components=[test_concept]))
-        ]
+        assert select.output_components == [test_concept.with_grain(Grain(components=[test_concept]))]
         assert len(compiled) == 2
 
         g = generate_graph(env)
@@ -117,9 +114,7 @@ def test_derivations():
         assert "CASE" not in compiled[-1]
 
         assert test_concept.purpose == Purpose.PROPERTY
-        assert env.datasources["bool_is_upper_name"].grain == Grain(
-            components=[test_concept]
-        )
+        assert env.datasources["bool_is_upper_name"].grain == Grain(components=[test_concept])
 
         # test that we can resolve a select
         test = SelectNode(

--- a/tests/persistence/test_complex_persistence.py
+++ b/tests/persistence/test_complex_persistence.py
@@ -41,7 +41,9 @@ def test_complex():
 
 
 def test_persist_in_import():
-    env = Environment(working_path=Path(__file__).parent)  # .parse_file(Path(__file__).parent / "query_one.preql")
+    env = Environment(
+        working_path=Path(__file__).parent
+    )  # .parse_file(Path(__file__).parent / "query_one.preql")
     engine = Dialects.DUCK_DB.default_executor(environment=env)
 
     results = engine.execute_file(Path(__file__).parent / "query_one.preql")

--- a/tests/persistence/test_complex_persistence.py
+++ b/tests/persistence/test_complex_persistence.py
@@ -1,5 +1,6 @@
-from trilogy import Environment, Dialects
 from pathlib import Path
+
+from trilogy import Dialects, Environment
 from trilogy.hooks.query_debugger import DebuggingHook
 
 
@@ -40,9 +41,7 @@ def test_complex():
 
 
 def test_persist_in_import():
-    env = Environment(
-        working_path=Path(__file__).parent
-    )  # .parse_file(Path(__file__).parent / "query_one.preql")
+    env = Environment(working_path=Path(__file__).parent)  # .parse_file(Path(__file__).parent / "query_one.preql")
     engine = Dialects.DUCK_DB.default_executor(environment=env)
 
     results = engine.execute_file(Path(__file__).parent / "query_one.preql")

--- a/tests/profiling/conftest.py
+++ b/tests/profiling/conftest.py
@@ -1,9 +1,11 @@
+from logging import INFO
+from pathlib import Path
+
+import pytest
+
 from trilogy import Dialects, Environment, Executor
 from trilogy.dialect.config import DuckDBConfig
-import pytest
 from trilogy.hooks.query_debugger import DebuggingHook
-from pathlib import Path
-from logging import INFO
 
 working_path = Path(__file__).parent
 

--- a/tests/profiling/perftest.py
+++ b/tests/profiling/perftest.py
@@ -1,10 +1,10 @@
 from cProfile import Profile
-from pstats import SortKey, Stats
-from trilogy import Environment
-from pathlib import Path
-from trilogy.parsing.parse_engine import parse_text, parse_text_raw
-
 from datetime import datetime
+from pathlib import Path
+from pstats import SortKey, Stats
+
+from trilogy import Environment
+from trilogy.parsing.parse_engine import parse_text, parse_text_raw
 
 
 def parsetest():

--- a/tests/profiling/perftestcompile.py
+++ b/tests/profiling/perftestcompile.py
@@ -1,46 +1,42 @@
 from cProfile import Profile
 from pstats import SortKey, Stats
-from trilogy.core.models import SelectStatement
-from trilogy import parse
+
+from trilogy import Environment, parse
+from trilogy.core.enums import (
+    ComparisonOperator,
+    FunctionType,
+    Purpose,
+    WindowType,
+)
+from trilogy.core.functions import Count, CountDistinct, Max, Min
 
 # from trilogy.compiler import compile
-
-from trilogy.core.models import DataType
+from trilogy.core.models import (
+    ColumnAssignment,
+    Comparison,
+    Concept,
+    Datasource,
+    DataType,
+    FilterItem,
+    Function,
+    Grain,
+    OrderItem,
+    SelectStatement,
+    WhereClause,
+    WindowItem,
+)
 from trilogy.core.query_processor import process_query
 from trilogy.dialect.base import BaseDialect
 from trilogy.dialect.bigquery import BigqueryDialect
 from trilogy.dialect.duckdb import DuckDBDialect
 from trilogy.dialect.sql_server import SqlServerDialect
 
-from trilogy import Environment
-from trilogy.core.enums import (
-    Purpose,
-    FunctionType,
-    ComparisonOperator,
-    WindowType,
-)
-from trilogy.core.functions import Count, CountDistinct, Max, Min
-from trilogy.core.models import (
-    Concept,
-    Datasource,
-    ColumnAssignment,
-    Function,
-    Grain,
-    WindowItem,
-    FilterItem,
-    OrderItem,
-    WhereClause,
-    Comparison,
-)
-
 
 def gen_environment():
     env = Environment()
     order_id = Concept(name="order_id", datatype=DataType.INTEGER, purpose=Purpose.KEY)
 
-    order_timestamp = Concept(
-        name="order_timestamp", datatype=DataType.TIMESTAMP, purpose=Purpose.PROPERTY
-    )
+    order_timestamp = Concept(name="order_timestamp", datatype=DataType.TIMESTAMP, purpose=Purpose.PROPERTY)
 
     order_count = Concept(
         name="order_count",
@@ -83,15 +79,11 @@ def gen_environment():
             operator=FunctionType.SUM,
         ),
     )
-    product_id = Concept(
-        name="product_id", datatype=DataType.INTEGER, purpose=Purpose.KEY
-    )
+    product_id = Concept(name="product_id", datatype=DataType.INTEGER, purpose=Purpose.KEY)
 
     assert product_id.grain.components[0].name == "product_id"
 
-    category_id = Concept(
-        name="category_id", datatype=DataType.INTEGER, purpose=Purpose.KEY
-    )
+    category_id = Concept(name="category_id", datatype=DataType.INTEGER, purpose=Purpose.KEY)
     category_name = Concept(
         name="category_name",
         datatype=DataType.STRING,
@@ -133,9 +125,7 @@ def gen_environment():
         lineage=WindowItem(
             type=WindowType.RANK,
             content=product_id,
-            order_by=[
-                OrderItem(expr=total_revenue.with_grain(product_id), order="desc")
-            ],
+            order_by=[OrderItem(expr=total_revenue.with_grain(product_id), order="desc")],
         ),
         grain=product_id,
     )

--- a/tests/profiling/perftestcompile.py
+++ b/tests/profiling/perftestcompile.py
@@ -36,7 +36,9 @@ def gen_environment():
     env = Environment()
     order_id = Concept(name="order_id", datatype=DataType.INTEGER, purpose=Purpose.KEY)
 
-    order_timestamp = Concept(name="order_timestamp", datatype=DataType.TIMESTAMP, purpose=Purpose.PROPERTY)
+    order_timestamp = Concept(
+        name="order_timestamp", datatype=DataType.TIMESTAMP, purpose=Purpose.PROPERTY
+    )
 
     order_count = Concept(
         name="order_count",
@@ -79,11 +81,15 @@ def gen_environment():
             operator=FunctionType.SUM,
         ),
     )
-    product_id = Concept(name="product_id", datatype=DataType.INTEGER, purpose=Purpose.KEY)
+    product_id = Concept(
+        name="product_id", datatype=DataType.INTEGER, purpose=Purpose.KEY
+    )
 
     assert product_id.grain.components[0].name == "product_id"
 
-    category_id = Concept(name="category_id", datatype=DataType.INTEGER, purpose=Purpose.KEY)
+    category_id = Concept(
+        name="category_id", datatype=DataType.INTEGER, purpose=Purpose.KEY
+    )
     category_name = Concept(
         name="category_name",
         datatype=DataType.STRING,
@@ -125,7 +131,9 @@ def gen_environment():
         lineage=WindowItem(
             type=WindowType.RANK,
             content=product_id,
-            order_by=[OrderItem(expr=total_revenue.with_grain(product_id), order="desc")],
+            order_by=[
+                OrderItem(expr=total_revenue.with_grain(product_id), order="desc")
+            ],
         ),
         grain=product_id,
     )

--- a/tests/rendering/test_ergonomics.py
+++ b/tests/rendering/test_ergonomics.py
@@ -1,5 +1,5 @@
-from trilogy.core.query_processor import generate_cte_name
 from trilogy.constants import CONFIG
+from trilogy.core.query_processor import generate_cte_name
 
 
 def test_generate_cte_name():

--- a/tests/rendering/test_rendering.py
+++ b/tests/rendering/test_rendering.py
@@ -108,7 +108,13 @@ def test_multi_select(test_environment):
                 where_clause=None,
             ),
         ],
-        align=AlignClause(items=[AlignItem(alias="merge", concepts=[test_environment.concepts["order_id"]])]),
+        align=AlignClause(
+            items=[
+                AlignItem(
+                    alias="merge", concepts=[test_environment.concepts["order_id"]]
+                )
+            ]
+        ),
         order_by=OrderBy(
             items=[
                 OrderItem(
@@ -216,18 +222,26 @@ ORDER BY
 
 
 def test_render_select_item(test_environment: Environment):
-    test = Renderer().to_string(SelectItem(content=test_environment.concepts["order_id"], modifiers=[Modifier.HIDDEN]))
+    test = Renderer().to_string(
+        SelectItem(
+            content=test_environment.concepts["order_id"], modifiers=[Modifier.HIDDEN]
+        )
+    )
 
     assert test == "--order_id"
 
 
 def test_render_concept_declaration(test_environment: Environment):
-    test = Renderer().to_string(ConceptDeclarationStatement(concept=test_environment.concepts["order_id"]))
+    test = Renderer().to_string(
+        ConceptDeclarationStatement(concept=test_environment.concepts["order_id"])
+    )
 
     assert test == "key order_id int;"
     env_two = Environment(namespace="test")
     env_two.parse("""key order_id int;""")
-    test = Renderer().to_string(ConceptDeclarationStatement(concept=env_two.concepts["test.order_id"]))
+    test = Renderer().to_string(
+        ConceptDeclarationStatement(concept=env_two.concepts["test.order_id"])
+    )
 
     assert test == "key test.order_id int;"
 
@@ -264,7 +278,11 @@ def test_render_rowset(test_environment: Environment):
             ]
         ),
     )
-    test = Renderer().to_string(RowsetDerivationStatement(select=query, name="test", namespace=DEFAULT_NAMESPACE))
+    test = Renderer().to_string(
+        RowsetDerivationStatement(
+            select=query, name="test", namespace=DEFAULT_NAMESPACE
+        )
+    )
 
     assert (
         test
@@ -511,17 +529,23 @@ def test_render_index_access():
 
 def test_render_import():
     base = Path("/path/to/file.preql")
-    test = Renderer().to_string(ImportStatement(alias="user_id", path=str(PureWindowsPath(base))))
+    test = Renderer().to_string(
+        ImportStatement(alias="user_id", path=str(PureWindowsPath(base)))
+    )
 
     assert test == "import path.to.file as user_id;"
 
     base = Path("/path/to/file.preql")
-    test = Renderer().to_string(ImportStatement(alias="user_id", path=str(PurePosixPath(base))))
+    test = Renderer().to_string(
+        ImportStatement(alias="user_id", path=str(PurePosixPath(base)))
+    )
 
     assert test == "import path.to.file as user_id;"
 
     base = Path("/path/to/file.preql")
-    test = Renderer().to_string(ImportStatement(alias="", path=str(PurePosixPath(base))))
+    test = Renderer().to_string(
+        ImportStatement(alias="", path=str(PurePosixPath(base)))
+    )
 
     assert test == "import path.to.file;"
 
@@ -536,7 +560,11 @@ def test_render_datasource():
     test = Renderer().to_string(
         Datasource(
             name="useful_data",
-            columns=[ColumnAssignment(alias="user_id", concept=user_id, modifiers=[Modifier.PARTIAL])],
+            columns=[
+                ColumnAssignment(
+                    alias="user_id", concept=user_id, modifiers=[Modifier.PARTIAL]
+                )
+            ],
             address="customers.dim_customers",
             grain=Grain(components=[user_id]),
             where=WhereClause(
@@ -665,7 +693,9 @@ select id
 where id in (1,2,3);
 """,
     )
-    assert isinstance(commands[-1].select.where_clause.conditional.right, TupleWrapper), type(commands[-1].select.where_clause.conditional.right)
+    assert isinstance(
+        commands[-1].select.where_clause.conditional.right, TupleWrapper
+    ), type(commands[-1].select.where_clause.conditional.right)
     rendered = Renderer().to_string(commands[-1])
 
     assert (
@@ -737,10 +767,15 @@ final_zips;
     )
 
     final_zips: ConceptDeclarationStatement = commands[-2]
-    assert isinstance(final_zips.concept.lineage.arguments[0].lineage.where.conditional.right, Concept), final_zips.concept.lineage.arguments[0].lineage.where.conditional.right
+    assert isinstance(
+        final_zips.concept.lineage.arguments[0].lineage.where.conditional.right, Concept
+    ), final_zips.concept.lineage.arguments[0].lineage.where.conditional.right
     rendered = Renderer().to_string(final_zips)
 
-    assert rendered == "property final_zips <- substring(filter zips where zips in substring(p_cust_zip,1,5),1,2);"
+    assert (
+        rendered
+        == "property final_zips <- substring(filter zips where zips in substring(p_cust_zip,1,5),1,2);"
+    )
 
 
 def test_render_environment():

--- a/tests/scripts/test_trilogy.py
+++ b/tests/scripts/test_trilogy.py
@@ -1,7 +1,9 @@
-from click.testing import CliRunner
-from trilogy.scripts.trilogy import cli
 import os
 from pathlib import Path
+
+from click.testing import CliRunner
+
+from trilogy.scripts.trilogy import cli
 
 path = Path(__file__).parent / "test.db"
 

--- a/tests/stack_overflow/test_aggregate_grain.py
+++ b/tests/stack_overflow/test_aggregate_grain.py
@@ -1,7 +1,7 @@
 # from trilogy.compiler import compile
 from os.path import dirname
 
-from trilogy.core.models import SelectStatement, Grain, Environment
+from trilogy.core.models import Environment, Grain, SelectStatement
 from trilogy.parser import parse
 
 QUERY = """import concepts.core as core;

--- a/tests/stack_overflow/test_filtering_reduction.py
+++ b/tests/stack_overflow/test_filtering_reduction.py
@@ -1,9 +1,9 @@
 from os.path import dirname
 
-from trilogy.core.models import SelectStatement, Environment
+from trilogy.core.models import Environment, SelectStatement
 from trilogy.core.query_processor import process_query
-from trilogy.parser import parse
 from trilogy.hooks.query_debugger import DebuggingHook
+from trilogy.parser import parse
 
 
 def test_filtering_reduction():

--- a/tests/stack_overflow/test_import_rendering.py
+++ b/tests/stack_overflow/test_import_rendering.py
@@ -87,7 +87,9 @@ def test_circular_base():
 
 
 def test_circular():
-    env, parsed = parse(CIRC_QUERY, environment=Environment(working_path=dirname(__file__)))
+    env, parsed = parse(
+        CIRC_QUERY, environment=Environment(working_path=dirname(__file__))
+    )
     from trilogy.hooks.query_debugger import DebuggingHook
 
     DebuggingHook()
@@ -113,7 +115,9 @@ def test_circular():
 
 
 def test_partial():
-    env, parsed = parse(CIRC_QUERY, environment=Environment(working_path=dirname(__file__)))
+    env, parsed = parse(
+        CIRC_QUERY, environment=Environment(working_path=dirname(__file__))
+    )
     # raise ValueError(env.concepts.keys())
     p_candidate = [c for c in env.datasources["c1.posts"].columns if c.alias == "id2"]
     assert Modifier.PARTIAL in p_candidate[0].modifiers

--- a/tests/stack_overflow/test_import_rendering.py
+++ b/tests/stack_overflow/test_import_rendering.py
@@ -1,8 +1,8 @@
 # from trilogy.compiler import compile
 from os.path import dirname
 
-from trilogy.core.models import Environment
 from trilogy.core.enums import Modifier
+from trilogy.core.models import Environment
 from trilogy.parser import parse
 from trilogy.parsing.render import render_environment
 
@@ -87,9 +87,7 @@ def test_circular_base():
 
 
 def test_circular():
-    env, parsed = parse(
-        CIRC_QUERY, environment=Environment(working_path=dirname(__file__))
-    )
+    env, parsed = parse(CIRC_QUERY, environment=Environment(working_path=dirname(__file__)))
     from trilogy.hooks.query_debugger import DebuggingHook
 
     DebuggingHook()
@@ -115,9 +113,7 @@ def test_circular():
 
 
 def test_partial():
-    env, parsed = parse(
-        CIRC_QUERY, environment=Environment(working_path=dirname(__file__))
-    )
+    env, parsed = parse(CIRC_QUERY, environment=Environment(working_path=dirname(__file__)))
     # raise ValueError(env.concepts.keys())
     p_candidate = [c for c in env.datasources["c1.posts"].columns if c.alias == "id2"]
     assert Modifier.PARTIAL in p_candidate[0].modifiers

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -1,16 +1,14 @@
+from trilogy.core.exceptions import InvalidSyntaxException
 from trilogy.core.models import (
     NumericType,
 )
 from trilogy.parsing.parse_engine import (
     parse_text,
 )
-from trilogy.core.exceptions import InvalidSyntaxException
 
 
 def test_numeric():
-    env, _ = parse_text(
-        "const order_id numeric(12,2); const rounded <- cast(order_id as numeric(15,2));"
-    )
+    env, _ = parse_text("const order_id numeric(12,2); const rounded <- cast(order_id as numeric(15,2));")
     assert env.concepts["order_id"].datatype == NumericType(precision=12, scale=2)
 
 

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -8,7 +8,9 @@ from trilogy.parsing.parse_engine import (
 
 
 def test_numeric():
-    env, _ = parse_text("const order_id numeric(12,2); const rounded <- cast(order_id as numeric(15,2));")
+    env, _ = parse_text(
+        "const order_id numeric(12,2); const rounded <- cast(order_id as numeric(15,2));"
+    )
     assert env.concepts["order_id"].datatype == NumericType(precision=12, scale=2)
 
 

--- a/tests/test_declarations.py
+++ b/tests/test_declarations.py
@@ -10,6 +10,9 @@ def test_declarations():
 
     assert env.concepts["namespace.user_id"].namespace == "namespace"
     assert env.concepts["namespace.count"].namespace == "namespace"
-    assert env.concepts["namespace.distinct_count"].metadata.description == "the distinct count of user ids"
+    assert (
+        env.concepts["namespace.distinct_count"].metadata.description
+        == "the distinct count of user ids"
+    )
 
     assert env.concepts["namespace.user_id"].metadata.description == "the description"

--- a/tests/test_declarations.py
+++ b/tests/test_declarations.py
@@ -10,9 +10,6 @@ def test_declarations():
 
     assert env.concepts["namespace.user_id"].namespace == "namespace"
     assert env.concepts["namespace.count"].namespace == "namespace"
-    assert (
-        env.concepts["namespace.distinct_count"].metadata.description
-        == "the distinct count of user ids"
-    )
+    assert env.concepts["namespace.distinct_count"].metadata.description == "the distinct count of user ids"
 
     assert env.concepts["namespace.user_id"].metadata.description == "the description"

--- a/tests/test_derived_concepts.py
+++ b/tests/test_derived_concepts.py
@@ -2,13 +2,8 @@ from trilogy import parse
 
 
 def test_derivations(test_environment):
-    assert (
-        test_environment.concepts["order_timestamp"].address == "local.order_timestamp"
-    )
-    assert (
-        test_environment.concepts["order_timestamp.date"].address
-        == "local.order_timestamp.date"
-    )
+    assert test_environment.concepts["order_timestamp"].address == "local.order_timestamp"
+    assert test_environment.concepts["order_timestamp.date"].address == "local.order_timestamp.date"
 
 
 def test_filtering_where_on_derived_aggregate(test_environment):
@@ -33,9 +28,7 @@ def test_filtering_where_on_derived_aggregate(test_environment):
         )
     except Exception as e:
         exception = True
-        assert str(e).startswith(
-            "Cannot reference an aggregate derived in the select (local.filtered_cst) in the same statement where clause"
-        )
+        assert str(e).startswith("Cannot reference an aggregate derived in the select (local.filtered_cst) in the same statement where clause")
     assert exception, "should have an exception"
 
 
@@ -61,14 +54,11 @@ def test_filtering_having_on_unincluded_value(test_environment):
         )
     except Exception as e:
         exception = True
-        assert str(e).startswith(
-            "Cannot reference a column (local.x) that is not in the select projection in the HAVING clause, move to WHERE"
-        ), str(e)
+        assert str(e).startswith("Cannot reference a column (local.x) that is not in the select projection in the HAVING clause, move to WHERE"), str(e)
     assert exception, "should have an exception"
 
 
 def test_filtering_valid(test_environment):
-
     env, _ = parse(
         """key x int;
 property x.cost float;

--- a/tests/test_derived_concepts.py
+++ b/tests/test_derived_concepts.py
@@ -2,8 +2,13 @@ from trilogy import parse
 
 
 def test_derivations(test_environment):
-    assert test_environment.concepts["order_timestamp"].address == "local.order_timestamp"
-    assert test_environment.concepts["order_timestamp.date"].address == "local.order_timestamp.date"
+    assert (
+        test_environment.concepts["order_timestamp"].address == "local.order_timestamp"
+    )
+    assert (
+        test_environment.concepts["order_timestamp.date"].address
+        == "local.order_timestamp.date"
+    )
 
 
 def test_filtering_where_on_derived_aggregate(test_environment):
@@ -28,7 +33,9 @@ def test_filtering_where_on_derived_aggregate(test_environment):
         )
     except Exception as e:
         exception = True
-        assert str(e).startswith("Cannot reference an aggregate derived in the select (local.filtered_cst) in the same statement where clause")
+        assert str(e).startswith(
+            "Cannot reference an aggregate derived in the select (local.filtered_cst) in the same statement where clause"
+        )
     assert exception, "should have an exception"
 
 
@@ -54,7 +61,9 @@ def test_filtering_having_on_unincluded_value(test_environment):
         )
     except Exception as e:
         exception = True
-        assert str(e).startswith("Cannot reference a column (local.x) that is not in the select projection in the HAVING clause, move to WHERE"), str(e)
+        assert str(e).startswith(
+            "Cannot reference a column (local.x) that is not in the select projection in the HAVING clause, move to WHERE"
+        ), str(e)
     assert exception, "should have an exception"
 
 

--- a/tests/test_discovery_nodes.py
+++ b/tests/test_discovery_nodes.py
@@ -39,7 +39,11 @@ def test_group_node_property(test_environment: Environment, test_environment_gra
         source_concepts=search_concepts,
         depth=0,
     )
-    input_concept_names = {x.name for x in group_node.parents[0].output_concepts if x not in group_node.parents[0].hidden_concepts}
+    input_concept_names = {
+        x.name
+        for x in group_node.parents[0].output_concepts
+        if x not in group_node.parents[0].hidden_concepts
+    }
     assert input_concept_names == {"category_name_length", "category_id"}
     final = group_node.resolve()
     assert len(final.datasources) == 1
@@ -58,7 +62,11 @@ def test_group_node_property_all(test_environment: Environment, test_environment
         source_concepts=search_concepts,
         depth=0,
     )
-    input_concept_names = {x.name for x in group_node.parents[0].output_concepts if x not in group_node.parents[0].hidden_concepts}
+    input_concept_names = {
+        x.name
+        for x in group_node.parents[0].output_concepts
+        if x not in group_node.parents[0].hidden_concepts
+    }
     assert input_concept_names == {"category_name_length", "category_id"}
     final = group_node.resolve()
     assert len(final.datasources) == 1

--- a/tests/test_discovery_nodes.py
+++ b/tests/test_discovery_nodes.py
@@ -1,10 +1,10 @@
+from trilogy.core.constants import ALL_ROWS_CONCEPT, INTERNAL_NAMESPACE
+from trilogy.core.models import Environment, Grain
 from trilogy.core.processing.concept_strategies_v3 import (
     GroupNode,
     search_concepts,
 )
 from trilogy.core.processing.node_generators import gen_group_node
-from trilogy.core.models import Environment, Grain
-from trilogy.core.constants import INTERNAL_NAMESPACE, ALL_ROWS_CONCEPT
 
 
 def test_group_node(test_environment, test_environment_graph):
@@ -39,11 +39,7 @@ def test_group_node_property(test_environment: Environment, test_environment_gra
         source_concepts=search_concepts,
         depth=0,
     )
-    input_concept_names = {
-        x.name
-        for x in group_node.parents[0].output_concepts
-        if x not in group_node.parents[0].hidden_concepts
-    }
+    input_concept_names = {x.name for x in group_node.parents[0].output_concepts if x not in group_node.parents[0].hidden_concepts}
     assert input_concept_names == {"category_name_length", "category_id"}
     final = group_node.resolve()
     assert len(final.datasources) == 1
@@ -62,11 +58,7 @@ def test_group_node_property_all(test_environment: Environment, test_environment
         source_concepts=search_concepts,
         depth=0,
     )
-    input_concept_names = {
-        x.name
-        for x in group_node.parents[0].output_concepts
-        if x not in group_node.parents[0].hidden_concepts
-    }
+    input_concept_names = {x.name for x in group_node.parents[0].output_concepts if x not in group_node.parents[0].hidden_concepts}
     assert input_concept_names == {"category_name_length", "category_id"}
     final = group_node.resolve()
     assert len(final.datasources) == 1

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,4 +1,4 @@
-from trilogy.core.enums import BooleanOperator, Boolean
+from trilogy.core.enums import Boolean, BooleanOperator
 
 
 def test_boolean_operator():

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,7 +1,8 @@
-from trilogy.core.models import Environment
 from pathlib import Path
+
 from trilogy.core.enums import Modifier
 from trilogy.core.exceptions import UndefinedConceptException
+from trilogy.core.models import Environment
 
 
 def test_environment_serialization(test_environment: Environment):
@@ -18,14 +19,12 @@ def test_environment_serialization(test_environment: Environment):
 
 
 def test_environment_from_path():
-
     env = Environment.from_file(Path(__file__).parent / "test_env.preql")
 
     assert "local.id" in env.concepts
 
 
 def test_environment_invalid():
-
     env = Environment()
     env.concepts.fail_on_missing = False
     x = env.concepts["abc"]
@@ -77,10 +76,7 @@ key  order_id int;
 
     found = False
     for x in env1.datasources["replacements.replacements"].columns:
-        if (
-            x.alias == "order_id"
-            and x.concept.address == env1.concepts["order_id"].address
-        ):
+        if x.alias == "order_id" and x.concept.address == env1.concepts["order_id"].address:
             assert x.concept == env1.concepts["order_id"]
             assert x.modifiers == [Modifier.PARTIAL]
             found = True

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -76,7 +76,10 @@ key  order_id int;
 
     found = False
     for x in env1.datasources["replacements.replacements"].columns:
-        if x.alias == "order_id" and x.concept.address == env1.concepts["order_id"].address:
+        if (
+            x.alias == "order_id"
+            and x.concept.address == env1.concepts["order_id"].address
+        ):
             assert x.concept == env1.concepts["order_id"]
             assert x.modifiers == [Modifier.PARTIAL]
             found = True

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,5 +1,6 @@
-from trilogy import Dialects, parse, Environment
 from pathlib import Path
+
+from trilogy import Dialects, Environment, parse
 
 
 def test_file_parsing():

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,18 +1,19 @@
 # from trilogy.compiler import compile
+from logging import INFO
+
 from pytest import raises
 
+from trilogy.constants import logger
+from trilogy.core.enums import Purpose, PurposeLineage
 from trilogy.core.exceptions import InvalidSyntaxException
-from trilogy.core.models import DataType, SelectStatement, ListType, Environment
+from trilogy.core.models import DataType, Environment, ListType, SelectStatement
 from trilogy.core.query_processor import process_query
 from trilogy.dialect.base import BaseDialect
 from trilogy.dialect.bigquery import BigqueryDialect
 from trilogy.dialect.duckdb import DuckDBDialect
-from trilogy.dialect.sql_server import SqlServerDialect
 from trilogy.dialect.snowflake import SnowflakeDialect
+from trilogy.dialect.sql_server import SqlServerDialect
 from trilogy.parser import parse
-from logging import INFO
-from trilogy.constants import logger
-from trilogy.core.enums import PurposeLineage, Purpose
 
 logger.setLevel(INFO)
 
@@ -209,10 +210,7 @@ def test_case_function(test_environment):
         test_upper_case
     ;"""
     env, parsed = parse(declarations, environment=test_environment)
-    assert (
-        test_environment.concepts["category_name"]
-        in test_environment.concepts["test_upper_case"].lineage.concept_arguments
-    )
+    assert test_environment.concepts["category_name"] in test_environment.concepts["test_upper_case"].lineage.concept_arguments
     select: SelectStatement = parsed[-1]
     for dialect in TEST_DIALECTS:
         compiled = dialect.compile_statement(process_query(test_environment, select))
@@ -230,10 +228,7 @@ def test_case_like_function(test_environment):
         test_like
     ;"""
     env, parsed = parse(declarations, environment=test_environment)
-    assert (
-        test_environment.concepts["category_name"]
-        in test_environment.concepts["test_like"].lineage.concept_arguments
-    )
+    assert test_environment.concepts["category_name"] in test_environment.concepts["test_like"].lineage.concept_arguments
     select: SelectStatement = parsed[-1]
     for dialect in TEST_DIALECTS:
         compiled = dialect.compile_statement(process_query(test_environment, select))

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -210,7 +210,10 @@ def test_case_function(test_environment):
         test_upper_case
     ;"""
     env, parsed = parse(declarations, environment=test_environment)
-    assert test_environment.concepts["category_name"] in test_environment.concepts["test_upper_case"].lineage.concept_arguments
+    assert (
+        test_environment.concepts["category_name"]
+        in test_environment.concepts["test_upper_case"].lineage.concept_arguments
+    )
     select: SelectStatement = parsed[-1]
     for dialect in TEST_DIALECTS:
         compiled = dialect.compile_statement(process_query(test_environment, select))
@@ -228,7 +231,10 @@ def test_case_like_function(test_environment):
         test_like
     ;"""
     env, parsed = parse(declarations, environment=test_environment)
-    assert test_environment.concepts["category_name"] in test_environment.concepts["test_like"].lineage.concept_arguments
+    assert (
+        test_environment.concepts["category_name"]
+        in test_environment.concepts["test_like"].lineage.concept_arguments
+    )
     select: SelectStatement = parsed[-1]
     for dialect in TEST_DIALECTS:
         compiled = dialect.compile_statement(process_query(test_environment, select))

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,5 +1,6 @@
-from trilogy import Environment
 from pathlib import Path
+
+from trilogy import Environment
 
 
 def test_multi_environment():

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,5 +1,6 @@
-from trilogy import parse, Environment
 from pathlib import Path
+
+from trilogy import Environment, parse
 
 
 def test_metadata():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -70,13 +70,21 @@ def test_cte_merge(test_environment, test_environment_graph):
 def test_concept(test_environment, test_environment_graph):
     test_concept = list(test_environment.concepts.values())[0]
     new = test_concept.with_namespace("test")
-    assert new.namespace == ("test" + "." + test_concept.namespace) if test_concept.namespace != "local" else "test"
+    assert (
+        new.namespace == ("test" + "." + test_concept.namespace)
+        if test_concept.namespace != "local"
+        else "test"
+    )
 
 
 def test_concept_filter(test_environment, test_environment_graph):
     test_concept: Concept = list(test_environment.concepts.values())[0]
-    new = test_concept.with_filter(Comparison(left=1, right=2, operator=ComparisonOperator.EQ))
-    new2 = test_concept.with_filter(Comparison(left=1, right=2, operator=ComparisonOperator.EQ))
+    new = test_concept.with_filter(
+        Comparison(left=1, right=2, operator=ComparisonOperator.EQ)
+    )
+    new2 = test_concept.with_filter(
+        Comparison(left=1, right=2, operator=ComparisonOperator.EQ)
+    )
 
     assert new.name == new2.name != test_concept.name
 
@@ -87,13 +95,23 @@ def test_concept_filter(test_environment, test_environment_graph):
 def test_conditional(test_environment, test_environment_graph):
     test_concept = list(test_environment.concepts.values())[-1]
 
-    condition_a = Conditional(left=test_concept, right=test_concept, operator=BooleanOperator.AND)
-    condition_b = Conditional(left=test_concept, right=test_concept, operator=BooleanOperator.AND)
+    condition_a = Conditional(
+        left=test_concept, right=test_concept, operator=BooleanOperator.AND
+    )
+    condition_b = Conditional(
+        left=test_concept, right=test_concept, operator=BooleanOperator.AND
+    )
     merged = condition_a + condition_b
     assert merged == condition_a
 
-    test_concept_two = [x for x in test_environment.concepts.values() if x.address != test_concept.address].pop()
-    condition_c = Conditional(left=test_concept, right=test_concept_two, operator=BooleanOperator.AND)
+    test_concept_two = [
+        x
+        for x in test_environment.concepts.values()
+        if x.address != test_concept.address
+    ].pop()
+    condition_c = Conditional(
+        left=test_concept, right=test_concept_two, operator=BooleanOperator.AND
+    )
     merged_two = condition_a + condition_c
     assert merged_two.left == condition_a, f"{str(merged_two.left), str(condition_a)}"
     assert merged_two.right == condition_c
@@ -128,7 +146,9 @@ def test_select(test_environment: Environment):
     cid = test_environment.concepts["category_id"]
     cname = test_environment.concepts["category_name"]
     x = SelectStatement(selection=[oid, pid, cid, cname])
-    ds = x.to_datasource(test_environment.namespace, "test", address=Address(location="test"))
+    ds = x.to_datasource(
+        test_environment.namespace, "test", address=Address(location="test")
+    )
 
     assert ds.grain == Grain(components=[oid, pid, cid])
 
@@ -227,11 +247,17 @@ def test_join(test_environment: Environment):
     test = Join(
         left_cte=a,
         right_cte=b,
-        joinkey_pairs=[CTEConceptPair(left=x, right=x, existing_datasource=a.source, cte=a) for x in outputs],
+        joinkey_pairs=[
+            CTEConceptPair(left=x, right=x, existing_datasource=a.source, cte=a)
+            for x in outputs
+        ],
         jointype=JoinType.RIGHT_OUTER,
     )
 
-    assert str(test) == "right outer join testb on test.local.product_id=local.product_id,test.local.category_id=local.category_id", str(test)
+    assert (
+        str(test)
+        == "right outer join testb on test.local.product_id=local.product_id,test.local.category_id=local.category_id"
+    ), str(test)
 
 
 def test_concept_address_in_check():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,25 +1,26 @@
-from trilogy.core.enums import BooleanOperator, Purpose, JoinType, ComparisonOperator
+from copy import deepcopy
+
+from trilogy import parse
+from trilogy.core.enums import BooleanOperator, ComparisonOperator, JoinType, Purpose
 from trilogy.core.models import (
     CTE,
-    Grain,
-    QueryDatasource,
-    Conditional,
-    SelectStatement,
-    Environment,
     Address,
-    UndefinedConcept,
+    AggregateWrapper,
     BaseJoin,
     Comparison,
-    Join,
-    CTEConceptPair,
     Concept,
-    AggregateWrapper,
-    RowsetItem,
-    TupleWrapper,
+    Conditional,
+    CTEConceptPair,
     DataType,
+    Environment,
+    Grain,
+    Join,
+    QueryDatasource,
+    RowsetItem,
+    SelectStatement,
+    TupleWrapper,
+    UndefinedConcept,
 )
-from trilogy import parse
-from copy import deepcopy
 
 
 def test_cte_merge(test_environment, test_environment_graph):
@@ -69,21 +70,13 @@ def test_cte_merge(test_environment, test_environment_graph):
 def test_concept(test_environment, test_environment_graph):
     test_concept = list(test_environment.concepts.values())[0]
     new = test_concept.with_namespace("test")
-    assert (
-        new.namespace == ("test" + "." + test_concept.namespace)
-        if test_concept.namespace != "local"
-        else "test"
-    )
+    assert new.namespace == ("test" + "." + test_concept.namespace) if test_concept.namespace != "local" else "test"
 
 
 def test_concept_filter(test_environment, test_environment_graph):
     test_concept: Concept = list(test_environment.concepts.values())[0]
-    new = test_concept.with_filter(
-        Comparison(left=1, right=2, operator=ComparisonOperator.EQ)
-    )
-    new2 = test_concept.with_filter(
-        Comparison(left=1, right=2, operator=ComparisonOperator.EQ)
-    )
+    new = test_concept.with_filter(Comparison(left=1, right=2, operator=ComparisonOperator.EQ))
+    new2 = test_concept.with_filter(Comparison(left=1, right=2, operator=ComparisonOperator.EQ))
 
     assert new.name == new2.name != test_concept.name
 
@@ -94,23 +87,13 @@ def test_concept_filter(test_environment, test_environment_graph):
 def test_conditional(test_environment, test_environment_graph):
     test_concept = list(test_environment.concepts.values())[-1]
 
-    condition_a = Conditional(
-        left=test_concept, right=test_concept, operator=BooleanOperator.AND
-    )
-    condition_b = Conditional(
-        left=test_concept, right=test_concept, operator=BooleanOperator.AND
-    )
+    condition_a = Conditional(left=test_concept, right=test_concept, operator=BooleanOperator.AND)
+    condition_b = Conditional(left=test_concept, right=test_concept, operator=BooleanOperator.AND)
     merged = condition_a + condition_b
     assert merged == condition_a
 
-    test_concept_two = [
-        x
-        for x in test_environment.concepts.values()
-        if x.address != test_concept.address
-    ].pop()
-    condition_c = Conditional(
-        left=test_concept, right=test_concept_two, operator=BooleanOperator.AND
-    )
+    test_concept_two = [x for x in test_environment.concepts.values() if x.address != test_concept.address].pop()
+    condition_c = Conditional(left=test_concept, right=test_concept_two, operator=BooleanOperator.AND)
     merged_two = condition_a + condition_c
     assert merged_two.left == condition_a, f"{str(merged_two.left), str(condition_a)}"
     assert merged_two.right == condition_c
@@ -145,9 +128,7 @@ def test_select(test_environment: Environment):
     cid = test_environment.concepts["category_id"]
     cname = test_environment.concepts["category_name"]
     x = SelectStatement(selection=[oid, pid, cid, cname])
-    ds = x.to_datasource(
-        test_environment.namespace, "test", address=Address(location="test")
-    )
+    ds = x.to_datasource(test_environment.namespace, "test", address=Address(location="test"))
 
     assert ds.grain == Grain(components=[oid, pid, cid])
 
@@ -246,17 +227,11 @@ def test_join(test_environment: Environment):
     test = Join(
         left_cte=a,
         right_cte=b,
-        joinkey_pairs=[
-            CTEConceptPair(left=x, right=x, existing_datasource=a.source, cte=a)
-            for x in outputs
-        ],
+        joinkey_pairs=[CTEConceptPair(left=x, right=x, existing_datasource=a.source, cte=a) for x in outputs],
         jointype=JoinType.RIGHT_OUTER,
     )
 
-    assert (
-        str(test)
-        == "right outer join testb on test.local.product_id=local.product_id,test.local.category_id=local.category_id"
-    ), str(test)
+    assert str(test) == "right outer join testb on test.local.product_id=local.product_id,test.local.category_id=local.category_id", str(test)
 
 
 def test_concept_address_in_check():

--- a/tests/test_multi_join_assignments.py
+++ b/tests/test_multi_join_assignments.py
@@ -1,5 +1,5 @@
 # from trilogy.compiler import compile
-from trilogy.core.models import SelectStatement, Grain
+from trilogy.core.models import Grain, SelectStatement
 from trilogy.core.query_processor import process_query
 from trilogy.parser import parse
 

--- a/tests/test_parse_engine.py
+++ b/tests/test_parse_engine.py
@@ -1,7 +1,8 @@
-from trilogy.parsing.parse_engine import ParseToObjects, PARSER, unpack_visit_error
+from pytest import raises
+
 from trilogy import Environment
 from trilogy.core.exceptions import UndefinedConceptException
-from pytest import raises
+from trilogy.parsing.parse_engine import PARSER, ParseToObjects, unpack_visit_error
 
 TEXT = """
 const a <- 1;

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -20,7 +20,9 @@ from trilogy.parsing.parse_engine import (
 
 
 def test_in():
-    _, parsed = parse_text("const order_id <- 3; SELECT order_id  WHERE order_id IN (1,2,3);")
+    _, parsed = parse_text(
+        "const order_id <- 3; SELECT order_id  WHERE order_id IN (1,2,3);"
+    )
     query = parsed[-1]
     right = query.where_clause.conditional.right
     assert isinstance(
@@ -31,7 +33,9 @@ def test_in():
     rendered = BaseDialect().render_expr(right)
     assert rendered.strip() == "(1,2,3)".strip()
 
-    _, parsed = parse_text("const order_id <- 3; SELECT order_id  WHERE order_id IN (1,);")
+    _, parsed = parse_text(
+        "const order_id <- 3; SELECT order_id  WHERE order_id IN (1,);"
+    )
     query = parsed[-1]
     right = query.where_clause.conditional.right
     assert isinstance(
@@ -44,7 +48,9 @@ def test_in():
 
 
 def test_not_in():
-    _, parsed = parse_text("const order_id <- 4; SELECT order_id  WHERE order_id NOT IN (1,2,3);")
+    _, parsed = parse_text(
+        "const order_id <- 4; SELECT order_id  WHERE order_id NOT IN (1,2,3);"
+    )
     query: ProcessedQuery = parsed[-1]
     right = query.where_clause.conditional.right
     assert isinstance(right, TupleWrapper), type(right)
@@ -54,7 +60,9 @@ def test_not_in():
 
 
 def test_is_not_null():
-    _, parsed = parse_text("const order_id <- 4; SELECT order_id  WHERE order_id is not null;")
+    _, parsed = parse_text(
+        "const order_id <- 4; SELECT order_id  WHERE order_id is not null;"
+    )
     query = parsed[-1]
     right = query.where_clause.conditional.right
     assert isinstance(right, MagicConstants), type(right)
@@ -63,10 +71,16 @@ def test_is_not_null():
 
 
 def test_sort():
-    _, parsed = parse_text("const order_id <- 4; SELECT order_id  ORDER BY order_id desc;")
+    _, parsed = parse_text(
+        "const order_id <- 4; SELECT order_id  ORDER BY order_id desc;"
+    )
 
-    _, parsed = parse_text("const order_id <- 4; SELECT order_id  ORDER BY order_id DESC;")
-    _, parsed = parse_text("const order_id <- 4; SELECT order_id  ORDER BY order_id DesC;")
+    _, parsed = parse_text(
+        "const order_id <- 4; SELECT order_id  ORDER BY order_id DESC;"
+    )
+    _, parsed = parse_text(
+        "const order_id <- 4; SELECT order_id  ORDER BY order_id DesC;"
+    )
 
 
 def test_arg_to_datatype():
@@ -87,20 +101,35 @@ def test_argument_to_purpose(test_environment: Environment):
         )
         == Purpose.CONSTANT
     )
-    assert function_args_to_output_purpose(["test", 1.00, test_environment.concepts["order_id"]]) == Purpose.PROPERTY
+    assert (
+        function_args_to_output_purpose(
+            ["test", 1.00, test_environment.concepts["order_id"]]
+        )
+        == Purpose.PROPERTY
+    )
     unnest_env, parsed = parse_text("const random <- unnest([1,2,3,4]);")
-    assert function_args_to_output_purpose([unnest_env.concepts["random"]]) == Purpose.PROPERTY
+    assert (
+        function_args_to_output_purpose([unnest_env.concepts["random"]])
+        == Purpose.PROPERTY
+    )
 
 
 def test_show(test_environment):
-    _, parsed = parse_text("const order_id <- 4; SHOW SELECT order_id  WHERE order_id is not null;")
+    _, parsed = parse_text(
+        "const order_id <- 4; SHOW SELECT order_id  WHERE order_id is not null;"
+    )
     query = parsed[-1]
     assert isinstance(query, ShowStatement)
-    assert query.content.output_components[0].address == test_environment.concepts["order_id"].address
+    assert (
+        query.content.output_components[0].address
+        == test_environment.concepts["order_id"].address
+    )
 
 
 def test_conditional(test_environment):
-    _, parsed = parse_text("const order_id <- 4; SELECT order_id  WHERE order_id =4 and order_id = 10;")
+    _, parsed = parse_text(
+        "const order_id <- 4; SELECT order_id  WHERE order_id =4 and order_id = 10;"
+    )
     query = parsed[-1]
     assert isinstance(query, SelectStatement)
     assert query.where_clause.conditional.operator == BooleanOperator.AND
@@ -198,7 +227,9 @@ select
 
 
 def test_between():
-    _, parsed = parse_text("const order_id <- 4; SELECT order_id  WHERE order_id BETWEEN 3 and 5;")
+    _, parsed = parse_text(
+        "const order_id <- 4; SELECT order_id  WHERE order_id BETWEEN 3 and 5;"
+    )
     query: ProcessedQuery = parsed[-1]
     left = query.where_clause.conditional.left
     assert isinstance(

--- a/tests/test_partial_handling.py
+++ b/tests/test_partial_handling.py
@@ -27,7 +27,9 @@ def setup_engine() -> Executor:
 
 def setup_titanic(env: Environment):
     namespace = "passenger"
-    id = Concept(name="id", namespace=namespace, datatype=DataType.INTEGER, purpose=Purpose.KEY)
+    id = Concept(
+        name="id", namespace=namespace, datatype=DataType.INTEGER, purpose=Purpose.KEY
+    )
     age = Concept(
         name="age",
         namespace=namespace,
@@ -119,7 +121,9 @@ def test_partial_assignment():
     assert len(resolved.partial_concepts) == 0
 
     # check at the source level
-    sourced = search_concepts([family, env.concepts["surviving_passenger"]], environment=env, g=g, depth=0)
+    sourced = search_concepts(
+        [family, env.concepts["surviving_passenger"]], environment=env, g=g, depth=0
+    )
     assert isinstance(sourced, MergeNode)
     assert len(sourced.parents) == 2
 

--- a/tests/test_partial_handling.py
+++ b/tests/test_partial_handling.py
@@ -1,23 +1,21 @@
-from trilogy import Executor, Dialects
-
 # from trilogy.core.models import Environment
 from sqlalchemy import create_engine
+
+from trilogy import Dialects, Executor
+from trilogy.core.enums import Purpose
 from trilogy.core.models import (
-    DataType,
-    Datasource,
-    Concept,
     ColumnAssignment,
+    Concept,
+    Datasource,
+    DataType,
     Environment,
 )
-from trilogy.core.enums import Purpose
-
-
-from trilogy.core.query_processor import generate_graph
-from trilogy.core.processing.nodes import MergeNode
 from trilogy.core.processing.concept_strategies_v3 import search_concepts
 from trilogy.core.processing.node_generators import (
     gen_filter_node,
 )
+from trilogy.core.processing.nodes import MergeNode
+from trilogy.core.query_processor import generate_graph
 from trilogy.hooks.query_debugger import DebuggingHook
 
 
@@ -29,9 +27,7 @@ def setup_engine() -> Executor:
 
 def setup_titanic(env: Environment):
     namespace = "passenger"
-    id = Concept(
-        name="id", namespace=namespace, datatype=DataType.INTEGER, purpose=Purpose.KEY
-    )
+    id = Concept(name="id", namespace=namespace, datatype=DataType.INTEGER, purpose=Purpose.KEY)
     age = Concept(
         name="age",
         namespace=namespace,
@@ -123,9 +119,7 @@ def test_partial_assignment():
     assert len(resolved.partial_concepts) == 0
 
     # check at the source level
-    sourced = search_concepts(
-        [family, env.concepts["surviving_passenger"]], environment=env, g=g, depth=0
-    )
+    sourced = search_concepts([family, env.concepts["surviving_passenger"]], environment=env, g=g, depth=0)
     assert isinstance(sourced, MergeNode)
     assert len(sourced.parents) == 2
 

--- a/tests/test_query_processing.py
+++ b/tests/test_query_processing.py
@@ -14,10 +14,14 @@ def test_direct_select(test_environment, test_environment_graph):
     ).resolve()
 
     assert isinstance(datasource, QueryDatasource)
-    assert set([datasource.name for datasource in datasource.datasources]) == {"products"}
+    assert set([datasource.name for datasource in datasource.datasources]) == {
+        "products"
+    }
 
 
-def test_get_datasource_from_window_function(test_environment: Environment, test_environment_graph):
+def test_get_datasource_from_window_function(
+    test_environment: Environment, test_environment_graph
+):
     # test without grouping
     product_rank = test_environment.concepts["product_revenue_rank"]
     #        concept, grain: Grain, environment: Environment, g: ReferenceGraph, query_graph: ReferenceGraph
@@ -36,7 +40,9 @@ def test_get_datasource_from_window_function(test_environment: Environment, test
     assert isinstance(datasource, QueryDatasource)
     assert datasource.grain.set == product_rank.grain.set
 
-    product_rank_by_category = test_environment.concepts["product_revenue_rank_by_category"]
+    product_rank_by_category = test_environment.concepts[
+        "product_revenue_rank_by_category"
+    ]
     #        concept, grain: Grain, environment: Environment, g: ReferenceGraph, query_graph: ReferenceGraph
     datasource = search_concepts(
         [product_rank_by_category] + product_rank_by_category.grain.components_copy,
@@ -50,7 +56,9 @@ def test_get_datasource_from_window_function(test_environment: Environment, test
     assert isinstance(datasource, QueryDatasource)
 
 
-def test_get_datasource_for_filter(test_environment: Environment, test_environment_graph):
+def test_get_datasource_for_filter(
+    test_environment: Environment, test_environment_graph
+):
     hi_rev_product = test_environment.concepts["products_with_revenue_over_50"]
     #        concept, grain: Grain, environment: Environment, g: ReferenceGraph, query_graph: ReferenceGraph
 
@@ -85,7 +93,9 @@ def test_select_output(test_environment, test_environment_graph):
     ).resolve()
 
     assert isinstance(datasource, QueryDatasource)
-    assert set([datasource.name for datasource in datasource.datasources]) == {"products"}
+    assert set([datasource.name for datasource in datasource.datasources]) == {
+        "products"
+    }
 
 
 def test_basic_aggregate(test_environment: Environment, test_environment_graph):
@@ -120,7 +130,9 @@ def test_join_aggregate(test_environment: Environment, test_environment_graph):
 
 def test_query_aggregation(test_environment, test_environment_graph):
     select = SelectStatement(selection=[test_environment.concepts["total_revenue"]])
-    datasource = get_query_datasources(environment=test_environment, graph=test_environment_graph, statement=select)
+    datasource = get_query_datasources(
+        environment=test_environment, graph=test_environment_graph, statement=select
+    )
 
     assert {datasource.identifier} == {"revenue_at_local_order_id_at_abstract"}
     check = datasource
@@ -138,7 +150,9 @@ def test_query_datasources(test_environment, test_environment_graph):
             test_environment.concepts["total_revenue"],
         ]
     )
-    get_query_datasources(environment=test_environment, graph=test_environment_graph, statement=select)
+    get_query_datasources(
+        environment=test_environment, graph=test_environment_graph, statement=select
+    )
 
 
 def test_full_query(test_environment, test_environment_graph):

--- a/tests/test_query_processing.py
+++ b/tests/test_query_processing.py
@@ -1,6 +1,6 @@
-from trilogy.core.models import SelectStatement, QueryDatasource, Environment, Grain
+from trilogy.core.models import Environment, Grain, QueryDatasource, SelectStatement
 from trilogy.core.processing.concept_strategies_v3 import search_concepts
-from trilogy.core.query_processor import process_query, get_query_datasources
+from trilogy.core.query_processor import get_query_datasources, process_query
 
 
 def test_direct_select(test_environment, test_environment_graph):
@@ -14,14 +14,10 @@ def test_direct_select(test_environment, test_environment_graph):
     ).resolve()
 
     assert isinstance(datasource, QueryDatasource)
-    assert set([datasource.name for datasource in datasource.datasources]) == {
-        "products"
-    }
+    assert set([datasource.name for datasource in datasource.datasources]) == {"products"}
 
 
-def test_get_datasource_from_window_function(
-    test_environment: Environment, test_environment_graph
-):
+def test_get_datasource_from_window_function(test_environment: Environment, test_environment_graph):
     # test without grouping
     product_rank = test_environment.concepts["product_revenue_rank"]
     #        concept, grain: Grain, environment: Environment, g: ReferenceGraph, query_graph: ReferenceGraph
@@ -40,9 +36,7 @@ def test_get_datasource_from_window_function(
     assert isinstance(datasource, QueryDatasource)
     assert datasource.grain.set == product_rank.grain.set
 
-    product_rank_by_category = test_environment.concepts[
-        "product_revenue_rank_by_category"
-    ]
+    product_rank_by_category = test_environment.concepts["product_revenue_rank_by_category"]
     #        concept, grain: Grain, environment: Environment, g: ReferenceGraph, query_graph: ReferenceGraph
     datasource = search_concepts(
         [product_rank_by_category] + product_rank_by_category.grain.components_copy,
@@ -56,9 +50,7 @@ def test_get_datasource_from_window_function(
     assert isinstance(datasource, QueryDatasource)
 
 
-def test_get_datasource_for_filter(
-    test_environment: Environment, test_environment_graph
-):
+def test_get_datasource_for_filter(test_environment: Environment, test_environment_graph):
     hi_rev_product = test_environment.concepts["products_with_revenue_over_50"]
     #        concept, grain: Grain, environment: Environment, g: ReferenceGraph, query_graph: ReferenceGraph
 
@@ -93,9 +85,7 @@ def test_select_output(test_environment, test_environment_graph):
     ).resolve()
 
     assert isinstance(datasource, QueryDatasource)
-    assert set([datasource.name for datasource in datasource.datasources]) == {
-        "products"
-    }
+    assert set([datasource.name for datasource in datasource.datasources]) == {"products"}
 
 
 def test_basic_aggregate(test_environment: Environment, test_environment_graph):
@@ -130,9 +120,7 @@ def test_join_aggregate(test_environment: Environment, test_environment_graph):
 
 def test_query_aggregation(test_environment, test_environment_graph):
     select = SelectStatement(selection=[test_environment.concepts["total_revenue"]])
-    datasource = get_query_datasources(
-        environment=test_environment, graph=test_environment_graph, statement=select
-    )
+    datasource = get_query_datasources(environment=test_environment, graph=test_environment_graph, statement=select)
 
     assert {datasource.identifier} == {"revenue_at_local_order_id_at_abstract"}
     check = datasource
@@ -150,9 +138,7 @@ def test_query_datasources(test_environment, test_environment_graph):
             test_environment.concepts["total_revenue"],
         ]
     )
-    get_query_datasources(
-        environment=test_environment, graph=test_environment_graph, statement=select
-    )
+    get_query_datasources(environment=test_environment, graph=test_environment_graph, statement=select)
 
 
 def test_full_query(test_environment, test_environment_graph):

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,6 +1,5 @@
 # from trilogy.compiler import compile
-from trilogy.core.models import Grain
-from trilogy.core.models import SelectStatement
+from trilogy.core.models import Grain, SelectStatement
 from trilogy.core.query_processor import process_query
 from trilogy.dialect.bigquery import BigqueryDialect
 from trilogy.parser import parse

--- a/tests/test_show.py
+++ b/tests/test_show.py
@@ -47,5 +47,11 @@ def test_show_bigquery():
     env, parsed = parse(q1, environment=env)
     select: ShowStatement = parsed[-1]
 
-    query = Dialects.DUCK_DB.default_executor(environment=env).execute_query(select).fetchall()
-    assert "FULL JOIN wakeful on 1=1" in query[0]["__preql_internal_query_text"], query[0]["__preql_internal_query_text"]
+    query = (
+        Dialects.DUCK_DB.default_executor(environment=env)
+        .execute_query(select)
+        .fetchall()
+    )
+    assert "FULL JOIN wakeful on 1=1" in query[0]["__preql_internal_query_text"], query[
+        0
+    ]["__preql_internal_query_text"]

--- a/tests/test_show.py
+++ b/tests/test_show.py
@@ -1,5 +1,5 @@
-from trilogy.core.models import ShowStatement
 from trilogy import Dialects
+from trilogy.core.models import ShowStatement
 from trilogy.parser import parse
 
 
@@ -47,11 +47,5 @@ def test_show_bigquery():
     env, parsed = parse(q1, environment=env)
     select: ShowStatement = parsed[-1]
 
-    query = (
-        Dialects.DUCK_DB.default_executor(environment=env)
-        .execute_query(select)
-        .fetchall()
-    )
-    assert "FULL JOIN wakeful on 1=1" in query[0]["__preql_internal_query_text"], query[
-        0
-    ]["__preql_internal_query_text"]
+    query = Dialects.DUCK_DB.default_executor(environment=env).execute_query(select).fetchall()
+    assert "FULL JOIN wakeful on 1=1" in query[0]["__preql_internal_query_text"], query[0]["__preql_internal_query_text"]

--- a/tests/test_statements.py
+++ b/tests/test_statements.py
@@ -1,7 +1,8 @@
-from trilogy.parser import parse
+from pathlib import Path
+
 from trilogy import Dialects
 from trilogy.core.models import ProcessedCopyStatement
-from pathlib import Path
+from trilogy.parser import parse
 
 # from trilogy.compiler import compile
 

--- a/tests/test_undefined_concept.py
+++ b/tests/test_undefined_concept.py
@@ -20,7 +20,9 @@ def test_undefined_concept_query(test_environment):
 
 def test_undefined_concept_dict():
     env = EnvironmentConceptDict()
-    env["order_id"] = Concept(name="order_id", datatype=DataType.INTEGER, purpose=Purpose.KEY)
+    env["order_id"] = Concept(
+        name="order_id", datatype=DataType.INTEGER, purpose=Purpose.KEY
+    )
     try:
         env["zzz"]
     except UndefinedConceptException as e:

--- a/tests/test_undefined_concept.py
+++ b/tests/test_undefined_concept.py
@@ -1,6 +1,6 @@
 from trilogy.core.enums import Purpose
 from trilogy.core.exceptions import UndefinedConceptException
-from trilogy.core.models import DataType, EnvironmentConceptDict, Concept
+from trilogy.core.models import Concept, DataType, EnvironmentConceptDict
 from trilogy.parser import parse
 
 
@@ -20,9 +20,7 @@ def test_undefined_concept_query(test_environment):
 
 def test_undefined_concept_dict():
     env = EnvironmentConceptDict()
-    env["order_id"] = Concept(
-        name="order_id", datatype=DataType.INTEGER, purpose=Purpose.KEY
-    )
+    env["order_id"] = Concept(name="order_id", datatype=DataType.INTEGER, purpose=Purpose.KEY)
     try:
         env["zzz"]
     except UndefinedConceptException as e:

--- a/tests/test_where_clause.py
+++ b/tests/test_where_clause.py
@@ -1,9 +1,9 @@
 # from trilogy.compiler import compile
-from trilogy.core.models import SelectStatement, Grain, Parenthetical
+from trilogy.core.models import Grain, Parenthetical, SelectStatement
+from trilogy.core.processing.utility import is_scalar_condition
 from trilogy.core.query_processor import process_query
 from trilogy.dialect.base import BaseDialect
 from trilogy.parser import parse
-from trilogy.core.processing.utility import is_scalar_condition
 
 
 def test_select_where(test_environment):
@@ -63,9 +63,7 @@ select
     )
     select: SelectStatement = parsed[-1]
 
-    BaseDialect().compile_statement(
-        process_query(test_environment, select, hooks=[DebuggingHook()])
-    )
+    BaseDialect().compile_statement(process_query(test_environment, select, hooks=[DebuggingHook()]))
 
 
 def test_select_where_joins(test_environment):
@@ -252,9 +250,7 @@ where
     env, parsed = parse(declarations, environment=test_environment)
     select: SelectStatement = parsed[-1]
 
-    query = BaseDialect().compile_statement(
-        process_query(test_environment, select, hooks=[DebuggingHook()])
-    )
+    query = BaseDialect().compile_statement(process_query(test_environment, select, hooks=[DebuggingHook()]))
 
     # check to make sure our subselect is well-formed
     assert "`category_id` not in (select" in query, query

--- a/tests/test_where_clause.py
+++ b/tests/test_where_clause.py
@@ -63,7 +63,9 @@ select
     )
     select: SelectStatement = parsed[-1]
 
-    BaseDialect().compile_statement(process_query(test_environment, select, hooks=[DebuggingHook()]))
+    BaseDialect().compile_statement(
+        process_query(test_environment, select, hooks=[DebuggingHook()])
+    )
 
 
 def test_select_where_joins(test_environment):
@@ -250,7 +252,9 @@ where
     env, parsed = parse(declarations, environment=test_environment)
     select: SelectStatement = parsed[-1]
 
-    query = BaseDialect().compile_statement(process_query(test_environment, select, hooks=[DebuggingHook()]))
+    query = BaseDialect().compile_statement(
+        process_query(test_environment, select, hooks=[DebuggingHook()])
+    )
 
     # check to make sure our subselect is well-formed
     assert "`category_id` not in (select" in query, query

--- a/tests/utility.py
+++ b/tests/utility.py
@@ -1,9 +1,10 @@
-from trilogy.core.models import Concept, Environment
-from trilogy.core.processing.nodes.group_node import GroupNode
-from trilogy.core.processing.nodes.base_node import StrategyNode
-from trilogy.core.processing.concept_strategies_v3 import source_query_concepts
-from trilogy.hooks.query_debugger import DebuggingHook
 from logging import INFO
+
+from trilogy.core.models import Concept, Environment
+from trilogy.core.processing.concept_strategies_v3 import source_query_concepts
+from trilogy.core.processing.nodes.base_node import StrategyNode
+from trilogy.core.processing.nodes.group_node import GroupNode
+from trilogy.hooks.query_debugger import DebuggingHook
 
 
 def get_parents(node: StrategyNode):
@@ -13,17 +14,11 @@ def get_parents(node: StrategyNode):
     return output
 
 
-def validate_shape(
-    input: list[Concept], environment: Environment, g, levels, error: str | None = None
-):
+def validate_shape(input: list[Concept], environment: Environment, g, levels, error: str | None = None):
     """test that our query resolves to the expected CTES"""
     base: GroupNode = source_query_concepts(input, environment, g)
     DebuggingHook(INFO).process_root_strategy_node(base)
     final = get_parents(base)
-    default_error = (
-        "\n".join([str(x) for x in final])
-        + "\nvs\n"
-        + "\n".join([str(x) for x in levels])
-    )
+    default_error = "\n".join([str(x) for x in final]) + "\nvs\n" + "\n".join([str(x) for x in levels])
 
     assert final == levels, error or default_error

--- a/tests/utility.py
+++ b/tests/utility.py
@@ -14,11 +14,17 @@ def get_parents(node: StrategyNode):
     return output
 
 
-def validate_shape(input: list[Concept], environment: Environment, g, levels, error: str | None = None):
+def validate_shape(
+    input: list[Concept], environment: Environment, g, levels, error: str | None = None
+):
     """test that our query resolves to the expected CTES"""
     base: GroupNode = source_query_concepts(input, environment, g)
     DebuggingHook(INFO).process_root_strategy_node(base)
     final = get_parents(base)
-    default_error = "\n".join([str(x) for x in final]) + "\nvs\n" + "\n".join([str(x) for x in levels])
+    default_error = (
+        "\n".join([str(x) for x in final])
+        + "\nvs\n"
+        + "\n".join([str(x) for x in levels])
+    )
 
     assert final == levels, error or default_error

--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -1,8 +1,8 @@
+from trilogy.constants import CONFIG
 from trilogy.core.models import Environment
 from trilogy.dialect.enums import Dialects
 from trilogy.executor import Executor
 from trilogy.parser import parse
-from trilogy.constants import CONFIG
 
 __version__ = "0.0.2.47"
 

--- a/trilogy/constants.py
+++ b/trilogy/constants.py
@@ -1,7 +1,7 @@
-from logging import getLogger
+import random
 from dataclasses import dataclass, field
 from enum import Enum
-import random
+from logging import getLogger
 
 logger = getLogger("trilogy")
 

--- a/trilogy/core/enums.py
+++ b/trilogy/core/enums.py
@@ -44,6 +44,7 @@ class PurposeLineage(Enum):
     FILTER = "filter"
     CONSTANT = "constant"
     UNNEST = "unnest"
+    UNION = "union"
     ROOT = "root"
     ROWSET = "rowset"
     MULTISELECT = "multiselect"
@@ -113,6 +114,9 @@ class FunctionType(Enum):
 
     # structural
     UNNEST = "unnest"
+
+    UNION = "union"
+
     ALIAS = "alias"
 
     # Generic
@@ -133,6 +137,7 @@ class FunctionType(Enum):
 
     # TEXT AND MAYBE MORE
     SPLIT = "split"
+    LENGTH = "len"
 
     # Math
     DIVIDE = "divide"
@@ -154,7 +159,6 @@ class FunctionType(Enum):
     MAX = "max"
     MIN = "min"
     AVG = "avg"
-    LENGTH = "len"
 
     # String
     LIKE = "like"
@@ -299,6 +303,7 @@ class SourceType(Enum):
     ROWSET = "rowset"
     MERGE = "merge"
     BASIC = "basic"
+    UNION = "union"
 
 
 class ShowCategory(Enum):

--- a/trilogy/core/env_processor.py
+++ b/trilogy/core/env_processor.py
@@ -3,12 +3,10 @@ from trilogy.core.graph_models import (
     concept_to_node,
     datasource_to_node,
 )
-from trilogy.core.models import Environment, Concept, Datasource
+from trilogy.core.models import Concept, Datasource, Environment
 
 
-def add_concept(
-    concept: Concept, g: ReferenceGraph, concept_mapping: dict[str, Concept]
-):
+def add_concept(concept: Concept, g: ReferenceGraph, concept_mapping: dict[str, Concept]):
     g.add_node(concept)
     # if we have sources, recursively add them
     node_name = concept_to_node(concept)
@@ -68,9 +66,7 @@ def generate_adhoc_graph(
 def generate_graph(
     environment: Environment,
 ) -> ReferenceGraph:
-
     return generate_adhoc_graph(
-        list(environment.concepts.values())
-        + list(environment.alias_origin_lookup.values()),
+        list(environment.concepts.values()) + list(environment.alias_origin_lookup.values()),
         list(environment.datasources.values()),
     )

--- a/trilogy/core/env_processor.py
+++ b/trilogy/core/env_processor.py
@@ -6,7 +6,9 @@ from trilogy.core.graph_models import (
 from trilogy.core.models import Concept, Datasource, Environment
 
 
-def add_concept(concept: Concept, g: ReferenceGraph, concept_mapping: dict[str, Concept]):
+def add_concept(
+    concept: Concept, g: ReferenceGraph, concept_mapping: dict[str, Concept]
+):
     g.add_node(concept)
     # if we have sources, recursively add them
     node_name = concept_to_node(concept)
@@ -67,6 +69,7 @@ def generate_graph(
     environment: Environment,
 ) -> ReferenceGraph:
     return generate_adhoc_graph(
-        list(environment.concepts.values()) + list(environment.alias_origin_lookup.values()),
+        list(environment.concepts.values())
+        + list(environment.alias_origin_lookup.values()),
         list(environment.datasources.values()),
     )

--- a/trilogy/core/environment_helpers.py
+++ b/trilogy/core/environment_helpers.py
@@ -1,15 +1,15 @@
+from trilogy.constants import DEFAULT_NAMESPACE
+from trilogy.core.enums import ConceptSource, FunctionType, Purpose
+from trilogy.core.functions import AttrAccess
 from trilogy.core.models import (
-    DataType,
     Concept,
+    DataType,
     Environment,
     Function,
     Metadata,
     StructType,
 )
-from trilogy.core.functions import AttrAccess
-from trilogy.core.enums import Purpose, FunctionType, ConceptSource
-from trilogy.constants import DEFAULT_NAMESPACE
-from trilogy.parsing.common import process_function_args, arg_to_datatype, Meta
+from trilogy.parsing.common import Meta, arg_to_datatype, process_function_args
 
 
 def generate_date_concepts(concept: Concept, environment: Environment):
@@ -29,20 +29,14 @@ def generate_date_concepts(concept: Concept, environment: Environment):
         FunctionType.DAY_OF_WEEK,
     ]:
         fname = ftype.name.lower()
-        default_type = (
-            Purpose.CONSTANT
-            if concept.purpose == Purpose.CONSTANT
-            else Purpose.PROPERTY
-        )
+        default_type = Purpose.CONSTANT if concept.purpose == Purpose.CONSTANT else Purpose.PROPERTY
         const_function: Function = Function(
             operator=ftype,
             output_datatype=DataType.INTEGER,
             output_purpose=default_type,
             arguments=[concept],
         )
-        namespace = (
-            None if concept.namespace == DEFAULT_NAMESPACE else concept.namespace
-        )
+        namespace = None if concept.namespace == DEFAULT_NAMESPACE else concept.namespace
         new_concept = Concept(
             name=f"{concept.name}.{fname}",
             datatype=DataType.INTEGER,
@@ -78,20 +72,14 @@ def generate_datetime_concepts(concept: Concept, environment: Environment):
         FunctionType.SECOND,
     ]:
         fname = ftype.name.lower()
-        default_type = (
-            Purpose.CONSTANT
-            if concept.purpose == Purpose.CONSTANT
-            else Purpose.PROPERTY
-        )
+        default_type = Purpose.CONSTANT if concept.purpose == Purpose.CONSTANT else Purpose.PROPERTY
         const_function: Function = Function(
             operator=ftype,
             output_datatype=DataType.INTEGER,
             output_purpose=default_type,
             arguments=[concept],
         )
-        namespace = (
-            None if concept.namespace == DEFAULT_NAMESPACE else concept.namespace
-        )
+        namespace = None if concept.namespace == DEFAULT_NAMESPACE else concept.namespace
         new_concept = Concept(
             name=f"{concept.name}.{fname}",
             datatype=DataType.INTEGER,
@@ -129,9 +117,7 @@ def generate_key_concepts(concept: Concept, environment: Environment):
             output_purpose=default_type,
             arguments=[concept],
         )
-        namespace = (
-            None if concept.namespace == DEFAULT_NAMESPACE else concept.namespace
-        )
+        namespace = None if concept.namespace == DEFAULT_NAMESPACE else concept.namespace
         new_concept = Concept(
             name=f"{concept.name}.{fname}",
             datatype=DataType.INTEGER,
@@ -173,19 +159,12 @@ def generate_related_concepts(
 
     if isinstance(concept.datatype, StructType):
         for key, value in concept.datatype.fields_map.items():
-            args = process_function_args(
-                [concept, key], meta=meta, environment=environment
-            )
+            args = process_function_args([concept, key], meta=meta, environment=environment)
             auto = Concept(
                 name=key,
                 datatype=arg_to_datatype(value),
                 purpose=Purpose.PROPERTY,
-                namespace=(
-                    environment.namespace + "." + concept.name
-                    if environment.namespace
-                    and environment.namespace != DEFAULT_NAMESPACE
-                    else concept.name
-                ),
+                namespace=(environment.namespace + "." + concept.name if environment.namespace and environment.namespace != DEFAULT_NAMESPACE else concept.name),
                 lineage=AttrAccess(args),
             )
             environment.add_concept(auto, meta=meta)

--- a/trilogy/core/environment_helpers.py
+++ b/trilogy/core/environment_helpers.py
@@ -29,14 +29,20 @@ def generate_date_concepts(concept: Concept, environment: Environment):
         FunctionType.DAY_OF_WEEK,
     ]:
         fname = ftype.name.lower()
-        default_type = Purpose.CONSTANT if concept.purpose == Purpose.CONSTANT else Purpose.PROPERTY
+        default_type = (
+            Purpose.CONSTANT
+            if concept.purpose == Purpose.CONSTANT
+            else Purpose.PROPERTY
+        )
         const_function: Function = Function(
             operator=ftype,
             output_datatype=DataType.INTEGER,
             output_purpose=default_type,
             arguments=[concept],
         )
-        namespace = None if concept.namespace == DEFAULT_NAMESPACE else concept.namespace
+        namespace = (
+            None if concept.namespace == DEFAULT_NAMESPACE else concept.namespace
+        )
         new_concept = Concept(
             name=f"{concept.name}.{fname}",
             datatype=DataType.INTEGER,
@@ -72,14 +78,20 @@ def generate_datetime_concepts(concept: Concept, environment: Environment):
         FunctionType.SECOND,
     ]:
         fname = ftype.name.lower()
-        default_type = Purpose.CONSTANT if concept.purpose == Purpose.CONSTANT else Purpose.PROPERTY
+        default_type = (
+            Purpose.CONSTANT
+            if concept.purpose == Purpose.CONSTANT
+            else Purpose.PROPERTY
+        )
         const_function: Function = Function(
             operator=ftype,
             output_datatype=DataType.INTEGER,
             output_purpose=default_type,
             arguments=[concept],
         )
-        namespace = None if concept.namespace == DEFAULT_NAMESPACE else concept.namespace
+        namespace = (
+            None if concept.namespace == DEFAULT_NAMESPACE else concept.namespace
+        )
         new_concept = Concept(
             name=f"{concept.name}.{fname}",
             datatype=DataType.INTEGER,
@@ -117,7 +129,9 @@ def generate_key_concepts(concept: Concept, environment: Environment):
             output_purpose=default_type,
             arguments=[concept],
         )
-        namespace = None if concept.namespace == DEFAULT_NAMESPACE else concept.namespace
+        namespace = (
+            None if concept.namespace == DEFAULT_NAMESPACE else concept.namespace
+        )
         new_concept = Concept(
             name=f"{concept.name}.{fname}",
             datatype=DataType.INTEGER,
@@ -159,12 +173,19 @@ def generate_related_concepts(
 
     if isinstance(concept.datatype, StructType):
         for key, value in concept.datatype.fields_map.items():
-            args = process_function_args([concept, key], meta=meta, environment=environment)
+            args = process_function_args(
+                [concept, key], meta=meta, environment=environment
+            )
             auto = Concept(
                 name=key,
                 datatype=arg_to_datatype(value),
                 purpose=Purpose.PROPERTY,
-                namespace=(environment.namespace + "." + concept.name if environment.namespace and environment.namespace != DEFAULT_NAMESPACE else concept.name),
+                namespace=(
+                    environment.namespace + "." + concept.name
+                    if environment.namespace
+                    and environment.namespace != DEFAULT_NAMESPACE
+                    else concept.name
+                ),
                 lineage=AttrAccess(args),
             )
             environment.add_concept(auto, meta=meta)

--- a/trilogy/core/ergonomics.py
+++ b/trilogy/core/ergonomics.py
@@ -179,7 +179,9 @@ thrush
 toucan
 turkey
 vulture
-warbler""".split("\n")
+warbler""".split(
+    "\n"
+)
 
 
 def generate_cte_names():

--- a/trilogy/core/ergonomics.py
+++ b/trilogy/core/ergonomics.py
@@ -179,9 +179,7 @@ thrush
 toucan
 turkey
 vulture
-warbler""".split(
-    "\n"
-)
+warbler""".split("\n")
 
 
 def generate_cte_names():

--- a/trilogy/core/functions.py
+++ b/trilogy/core/functions.py
@@ -1,20 +1,21 @@
+from typing import Optional
+
+from trilogy.constants import MagicConstants
+from trilogy.core.enums import DatePart, FunctionType, Granularity, Purpose
+from trilogy.core.exceptions import InvalidSyntaxException
 from trilogy.core.models import (
-    Function,
-    Concept,
     AggregateWrapper,
-    Parenthetical,
-    arg_to_datatype,
-    WindowItem,
+    Concept,
     DataType,
+    Function,
     ListType,
-    StructType,
     MapType,
     NumericType,
+    Parenthetical,
+    StructType,
+    WindowItem,
+    arg_to_datatype,
 )
-from trilogy.core.enums import FunctionType, Purpose, Granularity, DatePart
-from trilogy.core.exceptions import InvalidSyntaxException
-from trilogy.constants import MagicConstants
-from typing import Optional
 
 
 def create_function_derived_concept(
@@ -22,16 +23,10 @@ def create_function_derived_concept(
     namespace: str,
     operator: FunctionType,
     arguments: list[Concept],
-    output_type: Optional[
-        DataType | ListType | StructType | MapType | NumericType
-    ] = None,
+    output_type: Optional[DataType | ListType | StructType | MapType | NumericType] = None,
     output_purpose: Optional[Purpose] = None,
 ) -> Concept:
-    purpose = (
-        function_args_to_output_purpose(arguments)
-        if output_purpose is None
-        else output_purpose
-    )
+    purpose = function_args_to_output_purpose(arguments) if output_purpose is None else output_purpose
     output_type = arg_to_datatype(arguments[0]) if output_type is None else output_type
     return Concept(
         name=name,
@@ -62,11 +57,7 @@ def argument_to_purpose(arg) -> Purpose:
         return Purpose.PROPERTY
     elif isinstance(arg, Concept):
         base = arg.purpose
-        if (
-            isinstance(arg.lineage, AggregateWrapper)
-            and arg.lineage.by
-            and base == Purpose.METRIC
-        ):
+        if isinstance(arg.lineage, AggregateWrapper) and arg.lineage.by and base == Purpose.METRIC:
             return Purpose.PROPERTY
         return arg.purpose
     elif isinstance(arg, (int, float, str, bool, list, NumericType, DataType)):
@@ -253,9 +244,7 @@ def MapAccess(args: list[Concept]):
     )
 
 
-def get_attr_datatype(
-    arg: Concept, lookup
-) -> DataType | ListType | StructType | MapType | NumericType:
+def get_attr_datatype(arg: Concept, lookup) -> DataType | ListType | StructType | MapType | NumericType:
     if isinstance(arg.datatype, StructType):
         return arg_to_datatype(arg.datatype.fields_map[lookup])
     return arg.datatype
@@ -296,9 +285,7 @@ def Abs(args: list[Concept]) -> Function:
 def Coalesce(args: list[Concept]) -> Function:
     non_null = [x for x in args if not x == MagicConstants.NULL]
     if not len(set(arg_to_datatype(x) for x in non_null if x)) == 1:
-        raise InvalidSyntaxException(
-            f"All arguments to coalesce must be of the same type, have {set(arg_to_datatype(x) for x in args)}"
-        )
+        raise InvalidSyntaxException(f"All arguments to coalesce must be of the same type, have {set(arg_to_datatype(x) for x in args)}")
     return Function(
         operator=FunctionType.COALESCE,
         arguments=args,

--- a/trilogy/core/functions.py
+++ b/trilogy/core/functions.py
@@ -23,10 +23,16 @@ def create_function_derived_concept(
     namespace: str,
     operator: FunctionType,
     arguments: list[Concept],
-    output_type: Optional[DataType | ListType | StructType | MapType | NumericType] = None,
+    output_type: Optional[
+        DataType | ListType | StructType | MapType | NumericType
+    ] = None,
     output_purpose: Optional[Purpose] = None,
 ) -> Concept:
-    purpose = function_args_to_output_purpose(arguments) if output_purpose is None else output_purpose
+    purpose = (
+        function_args_to_output_purpose(arguments)
+        if output_purpose is None
+        else output_purpose
+    )
     output_type = arg_to_datatype(arguments[0]) if output_type is None else output_type
     return Concept(
         name=name,
@@ -57,7 +63,11 @@ def argument_to_purpose(arg) -> Purpose:
         return Purpose.PROPERTY
     elif isinstance(arg, Concept):
         base = arg.purpose
-        if isinstance(arg.lineage, AggregateWrapper) and arg.lineage.by and base == Purpose.METRIC:
+        if (
+            isinstance(arg.lineage, AggregateWrapper)
+            and arg.lineage.by
+            and base == Purpose.METRIC
+        ):
             return Purpose.PROPERTY
         return arg.purpose
     elif isinstance(arg, (int, float, str, bool, list, NumericType, DataType)):
@@ -244,7 +254,9 @@ def MapAccess(args: list[Concept]):
     )
 
 
-def get_attr_datatype(arg: Concept, lookup) -> DataType | ListType | StructType | MapType | NumericType:
+def get_attr_datatype(
+    arg: Concept, lookup
+) -> DataType | ListType | StructType | MapType | NumericType:
     if isinstance(arg.datatype, StructType):
         return arg_to_datatype(arg.datatype.fields_map[lookup])
     return arg.datatype
@@ -285,7 +297,9 @@ def Abs(args: list[Concept]) -> Function:
 def Coalesce(args: list[Concept]) -> Function:
     non_null = [x for x in args if not x == MagicConstants.NULL]
     if not len(set(arg_to_datatype(x) for x in non_null if x)) == 1:
-        raise InvalidSyntaxException(f"All arguments to coalesce must be of the same type, have {set(arg_to_datatype(x) for x in args)}")
+        raise InvalidSyntaxException(
+            f"All arguments to coalesce must be of the same type, have {set(arg_to_datatype(x) for x in args)}"
+        )
     return Function(
         operator=FunctionType.COALESCE,
         arguments=args,

--- a/trilogy/core/internal.py
+++ b/trilogy/core/internal.py
@@ -1,7 +1,6 @@
-from trilogy.core.models import Concept, DataType, Function
-from trilogy.core.enums import Purpose, FunctionType
 from trilogy.core.constants import ALL_ROWS_CONCEPT, INTERNAL_NAMESPACE
-
+from trilogy.core.enums import FunctionType, Purpose
+from trilogy.core.models import Concept, DataType, Function
 
 DEFAULT_CONCEPTS = {
     ALL_ROWS_CONCEPT: Concept(

--- a/trilogy/core/models.py
+++ b/trilogy/core/models.py
@@ -75,8 +75,8 @@ from trilogy.core.enums import (
     WindowType,
 )
 from trilogy.core.exceptions import (
-    UndefinedConceptException,
     InvalidSyntaxException,
+    UndefinedConceptException,
 )
 from trilogy.utility import unique
 

--- a/trilogy/core/models.py
+++ b/trilogy/core/models.py
@@ -135,7 +135,9 @@ def get_concept_arguments(expr) -> List["Concept"]:
     return output
 
 
-ALL_TYPES = Union["DataType", "MapType", "ListType", "NumericType", "StructType", "Concept"]
+ALL_TYPES = Union[
+    "DataType", "MapType", "ListType", "NumericType", "StructType", "Concept"
+]
 
 NAMESPACED_TYPES = Union[
     "WindowItem",
@@ -208,11 +210,19 @@ class SelectTypeMixin(BaseModel):
     def implicit_where_clause_selections(self) -> List[Concept]:
         if not self.where_clause:
             return []
-        filter = set([str(x.address) for x in self.where_clause.row_arguments if not x.derivation == PurposeLineage.CONSTANT])
+        filter = set(
+            [
+                str(x.address)
+                for x in self.where_clause.row_arguments
+                if not x.derivation == PurposeLineage.CONSTANT
+            ]
+        )
         query_output = set([str(z.address) for z in self.output_components])
         delta = filter.difference(query_output)
         if delta:
-            return [x for x in self.where_clause.row_arguments if str(x.address) in delta]
+            return [
+                x for x in self.where_clause.row_arguments if str(x.address) in delta
+            ]
         return []
 
     @property
@@ -341,7 +351,9 @@ class ListWrapper(Generic[VT], UserList):
         self.type = type
 
     @classmethod
-    def __get_pydantic_core_schema__(cls, source_type: Any, handler: Callable[[Any], core_schema.CoreSchema]) -> core_schema.CoreSchema:
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: Callable[[Any], core_schema.CoreSchema]
+    ) -> core_schema.CoreSchema:
         args = get_args(source_type)
         if args:
             schema = handler(List[args])  # type: ignore
@@ -363,7 +375,9 @@ class MapWrapper(Generic[KT, VT], UserDict):
         self.value_type = value_type
 
     @classmethod
-    def __get_pydantic_core_schema__(cls, source_type: Any, handler: Callable[[Any], core_schema.CoreSchema]) -> core_schema.CoreSchema:
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: Callable[[Any], core_schema.CoreSchema]
+    ) -> core_schema.CoreSchema:
         args = get_args(source_type)
         if args:
             schema = handler(Dict[args])  # type: ignore
@@ -389,7 +403,9 @@ class Metadata(BaseModel):
     concept_source: ConceptSource = ConceptSource.MANUAL
 
 
-def lineage_validator(v: Any, handler: ValidatorFunctionWrapHandler, info: ValidationInfo) -> Union[Function, WindowItem, FilterItem, AggregateWrapper]:
+def lineage_validator(
+    v: Any, handler: ValidatorFunctionWrapHandler, info: ValidationInfo
+) -> Union[Function, WindowItem, FilterItem, AggregateWrapper]:
     if v and not isinstance(v, (Function, WindowItem, FilterItem, AggregateWrapper)):
         raise ValueError(v)
     return v
@@ -442,9 +458,18 @@ class Concept(Mergeable, Namespaced, SelectContext, BaseModel):
 
     @property
     def is_aggregate(self):
-        if self.lineage and isinstance(self.lineage, Function) and self.lineage.operator in FunctionClass.AGGREGATE_FUNCTIONS.value:
+        if (
+            self.lineage
+            and isinstance(self.lineage, Function)
+            and self.lineage.operator in FunctionClass.AGGREGATE_FUNCTIONS.value
+        ):
             return True
-        if self.lineage and isinstance(self.lineage, AggregateWrapper) and self.lineage.function.operator in FunctionClass.AGGREGATE_FUNCTIONS.value:
+        if (
+            self.lineage
+            and isinstance(self.lineage, AggregateWrapper)
+            and self.lineage.function.operator
+            in FunctionClass.AGGREGATE_FUNCTIONS.value
+        ):
             return True
         return False
 
@@ -458,10 +483,18 @@ class Concept(Mergeable, Namespaced, SelectContext, BaseModel):
             datatype=self.datatype,
             purpose=self.purpose,
             metadata=self.metadata,
-            lineage=(self.lineage.with_merge(source, target, modifiers) if self.lineage else None),
+            lineage=(
+                self.lineage.with_merge(source, target, modifiers)
+                if self.lineage
+                else None
+            ),
             grain=self.grain.with_merge(source, target, modifiers),
             namespace=self.namespace,
-            keys=(tuple(x.with_merge(source, target, modifiers) for x in self.keys) if self.keys else None),
+            keys=(
+                tuple(x.with_merge(source, target, modifiers) for x in self.keys)
+                if self.keys
+                else None
+            ),
             modifiers=self.modifiers,
             pseudonyms=self.pseudonyms,
         )
@@ -512,7 +545,11 @@ class Concept(Mergeable, Namespaced, SelectContext, BaseModel):
                     )
                 ]
             )
-        elif "lineage" in values and isinstance(values["lineage"], AggregateWrapper) and values["lineage"].by:
+        elif (
+            "lineage" in values
+            and isinstance(values["lineage"], AggregateWrapper)
+            and values["lineage"].by
+        ):
             v = Grain(components=values["lineage"].by)
         elif not v:
             v = Grain(components=[])
@@ -531,7 +568,11 @@ class Concept(Mergeable, Namespaced, SelectContext, BaseModel):
         if not isinstance(other, Concept):
             return False
         return (
-            self.name == other.name and self.datatype == other.datatype and self.purpose == other.purpose and self.namespace == other.namespace and self.grain == other.grain
+            self.name == other.name
+            and self.datatype == other.datatype
+            and self.purpose == other.purpose
+            and self.namespace == other.namespace
+            and self.grain == other.grain
             # and self.keys == other.keys
         )
 
@@ -575,9 +616,23 @@ class Concept(Mergeable, Namespaced, SelectContext, BaseModel):
             purpose=self.purpose,
             metadata=self.metadata,
             lineage=self.lineage.with_namespace(namespace) if self.lineage else None,
-            grain=(self.grain.with_namespace(namespace) if self.grain else Grain(components=[])),
-            namespace=(namespace + "." + self.namespace if self.namespace and self.namespace != DEFAULT_NAMESPACE and self.namespace != namespace else namespace),
-            keys=(tuple([x.with_namespace(namespace) for x in self.keys]) if self.keys else None),
+            grain=(
+                self.grain.with_namespace(namespace)
+                if self.grain
+                else Grain(components=[])
+            ),
+            namespace=(
+                namespace + "." + self.namespace
+                if self.namespace
+                and self.namespace != DEFAULT_NAMESPACE
+                and self.namespace != namespace
+                else namespace
+            ),
+            keys=(
+                tuple([x.with_namespace(namespace) for x in self.keys])
+                if self.keys
+                else None
+            ),
             modifiers=self.modifiers,
             pseudonyms={address_with_namespace(v, namespace) for v in self.pseudonyms},
         )
@@ -593,7 +648,9 @@ class Concept(Mergeable, Namespaced, SelectContext, BaseModel):
         new_grain = grain or self.grain
         new_lineage = self.lineage
         if isinstance(self.lineage, SelectContext):
-            new_lineage = self.lineage.with_select_context(new_grain, conditional, environment=environment)
+            new_lineage = self.lineage.with_select_context(
+                new_grain, conditional, environment=environment
+            )
         return self.__class__(
             name=self.name,
             datatype=self.datatype,
@@ -684,7 +741,9 @@ class Concept(Mergeable, Namespaced, SelectContext, BaseModel):
                 for item in expr.arguments:
                     if isinstance(item, Concept):
                         if item.address == self.address:
-                            raise SyntaxError(f"Concept {self.address} references itself")
+                            raise SyntaxError(
+                                f"Concept {self.address} references itself"
+                            )
                         output.append(item)
                         output += item.sources
                     elif isinstance(item, Function):
@@ -714,19 +773,40 @@ class Concept(Mergeable, Namespaced, SelectContext, BaseModel):
             return PurposeLineage.ROWSET
         elif self.lineage and isinstance(self.lineage, MultiSelectStatement):
             return PurposeLineage.MULTISELECT
-        elif self.lineage and isinstance(self.lineage, Function) and self.lineage.operator in FunctionClass.AGGREGATE_FUNCTIONS.value:
+        elif (
+            self.lineage
+            and isinstance(self.lineage, Function)
+            and self.lineage.operator in FunctionClass.AGGREGATE_FUNCTIONS.value
+        ):
             return PurposeLineage.AGGREGATE
-        elif self.lineage and isinstance(self.lineage, Function) and self.lineage.operator == FunctionType.UNNEST:
+        elif (
+            self.lineage
+            and isinstance(self.lineage, Function)
+            and self.lineage.operator == FunctionType.UNNEST
+        ):
             return PurposeLineage.UNNEST
-        elif self.lineage and isinstance(self.lineage, Function) and self.lineage.operator == FunctionType.UNION:
+        elif (
+            self.lineage
+            and isinstance(self.lineage, Function)
+            and self.lineage.operator == FunctionType.UNION
+        ):
             return PurposeLineage.UNION
-        elif self.lineage and isinstance(self.lineage, Function) and self.lineage.operator in FunctionClass.SINGLE_ROW.value:
+        elif (
+            self.lineage
+            and isinstance(self.lineage, Function)
+            and self.lineage.operator in FunctionClass.SINGLE_ROW.value
+        ):
             return PurposeLineage.CONSTANT
 
         elif self.lineage and isinstance(self.lineage, Function):
             if not self.lineage.concept_arguments:
                 return PurposeLineage.CONSTANT
-            elif all([x.derivation == PurposeLineage.CONSTANT for x in self.lineage.concept_arguments]):
+            elif all(
+                [
+                    x.derivation == PurposeLineage.CONSTANT
+                    for x in self.lineage.concept_arguments
+                ]
+            ):
                 return PurposeLineage.CONSTANT
             return PurposeLineage.BASIC
         elif self.purpose == Purpose.CONSTANT:
@@ -747,9 +827,18 @@ class Concept(Mergeable, Namespaced, SelectContext, BaseModel):
                 return Granularity.SINGLE_ROW
         elif self.namespace == INTERNAL_NAMESPACE and self.name == ALL_ROWS_CONCEPT:
             return Granularity.SINGLE_ROW
-        elif self.lineage and isinstance(self.lineage, Function) and self.lineage.operator in (FunctionType.UNNEST, FunctionType.UNION):
+        elif (
+            self.lineage
+            and isinstance(self.lineage, Function)
+            and self.lineage.operator in (FunctionType.UNNEST, FunctionType.UNION)
+        ):
             return Granularity.MULTI_ROW
-        elif self.lineage and all([x.granularity == Granularity.SINGLE_ROW for x in self.lineage.concept_arguments]):
+        elif self.lineage and all(
+            [
+                x.granularity == Granularity.SINGLE_ROW
+                for x in self.lineage.concept_arguments
+            ]
+        ):
             return Granularity.SINGLE_ROW
         return Granularity.MULTI_ROW
 
@@ -790,7 +879,9 @@ class Grain(Mergeable, BaseModel):
     def component_validator(cls, v, info: ValidationInfo):
         values = info.data
         if not values.get("nested", False):
-            v2: List[Concept] = unique([safe_concept(c).with_default_grain() for c in v], "address")
+            v2: List[Concept] = unique(
+                [safe_concept(c).with_default_grain() for c in v], "address"
+            )
         else:
             v2 = unique(v, "address")
         final: List[Concept] = []
@@ -831,15 +922,21 @@ class Grain(Mergeable, BaseModel):
             nested=self.nested,
         )
 
-    def with_merge(self, source: Concept, target: Concept, modifiers: List[Modifier]) -> "Grain":
+    def with_merge(
+        self, source: Concept, target: Concept, modifiers: List[Modifier]
+    ) -> "Grain":
         return Grain(
-            components=[x.with_merge(source, target, modifiers) for x in self.components],
+            components=[
+                x.with_merge(source, target, modifiers) for x in self.components
+            ],
             nested=self.nested,
         )
 
     @property
     def abstract(self):
-        return not self.components or all([c.name == ALL_ROWS_CONCEPT for c in self.components])
+        return not self.components or all(
+            [c.name == ALL_ROWS_CONCEPT for c in self.components]
+        )
 
     @property
     def synonym_set(self) -> set[str]:
@@ -882,7 +979,10 @@ class Grain(Mergeable, BaseModel):
     def union(self, other: "Grain"):
         addresses = self.set.union(other.set)
 
-        return Grain(components=[c for c in self.components if c.address in addresses] + [c for c in other.components if c.address in addresses])
+        return Grain(
+            components=[c for c in self.components if c.address in addresses]
+            + [c for c in other.components if c.address in addresses]
+        )
 
     def isdisjoint(self, other: "Grain"):
         return self.set.isdisjoint(other.set)
@@ -901,9 +1001,14 @@ class Grain(Mergeable, BaseModel):
                 components.append(component.with_default_grain())
         base_components = [c for c in components if c.purpose == Purpose.KEY]
         for c in components:
-            if c.purpose == Purpose.PROPERTY and not any([key in base_components for key in (c.keys or [])]):
+            if c.purpose == Purpose.PROPERTY and not any(
+                [key in base_components for key in (c.keys or [])]
+            ):
                 base_components.append(c)
-            elif c.purpose == Purpose.CONSTANT and not c.derivation == PurposeLineage.CONSTANT:
+            elif (
+                c.purpose == Purpose.CONSTANT
+                and not c.derivation == PurposeLineage.CONSTANT
+            ):
                 base_components.append(c)
         return Grain(components=base_components)
 
@@ -933,16 +1038,24 @@ class ColumnAssignment(BaseModel):
 
     def with_namespace(self, namespace: str) -> "ColumnAssignment":
         return ColumnAssignment(
-            alias=(self.alias.with_namespace(namespace) if isinstance(self.alias, Function) else self.alias),
+            alias=(
+                self.alias.with_namespace(namespace)
+                if isinstance(self.alias, Function)
+                else self.alias
+            ),
             concept=self.concept.with_namespace(namespace),
             modifiers=self.modifiers,
         )
 
-    def with_merge(self, source: Concept, target: Concept, modifiers: List[Modifier]) -> "ColumnAssignment":
+    def with_merge(
+        self, source: Concept, target: Concept, modifiers: List[Modifier]
+    ) -> "ColumnAssignment":
         return ColumnAssignment(
             alias=self.alias,
             concept=self.concept.with_merge(source, target, modifiers),
-            modifiers=(modifiers if self.concept.address == source.address else self.modifiers),
+            modifiers=(
+                modifiers if self.concept.address == source.address else self.modifiers
+            ),
         )
 
 
@@ -1056,7 +1169,10 @@ class Function(Mergeable, Namespaced, SelectContext, BaseModel):
                 )
                 for c in self.arguments
             ]
-            final = [c.with_filter(conditional, environment) if isinstance(c, Concept) else c for c in base]
+            final = [
+                c.with_filter(conditional, environment) if isinstance(c, Concept) else c
+                for c in base
+            ]
             return Function(
                 operator=self.operator,
                 arguments=final,
@@ -1100,7 +1216,10 @@ class Function(Mergeable, Namespaced, SelectContext, BaseModel):
         valid_inputs = values["valid_inputs"]
         if not arg_count <= target_arg_count:
             if target_arg_count != InfiniteFunctionArgs:
-                raise ParseError(f"Incorrect argument count to {operator_name} function, expects" f" {target_arg_count}, got {arg_count}")
+                raise ParseError(
+                    f"Incorrect argument count to {operator_name} function, expects"
+                    f" {target_arg_count}, got {arg_count}"
+                )
         # if all arguments can be any of the set type
         # turn this into an array for validation
         if isinstance(valid_inputs, set):
@@ -1108,12 +1227,24 @@ class Function(Mergeable, Namespaced, SelectContext, BaseModel):
         elif not valid_inputs:
             return v
         for idx, arg in enumerate(v):
-            if isinstance(arg, Concept) and arg.datatype.data_type not in valid_inputs[idx]:
+            if (
+                isinstance(arg, Concept)
+                and arg.datatype.data_type not in valid_inputs[idx]
+            ):
                 if arg.datatype != DataType.UNKNOWN:
-                    raise TypeError(f"Invalid input datatype {arg.datatype.data_type} passed into position {idx}" f" for {operator_name} from concept {arg.name}, valid is {valid_inputs[idx]}")
-            if isinstance(arg, Function) and arg.output_datatype not in valid_inputs[idx]:
+                    raise TypeError(
+                        f"Invalid input datatype {arg.datatype.data_type} passed into position {idx}"
+                        f" for {operator_name} from concept {arg.name}, valid is {valid_inputs[idx]}"
+                    )
+            if (
+                isinstance(arg, Function)
+                and arg.output_datatype not in valid_inputs[idx]
+            ):
                 if arg.output_datatype != DataType.UNKNOWN:
-                    raise TypeError(f"Invalid input datatype {arg.output_datatype} passed into" f" {operator_name} from function {arg.operator.name}")
+                    raise TypeError(
+                        f"Invalid input datatype {arg.output_datatype} passed into"
+                        f" {operator_name} from function {arg.operator.name}"
+                    )
             # check constants
             comparisons: List[Tuple[Type, DataType]] = [
                 (str, DataType.STRING),
@@ -1127,7 +1258,9 @@ class Function(Mergeable, Namespaced, SelectContext, BaseModel):
                     # attempt to exit early to avoid checking all types
                     break
                 elif isinstance(arg, ptype):
-                    raise TypeError(f"Invalid {dtype} constant passed into {operator_name} {arg}, expecting one of {valid_inputs[idx]}")
+                    raise TypeError(
+                        f"Invalid {dtype} constant passed into {operator_name} {arg}, expecting one of {valid_inputs[idx]}"
+                    )
         return v
 
     def with_namespace(self, namespace: str) -> "Function":
@@ -1150,7 +1283,9 @@ class Function(Mergeable, Namespaced, SelectContext, BaseModel):
             arg_count=self.arg_count,
         )
 
-    def with_merge(self, source: Concept, target: Concept, modifiers: List[Modifier]) -> "Function":
+    def with_merge(
+        self, source: Concept, target: Concept, modifiers: List[Modifier]
+    ) -> "Function":
         return Function(
             operator=self.operator,
             arguments=[
@@ -1342,7 +1477,9 @@ class FilterItem(Namespaced, SelectContext, BaseModel):
     def __str__(self):
         return f"<Filter: {str(self.content)} where {str(self.where)}>"
 
-    def with_merge(self, source: Concept, target: Concept, modifiers: List[Modifier]) -> "FilterItem":
+    def with_merge(
+        self, source: Concept, target: Concept, modifiers: List[Modifier]
+    ) -> "FilterItem":
         return FilterItem(
             content=source.with_merge(source, target, modifiers),
             where=self.where.with_merge(source, target, modifiers),
@@ -1419,7 +1556,9 @@ class SelectItem(Mergeable, Namespaced, BaseModel):
     def input(self) -> List[Concept]:
         return self.content.input
 
-    def with_merge(self, source: Concept, target: Concept, modifiers: List[Modifier]) -> "SelectItem":
+    def with_merge(
+        self, source: Concept, target: Concept, modifiers: List[Modifier]
+    ) -> "SelectItem":
         return SelectItem(
             content=self.content.with_merge(source, target, modifiers),
             modifiers=modifiers,
@@ -1446,12 +1585,18 @@ class OrderItem(Mergeable, SelectContext, Namespaced, BaseModel):
         environment: Environment | None = None,
     ) -> "OrderItem":
         return OrderItem(
-            expr=self.expr.with_select_context(grain, conditional=conditional, environment=environment),
+            expr=self.expr.with_select_context(
+                grain, conditional=conditional, environment=environment
+            ),
             order=self.order,
         )
 
-    def with_merge(self, source: Concept, target: Concept, modifiers: List[Modifier]) -> "OrderItem":
-        return OrderItem(expr=source.with_merge(source, target, modifiers), order=self.order)
+    def with_merge(
+        self, source: Concept, target: Concept, modifiers: List[Modifier]
+    ) -> "OrderItem":
+        return OrderItem(
+            expr=source.with_merge(source, target, modifiers), order=self.order
+        )
 
     @property
     def input(self):
@@ -1468,8 +1613,12 @@ class OrderBy(Mergeable, Namespaced, BaseModel):
     def with_namespace(self, namespace: str) -> "OrderBy":
         return OrderBy(items=[x.with_namespace(namespace) for x in self.items])
 
-    def with_merge(self, source: Concept, target: Concept, modifiers: List[Modifier]) -> "OrderBy":
-        return OrderBy(items=[x.with_merge(source, target, modifiers) for x in self.items])
+    def with_merge(
+        self, source: Concept, target: Concept, modifiers: List[Modifier]
+    ) -> "OrderBy":
+        return OrderBy(
+            items=[x.with_merge(source, target, modifiers) for x in self.items]
+        )
 
     @property
     def concept_arguments(self):
@@ -1490,19 +1639,31 @@ class SelectStatement(HasUUID, Mergeable, Namespaced, SelectTypeMixin, BaseModel
     def refresh_bindings(self, environment: Environment):
         for item in self.selection:
             if isinstance(item.content, Concept):
-                item.content = environment.concepts[item.content.address].with_grain(self.grain)
+                item.content = environment.concepts[item.content.address].with_grain(
+                    self.grain
+                )
 
     def validate_syntax(self):
         all_in_output = [x.address for x in self.output_components]
         if self.where_clause:
             for concept in self.where_clause.concept_arguments:
-                if concept.lineage and isinstance(concept.lineage, Function) and concept.lineage.operator in FunctionClass.AGGREGATE_FUNCTIONS.value:
+                if (
+                    concept.lineage
+                    and isinstance(concept.lineage, Function)
+                    and concept.lineage.operator
+                    in FunctionClass.AGGREGATE_FUNCTIONS.value
+                ):
                     if concept.address in self.locally_derived:
                         raise SyntaxError(
                             f"Cannot reference an aggregate derived in the select ({concept.address}) in the same statement where clause; move to the HAVING clause instead; Line: {self.meta.line_number}"
                         )
 
-                if concept.lineage and isinstance(concept.lineage, AggregateWrapper) and concept.lineage.function.operator in FunctionClass.AGGREGATE_FUNCTIONS.value:
+                if (
+                    concept.lineage
+                    and isinstance(concept.lineage, AggregateWrapper)
+                    and concept.lineage.function.operator
+                    in FunctionClass.AGGREGATE_FUNCTIONS.value
+                ):
                     if concept.address in self.locally_derived:
                         raise SyntaxError(
                             f"Cannot reference an aggregate derived in the select ({concept.address}) in the same statement where clause; move to the HAVING clause instead; Line: {self.meta.line_number}"
@@ -1510,11 +1671,15 @@ class SelectStatement(HasUUID, Mergeable, Namespaced, SelectTypeMixin, BaseModel
         if self.having_clause:
             for concept in self.having_clause.concept_arguments:
                 if concept.address not in [x.address for x in self.output_components]:
-                    raise SyntaxError(f"Cannot reference a column ({concept.address}) that is not in the select projection in the HAVING clause, move to WHERE;  Line: {self.meta.line_number}")
+                    raise SyntaxError(
+                        f"Cannot reference a column ({concept.address}) that is not in the select projection in the HAVING clause, move to WHERE;  Line: {self.meta.line_number}"
+                    )
         if self.order_by:
             for concept in self.order_by.concept_arguments:
                 if concept.address not in all_in_output:
-                    raise SyntaxError(f"Cannot order by a column that is not in the output projection; {self.meta.line_number}")
+                    raise SyntaxError(
+                        f"Cannot order by a column that is not in the output projection; {self.meta.line_number}"
+                    )
 
     def __str__(self):
         from trilogy.parsing.render import render_query
@@ -1541,10 +1706,16 @@ class SelectStatement(HasUUID, Mergeable, Namespaced, SelectTypeMixin, BaseModel
                 new.append(item)
         return new
 
-    def with_merge(self, source: Concept, target: Concept, modifiers: List[Modifier]) -> "SelectStatement":
+    def with_merge(
+        self, source: Concept, target: Concept, modifiers: List[Modifier]
+    ) -> "SelectStatement":
         return SelectStatement(
             selection=[x.with_merge(source, target, modifiers) for x in self.selection],
-            order_by=(self.order_by.with_merge(source, target, modifiers) if self.order_by else None),
+            order_by=(
+                self.order_by.with_merge(source, target, modifiers)
+                if self.order_by
+                else None
+            ),
             limit=self.limit,
         )
 
@@ -1595,7 +1766,9 @@ class SelectStatement(HasUUID, Mergeable, Namespaced, SelectTypeMixin, BaseModel
 
     @property
     def all_components(self) -> List[Concept]:
-        return self.input_components + self.output_components + self.grain.components_copy
+        return (
+            self.input_components + self.output_components + self.grain.components_copy
+        )
 
     def to_datasource(
         self,
@@ -1613,7 +1786,11 @@ class SelectStatement(HasUUID, Mergeable, Namespaced, SelectTypeMixin, BaseModel
             # if the concept is a locally derived concept, it cannot ever be partial
             # but if it's a concept pulled in from upstream and we have a where clause, it should be partial
             ColumnAssignment(
-                alias=(c.name.replace(".", "_") if c.namespace == DEFAULT_NAMESPACE else c.address.replace(".", "_")),
+                alias=(
+                    c.name.replace(".", "_")
+                    if c.namespace == DEFAULT_NAMESPACE
+                    else c.address.replace(".", "_")
+                ),
                 concept=c,
                 modifiers=modifiers if c.address not in self.locally_derived else [],
             )
@@ -1660,24 +1837,44 @@ class SelectStatement(HasUUID, Mergeable, Namespaced, SelectTypeMixin, BaseModel
         # we want to group to that grain and ignore the property, which is a derivation
         # otherwise, we need to include property as the group by
         for item in self.output_components:
-            if item.purpose == Purpose.PROPERTY and item.grain and (not item.grain.components or not item.grain.issubset(Grain(components=unique(output, "address")))):
+            if (
+                item.purpose == Purpose.PROPERTY
+                and item.grain
+                and (
+                    not item.grain.components
+                    or not item.grain.issubset(
+                        Grain(components=unique(output, "address"))
+                    )
+                )
+            ):
                 output.append(item)
             if (
                 item.purpose == Purpose.CONSTANT
                 and item.derivation != PurposeLineage.CONSTANT
                 and item.grain
-                and (not item.grain.components or not item.grain.issubset(Grain(components=unique(output, "address"))))
+                and (
+                    not item.grain.components
+                    or not item.grain.issubset(
+                        Grain(components=unique(output, "address"))
+                    )
+                )
             ):
                 output.append(item)
         # TODO: explore implicit filtering more
         # if self.where_clause.conditional and self.where_clause_category == SelectFiltering.IMPLICIT:
         #     output =[x.with_filter(self.where_clause.conditional) for x in output]
-        return Grain(components=unique(output, "address"), where_clause=self.where_clause)
+        return Grain(
+            components=unique(output, "address"), where_clause=self.where_clause
+        )
 
     def with_namespace(self, namespace: str) -> "SelectStatement":
         return SelectStatement(
             selection=[c.with_namespace(namespace) for c in self.selection],
-            where_clause=(self.where_clause.with_namespace(namespace) if self.where_clause else None),
+            where_clause=(
+                self.where_clause.with_namespace(namespace)
+                if self.where_clause
+                else None
+            ),
             order_by=self.order_by.with_namespace(namespace) if self.order_by else None,
             limit=self.limit,
         )
@@ -1714,7 +1911,9 @@ class AlignItem(Namespaced, BaseModel):
         datatypes = set([c.datatype for c in self.concepts])
         purposes = set([c.purpose for c in self.concepts])
         if len(datatypes) > 1:
-            raise InvalidSyntaxException(f"Datatypes do not align for merged statements {self.alias}, have {datatypes}")
+            raise InvalidSyntaxException(
+                f"Datatypes do not align for merged statements {self.alias}, have {datatypes}"
+            )
         if len(purposes) > 1:
             purpose = Purpose.KEY
         else:
@@ -1769,15 +1968,25 @@ class MultiSelectStatement(HasUUID, SelectTypeMixin, Mergeable, Namespaced, Base
             output += self.where_clause.concept_arguments
         return unique(output, "address")
 
-    def with_merge(self, source: Concept, target: Concept, modifiers: List[Modifier]) -> "MultiSelectStatement":
+    def with_merge(
+        self, source: Concept, target: Concept, modifiers: List[Modifier]
+    ) -> "MultiSelectStatement":
         new = MultiSelectStatement(
             selects=[s.with_merge(source, target, modifiers) for s in self.selects],
             align=self.align,
             namespace=self.namespace,
-            order_by=(self.order_by.with_merge(source, target, modifiers) if self.order_by else None),
+            order_by=(
+                self.order_by.with_merge(source, target, modifiers)
+                if self.order_by
+                else None
+            ),
             limit=self.limit,
             meta=self.meta,
-            where_clause=(self.where_clause.with_merge(source, target, modifiers) if self.where_clause else None),
+            where_clause=(
+                self.where_clause.with_merge(source, target, modifiers)
+                if self.where_clause
+                else None
+            ),
         )
         return new
 
@@ -1795,7 +2004,11 @@ class MultiSelectStatement(HasUUID, SelectTypeMixin, Mergeable, Namespaced, Base
             order_by=self.order_by.with_namespace(namespace) if self.order_by else None,
             limit=self.limit,
             meta=self.meta,
-            where_clause=(self.where_clause.with_namespace(namespace) if self.where_clause else None),
+            where_clause=(
+                self.where_clause.with_namespace(namespace)
+                if self.where_clause
+                else None
+            ),
         )
 
     @property
@@ -1819,7 +2032,9 @@ class MultiSelectStatement(HasUUID, SelectTypeMixin, Mergeable, Namespaced, Base
                 for c in x.concepts:
                     if c.address in cte.output_lcl:
                         return c
-        raise SyntaxError(f"Could not find upstream map for multiselect {str(concept)} on cte ({cte})")
+        raise SyntaxError(
+            f"Could not find upstream map for multiselect {str(concept)} on cte ({cte})"
+        )
 
     @property
     def output_components(self) -> List[Concept]:
@@ -1858,7 +2073,11 @@ class GrainWindow(BaseModel):
     sort_concepts: List[Concept]
 
     def __str__(self):
-        return "GrainWindow<" + ",".join([c.address for c in self.sort_concepts]) + f":{str(self.window)}>"
+        return (
+            "GrainWindow<"
+            + ",".join([c.address for c in self.sort_concepts])
+            + f":{str(self.window)}>"
+        )
 
 
 def safe_grain(v) -> Grain:
@@ -1898,23 +2117,39 @@ class Datasource(HasUUID, Namespaced, BaseModel):
     name: str
     columns: List[ColumnAssignment]
     address: Union[Address, str]
-    grain: Grain = Field(default_factory=lambda: Grain(components=[]), validate_default=True)
+    grain: Grain = Field(
+        default_factory=lambda: Grain(components=[]), validate_default=True
+    )
     namespace: Optional[str] = Field(default=DEFAULT_NAMESPACE, validate_default=True)
-    metadata: DatasourceMetadata = Field(default_factory=lambda: DatasourceMetadata(freshness_concept=None))
+    metadata: DatasourceMetadata = Field(
+        default_factory=lambda: DatasourceMetadata(freshness_concept=None)
+    )
     where: Optional[WhereClause] = None
     non_partial_for: Optional[WhereClause] = None
 
-    def merge_concept(self, source: Concept, target: Concept, modifiers: List[Modifier]):
+    def merge_concept(
+        self, source: Concept, target: Concept, modifiers: List[Modifier]
+    ):
         original = [c for c in self.columns if c.concept.address == source.address]
-        early_exit_check = [c for c in self.columns if c.concept.address == target.address]
+        early_exit_check = [
+            c for c in self.columns if c.concept.address == target.address
+        ]
         if early_exit_check:
             return None
         if len(original) != 1:
-            raise ValueError(f"Expected exactly one column to merge, got {len(original)} for {source.address}, {[x.alias for x in original]}")
+            raise ValueError(
+                f"Expected exactly one column to merge, got {len(original)} for {source.address}, {[x.alias for x in original]}"
+            )
         # map to the alias with the modifier, and the original
-        self.columns = [c.with_merge(source, target, modifiers) for c in self.columns if c.concept.address != source.address] + original
+        self.columns = [
+            c.with_merge(source, target, modifiers)
+            for c in self.columns
+            if c.concept.address != source.address
+        ] + original
         self.grain = self.grain.with_merge(source, target, modifiers)
-        self.where = self.where.with_merge(source, target, modifiers) if self.where else None
+        self.where = (
+            self.where.with_merge(source, target, modifiers) if self.where else None
+        )
 
         self.add_column(target, original[0].alias, modifiers)
 
@@ -1968,7 +2203,13 @@ class Datasource(HasUUID, Namespaced, BaseModel):
         grain: Grain = safe_grain(v)
         if not grain.components:
             columns: List[ColumnAssignment] = values.get("columns", [])
-            grain = Grain(components=[c.concept.with_grain(Grain()) for c in columns if c.concept.purpose == Purpose.KEY])
+            grain = Grain(
+                components=[
+                    c.concept.with_grain(Grain())
+                    for c in columns
+                    if c.concept.purpose == Purpose.KEY
+                ]
+            )
         return grain
 
     def add_column(
@@ -1977,11 +2218,15 @@ class Datasource(HasUUID, Namespaced, BaseModel):
         alias: str | RawColumnExpr | Function,
         modifiers: List[Modifier] | None = None,
     ):
-        self.columns.append(ColumnAssignment(alias=alias, concept=concept, modifiers=modifiers or []))
+        self.columns.append(
+            ColumnAssignment(alias=alias, concept=concept, modifiers=modifiers or [])
+        )
 
     def __add__(self, other):
         if not other == self:
-            raise ValueError("Attempted to add two datasources that are not identical, this is not a valid operation")
+            raise ValueError(
+                "Attempted to add two datasources that are not identical, this is not a valid operation"
+            )
         return self
 
     def __repr__(self):
@@ -1994,7 +2239,11 @@ class Datasource(HasUUID, Namespaced, BaseModel):
         return self.identifier.__hash__()
 
     def with_namespace(self, namespace: str):
-        new_namespace = namespace + "." + self.namespace if self.namespace and self.namespace != DEFAULT_NAMESPACE else namespace
+        new_namespace = (
+            namespace + "." + self.namespace
+            if self.namespace and self.namespace != DEFAULT_NAMESPACE
+            else namespace
+        )
         return Datasource(
             name=self.name,
             namespace=new_namespace,
@@ -2028,7 +2277,9 @@ class Datasource(HasUUID, Namespaced, BaseModel):
     def partial_concepts(self) -> List[Concept]:
         return [c.concept for c in self.columns if Modifier.PARTIAL in c.modifiers]
 
-    def get_alias(self, concept: Concept, use_raw_name: bool = True, force_alias: bool = False) -> Optional[str | RawColumnExpr] | Function:
+    def get_alias(
+        self, concept: Concept, use_raw_name: bool = True, force_alias: bool = False
+    ) -> Optional[str | RawColumnExpr] | Function:
         # 2022-01-22
         # this logic needs to be refined.
         # if concept.lineage:
@@ -2039,7 +2290,10 @@ class Datasource(HasUUID, Namespaced, BaseModel):
                     return x.alias
                 return concept.safe_address
         existing = [str(c.concept.with_grain(self.grain)) for c in self.columns]
-        raise ValueError(f"{LOGGER_PREFIX} Concept {concept} not found on {self.identifier}; have" f" {existing}.")
+        raise ValueError(
+            f"{LOGGER_PREFIX} Concept {concept} not found on {self.identifier}; have"
+            f" {existing}."
+        )
 
     @property
     def safe_location(self) -> str:
@@ -2095,8 +2349,14 @@ class BaseJoin(BaseModel):
 
     def __init__(self, **data: Any):
         super().__init__(**data)
-        if self.left_datasource and self.left_datasource.identifier == self.right_datasource.identifier:
-            raise SyntaxError(f"Cannot join a dataself to itself, joining {self.left_datasource} and" f" {self.right_datasource}")
+        if (
+            self.left_datasource
+            and self.left_datasource.identifier == self.right_datasource.identifier
+        ):
+            raise SyntaxError(
+                f"Cannot join a dataself to itself, joining {self.left_datasource} and"
+                f" {self.right_datasource}"
+            )
         final_concepts = []
 
         # if we have a list of concept pairs
@@ -2111,8 +2371,14 @@ class BaseJoin(BaseModel):
                 synonyms = []
                 for c in ds.output_concepts:
                     synonyms += list(c.pseudonyms)
-                if concept.address not in [c.address for c in ds.output_concepts] and concept.address not in synonyms:
-                    raise SyntaxError(f"Invalid join, missing {concept} on {ds.name}, have" f" {[c.address for c in ds.output_concepts]}")
+                if (
+                    concept.address not in [c.address for c in ds.output_concepts]
+                    and concept.address not in synonyms
+                ):
+                    raise SyntaxError(
+                        f"Invalid join, missing {concept} on {ds.name}, have"
+                        f" {[c.address for c in ds.output_concepts]}"
+                    )
             if include:
                 final_concepts.append(concept)
         if not final_concepts and self.concepts:
@@ -2120,7 +2386,12 @@ class BaseJoin(BaseModel):
             # we can join on 1=1
             for ds in [self.left_datasource, self.right_datasource]:
                 # single rows
-                if all([c.granularity == Granularity.SINGLE_ROW for c in ds.output_concepts]):
+                if all(
+                    [
+                        c.granularity == Granularity.SINGLE_ROW
+                        for c in ds.output_concepts
+                    ]
+                ):
                     self.concepts = []
                     return
                 # if everything is at abstract grain, we can skip joins
@@ -2156,8 +2427,14 @@ class BaseJoin(BaseModel):
 
     def __str__(self):
         if self.concept_pairs:
-            return f"{self.join_type.value} {self.right_datasource.name} on" f" {','.join([str(k.existing_datasource.name) + '.'+ str(k.left)+'='+str(k.right) for k in self.concept_pairs])}"
-        return f"{self.join_type.value} {self.right_datasource.name} on" f" {','.join([str(k) for k in self.concepts])}"
+            return (
+                f"{self.join_type.value} {self.right_datasource.name} on"
+                f" {','.join([str(k.existing_datasource.name) + '.'+ str(k.left)+'='+str(k.right) for k in self.concept_pairs])}"
+            )
+        return (
+            f"{self.join_type.value} {self.right_datasource.name} on"
+            f" {','.join([str(k) for k in self.concepts])}"
+        )
 
 
 class QueryDatasource(BaseModel):
@@ -2169,7 +2446,9 @@ class QueryDatasource(BaseModel):
     grain: Grain
     joins: List[BaseJoin | UnnestJoin]
     limit: Optional[int] = None
-    condition: Optional[Union["Conditional", "Comparison", "Parenthetical"]] = Field(default=None)
+    condition: Optional[Union["Conditional", "Comparison", "Parenthetical"]] = Field(
+        default=None
+    )
     filter_concepts: List[Concept] = Field(default_factory=list)
     source_type: SourceType = SourceType.SELECT
     partial_concepts: List[Concept] = Field(default_factory=list)
@@ -2177,7 +2456,9 @@ class QueryDatasource(BaseModel):
     nullable_concepts: List[Concept] = Field(default_factory=list)
     join_derived_concepts: List[Concept] = Field(default_factory=list)
     force_group: bool | None = None
-    existence_source_map: Dict[str, Set[Union[Datasource, "QueryDatasource"]]] = Field(default_factory=dict)
+    existence_source_map: Dict[str, Set[Union[Datasource, "QueryDatasource"]]] = Field(
+        default_factory=dict
+    )
 
     def __repr__(self):
         return f"{self.identifier}@<{self.grain}>"
@@ -2188,7 +2469,11 @@ class QueryDatasource(BaseModel):
 
     @property
     def non_partial_concept_addresses(self) -> List[str]:
-        return [c.address for c in self.output_concepts if c.address not in [z.address for z in self.partial_concepts]]
+        return [
+            c.address
+            for c in self.output_concepts
+            if c.address not in [z.address for z in self.partial_concepts]
+        ]
 
     @field_validator("joins")
     @classmethod
@@ -2222,8 +2507,14 @@ class QueryDatasource(BaseModel):
                 continue
             concept: Concept
             for concept in values[key]:
-                if concept.address not in v and not any(x in v for x in concept.pseudonyms) and CONFIG.validate_missing:
-                    raise SyntaxError(f"Missing source map for {concept.address} on {key}, have {v}")
+                if (
+                    concept.address not in v
+                    and not any(x in v for x in concept.pseudonyms)
+                    and CONFIG.validate_missing
+                ):
+                    raise SyntaxError(
+                        f"Missing source map for {concept.address} on {key}, have {v}"
+                    )
         return v
 
     def __str__(self):
@@ -2262,22 +2553,34 @@ class QueryDatasource(BaseModel):
         if not isinstance(other, QueryDatasource):
             raise SyntaxError("Can only merge two query datasources")
         if not other.grain == self.grain:
-            raise SyntaxError("Can only merge two query datasources with identical grain")
+            raise SyntaxError(
+                "Can only merge two query datasources with identical grain"
+            )
         if not self.group_required == other.group_required:
-            raise SyntaxError("can only merge two datasources if the group required flag is the same")
+            raise SyntaxError(
+                "can only merge two datasources if the group required flag is the same"
+            )
         if not self.join_derived_concepts == other.join_derived_concepts:
-            raise SyntaxError("can only merge two datasources if the join derived concepts are the same")
+            raise SyntaxError(
+                "can only merge two datasources if the join derived concepts are the same"
+            )
         if not self.force_group == other.force_group:
-            raise SyntaxError("can only merge two datasources if the force_group flag is the same")
+            raise SyntaxError(
+                "can only merge two datasources if the force_group flag is the same"
+            )
         logger.debug(
-            f"{LOGGER_PREFIX} merging {self.name} with" f" {[c.address for c in self.output_concepts]} concepts and" f" {other.name} with {[c.address for c in other.output_concepts]} concepts"
+            f"{LOGGER_PREFIX} merging {self.name} with"
+            f" {[c.address for c in self.output_concepts]} concepts and"
+            f" {other.name} with {[c.address for c in other.output_concepts]} concepts"
         )
 
         merged_datasources: dict[str, Union[Datasource, "QueryDatasource"]] = {}
 
         for ds in [*self.datasources, *other.datasources]:
             if ds.safe_identifier in merged_datasources:
-                merged_datasources[ds.safe_identifier] = merged_datasources[ds.safe_identifier] + ds
+                merged_datasources[ds.safe_identifier] = (
+                    merged_datasources[ds.safe_identifier] + ds
+                )
             else:
                 merged_datasources[ds.safe_identifier] = ds
 
@@ -2306,8 +2609,12 @@ class QueryDatasource(BaseModel):
         # hidden is the minimum overlapping set
         hidden = [x for x in self_hidden if x.address in other_hidden]
         qds = QueryDatasource(
-            input_concepts=unique(self.input_concepts + other.input_concepts, "address"),
-            output_concepts=unique(self.output_concepts + other.output_concepts, "address"),
+            input_concepts=unique(
+                self.input_concepts + other.input_concepts, "address"
+            ),
+            output_concepts=unique(
+                self.output_concepts + other.output_concepts, "address"
+            ),
             source_map=final_source_map,
             datasources=list(merged_datasources.values()),
             grain=self.grain,
@@ -2318,7 +2625,9 @@ class QueryDatasource(BaseModel):
                 else self.condition or other.condition
             ),
             source_type=self.source_type,
-            partial_concepts=unique(self.partial_concepts + other.partial_concepts, "address"),
+            partial_concepts=unique(
+                self.partial_concepts + other.partial_concepts, "address"
+            ),
             join_derived_concepts=self.join_derived_concepts,
             force_group=self.force_group,
             hidden_concepts=hidden,
@@ -2329,10 +2638,14 @@ class QueryDatasource(BaseModel):
     @property
     def identifier(self) -> str:
         filters = abs(hash(str(self.condition))) if self.condition else ""
-        grain = "_".join([str(c.address).replace(".", "_") for c in self.grain.components])
+        grain = "_".join(
+            [str(c.address).replace(".", "_") for c in self.grain.components]
+        )
         # partial = "_".join([str(c.address).replace(".", "_") for c in self.partial_concepts])
         return (
-            "_join_".join([d.identifier for d in self.datasources]) + (f"_at_{grain}" if grain else "_at_abstract") + (f"_filtered_by_{filters}" if filters else "")
+            "_join_".join([d.identifier for d in self.datasources])
+            + (f"_at_{grain}" if grain else "_at_abstract")
+            + (f"_filtered_by_{filters}" if filters else "")
             # + (f"_partial_{partial}" if partial else "")
         )
 
@@ -2367,7 +2680,10 @@ class QueryDatasource(BaseModel):
 
         existing_str = [str(c) for c in existing]
         datasources = [ds.identifier for ds in self.datasources]
-        raise ValueError(f"{LOGGER_PREFIX} Concept {str(concept)} not found on {self.identifier};" f" have {existing_str} from {datasources}.")
+        raise ValueError(
+            f"{LOGGER_PREFIX} Concept {str(concept)} not found on {self.identifier};"
+            f" have {existing_str} from {datasources}."
+        )
 
     @property
     def safe_location(self):
@@ -2434,18 +2750,38 @@ class CTE(BaseModel):
         # if we've entirely removed the need to join to someplace to get the concept
         # drop the join as well.
         for removed_cte in removed:
-            still_required = any([removed_cte in x for x in self.source_map.values() or self.existence_source_map.values()])
+            still_required = any(
+                [
+                    removed_cte in x
+                    for x in self.source_map.values()
+                    or self.existence_source_map.values()
+                ]
+            )
             if not still_required:
                 self.joins = [
                     join
                     for join in self.joins
-                    if not isinstance(join, Join) or (isinstance(join, Join) and (join.right_cte.name != removed_cte and any([x.cte.name != removed_cte for x in (join.joinkey_pairs or [])])))
+                    if not isinstance(join, Join)
+                    or (
+                        isinstance(join, Join)
+                        and (
+                            join.right_cte.name != removed_cte
+                            and any(
+                                [
+                                    x.cte.name != removed_cte
+                                    for x in (join.joinkey_pairs or [])
+                                ]
+                            )
+                        )
+                    )
                 ]
                 for join in self.joins:
                     if isinstance(join, UnnestJoin) and concept in join.concepts:
                         join.rendering_required = False
 
-                self.parent_ctes = [x for x in self.parent_ctes if x.name != removed_cte]
+                self.parent_ctes = [
+                    x for x in self.parent_ctes if x.name != removed_cte
+                ]
                 if removed_cte == self.base_name_override:
                     candidates = [x.name for x in self.parent_ctes]
                     self.base_name_override = candidates[0] if candidates else None
@@ -2461,7 +2797,9 @@ class CTE(BaseModel):
         if self.joins:
             base += f"\n-- Joins: {', '.join([str(x) for x in self.joins])}."
         if self.partial_concepts:
-            base += f"\n-- Partials: {', '.join([str(x) for x in self.partial_concepts])}."
+            base += (
+                f"\n-- Partials: {', '.join([str(x) for x in self.partial_concepts])}."
+            )
         base += f"\n-- Source Map: {self.source_map}."
         base += f"\n-- Output: {', '.join([str(x) for x in self.output_columns])}."
         if self.source.input_concepts:
@@ -2469,7 +2807,9 @@ class CTE(BaseModel):
         if self.hidden_concepts:
             base += f"\n-- Hidden: {', '.join([str(x) for x in self.hidden_concepts])}."
         if self.nullable_concepts:
-            base += f"\n-- Nullable: {', '.join([str(x) for x in self.nullable_concepts])}."
+            base += (
+                f"\n-- Nullable: {', '.join([str(x) for x in self.nullable_concepts])}."
+            )
 
         return base
 
@@ -2478,12 +2818,21 @@ class CTE(BaseModel):
         ds_being_inlined = qds_being_inlined.datasources[0]
         if not isinstance(ds_being_inlined, Datasource):
             return False
-        if any([x.safe_identifier == ds_being_inlined.safe_identifier for x in self.source.datasources]):
+        if any(
+            [
+                x.safe_identifier == ds_being_inlined.safe_identifier
+                for x in self.source.datasources
+            ]
+        ):
             return False
 
         self.source.datasources = [
             ds_being_inlined,
-            *[x for x in self.source.datasources if x.safe_identifier != qds_being_inlined.safe_identifier],
+            *[
+                x
+                for x in self.source.datasources
+                if x.safe_identifier != qds_being_inlined.safe_identifier
+            ],
         ]
         # need to identify this before updating joins
         if self.base_name == parent.name:
@@ -2493,7 +2842,10 @@ class CTE(BaseModel):
         for join in self.joins:
             if isinstance(join, InstantiatedUnnestJoin):
                 continue
-            if join.left_cte and join.left_cte.safe_identifier == parent.safe_identifier:
+            if (
+                join.left_cte
+                and join.left_cte.safe_identifier == parent.safe_identifier
+            ):
                 join.inline_cte(parent)
             if join.joinkey_pairs:
                 for pair in join.joinkey_pairs:
@@ -2503,7 +2855,14 @@ class CTE(BaseModel):
                 join.inline_cte(parent)
         for k, v in self.source_map.items():
             if isinstance(v, list):
-                self.source_map[k] = [(ds_being_inlined.safe_identifier if x == parent.safe_identifier else x) for x in v]
+                self.source_map[k] = [
+                    (
+                        ds_being_inlined.safe_identifier
+                        if x == parent.safe_identifier
+                        else x
+                    )
+                    for x in v
+                ]
             elif v == parent.safe_identifier:
                 self.source_map[k] = [ds_being_inlined.safe_identifier]
 
@@ -2512,7 +2871,9 @@ class CTE(BaseModel):
             if k in self.source_map and self.source_map[k]:
                 continue
             self.source_map[k] = [ds_being_inlined.safe_identifier]
-        self.parent_ctes = [x for x in self.parent_ctes if x.safe_identifier != parent.safe_identifier]
+        self.parent_ctes = [
+            x for x in self.parent_ctes if x.safe_identifier != parent.safe_identifier
+        ]
         if force_group:
             self.group_to_grain = True
         return True
@@ -2528,25 +2889,40 @@ class CTE(BaseModel):
             )
             raise ValueError(error)
         if not self.condition == other.condition:
-            error = "Attempting to merge two ctes with different conditions" f" {self.name} {other.name} conditions {self.condition} {other.condition}"
+            error = (
+                "Attempting to merge two ctes with different conditions"
+                f" {self.name} {other.name} conditions {self.condition} {other.condition}"
+            )
             raise ValueError(error)
         mutually_hidden = []
         for concept in self.hidden_concepts:
             if concept.address in other.hidden_concepts:
                 mutually_hidden.append(concept)
-        self.partial_concepts = unique(self.partial_concepts + other.partial_concepts, "address")
+        self.partial_concepts = unique(
+            self.partial_concepts + other.partial_concepts, "address"
+        )
         self.parent_ctes = merge_ctes(self.parent_ctes + other.parent_ctes)
 
         self.source_map = {**self.source_map, **other.source_map}
 
-        self.output_columns = unique(self.output_columns + other.output_columns, "address")
+        self.output_columns = unique(
+            self.output_columns + other.output_columns, "address"
+        )
         self.joins = unique(self.joins + other.joins, "unique_id")
-        self.partial_concepts = unique(self.partial_concepts + other.partial_concepts, "address")
-        self.join_derived_concepts = unique(self.join_derived_concepts + other.join_derived_concepts, "address")
+        self.partial_concepts = unique(
+            self.partial_concepts + other.partial_concepts, "address"
+        )
+        self.join_derived_concepts = unique(
+            self.join_derived_concepts + other.join_derived_concepts, "address"
+        )
 
         self.source.source_map = {**self.source.source_map, **other.source.source_map}
-        self.source.output_concepts = unique(self.source.output_concepts + other.source.output_concepts, "address")
-        self.nullable_concepts = unique(self.nullable_concepts + other.nullable_concepts, "address")
+        self.source.output_concepts = unique(
+            self.source.output_concepts + other.source.output_concepts, "address"
+        )
+        self.nullable_concepts = unique(
+            self.nullable_concepts + other.nullable_concepts, "address"
+        )
         self.hidden_concepts = mutually_hidden
         self.existence_source_map = {
             **self.existence_source_map,
@@ -2560,7 +2936,11 @@ class CTE(BaseModel):
 
     @property
     def is_root_datasource(self) -> bool:
-        return len(self.source.datasources) == 1 and isinstance(self.source.datasources[0], Datasource) and not self.source.datasources[0].name == CONSTANT_DATASET
+        return (
+            len(self.source.datasources) == 1
+            and isinstance(self.source.datasources[0], Datasource)
+            and not self.source.datasources[0].name == CONSTANT_DATASET
+        )
 
     @property
     def base_name(self) -> str:
@@ -2582,7 +2962,9 @@ class CTE(BaseModel):
     def quote_address(self) -> bool:
         if self.is_root_datasource:
             candidate = self.source.datasources[0]
-            if isinstance(candidate, Datasource) and isinstance(candidate.address, Address):
+            if isinstance(candidate, Datasource) and isinstance(
+                candidate.address, Address
+            ):
                 return candidate.address.quoted
         return False
 
@@ -2651,14 +3033,21 @@ class CTE(BaseModel):
 
     @property
     def render_from_clause(self) -> bool:
-        if all([c.derivation == PurposeLineage.CONSTANT for c in self.output_columns]) and not self.parent_ctes and not self.group_to_grain:
+        if (
+            all([c.derivation == PurposeLineage.CONSTANT for c in self.output_columns])
+            and not self.parent_ctes
+            and not self.group_to_grain
+        ):
             return False
         # if we don't need to source any concepts from anywhere
         # render without from
         # most likely to happen from inlining constants
         if not any([v for v in self.source_map.values()]):
             return False
-        if len(self.source.datasources) == 1 and self.source.datasources[0].name == CONSTANT_DATASET:
+        if (
+            len(self.source.datasources) == 1
+            and self.source.datasources[0].name == CONSTANT_DATASET
+        ):
             return False
         return True
 
@@ -2789,9 +3178,16 @@ class Join(BaseModel):
 
     def __str__(self):
         if self.joinkey_pairs:
-            return f"{self.jointype.value} join" f" {self.right_name} on" f" {','.join([k.cte.name + '.'+str(k.left.address)+'='+str(k.right.address) for k in self.joinkey_pairs])}"
+            return (
+                f"{self.jointype.value} join"
+                f" {self.right_name} on"
+                f" {','.join([k.cte.name + '.'+str(k.left.address)+'='+str(k.right.address) for k in self.joinkey_pairs])}"
+            )
         elif self.left_cte:
-            return f"{self.jointype.value} JOIN {self.left_cte.name} and" f" {self.right_name} on {','.join([str(k) for k in self.joinkey_pairs])}"
+            return (
+                f"{self.jointype.value} JOIN {self.left_cte.name} and"
+                f" {self.right_name} on {','.join([str(k) for k in self.joinkey_pairs])}"
+            )
         return f"{self.jointype.value} JOIN  {self.right_name} on {','.join([str(k) for k in self.joinkey_pairs])}"
 
 
@@ -2805,7 +3201,9 @@ class UndefinedConcept(Concept, Mergeable, Namespaced):
     )
     purpose: Purpose = Purpose.KEY
 
-    def with_merge(self, source: Concept, target: Concept, modifiers: List[Modifier]) -> "UndefinedConcept" | Concept:
+    def with_merge(
+        self, source: Concept, target: Concept, modifiers: List[Modifier]
+    ) -> "UndefinedConcept" | Concept:
         if self.address == source.address:
             new = target.with_grain(self.grain.with_merge(source, target, modifiers))
             new.pseudonyms.add(self.address)
@@ -2815,10 +3213,18 @@ class UndefinedConcept(Concept, Mergeable, Namespaced):
             datatype=self.datatype,
             purpose=self.purpose,
             metadata=self.metadata,
-            lineage=(self.lineage.with_merge(source, target, modifiers) if self.lineage else None),
+            lineage=(
+                self.lineage.with_merge(source, target, modifiers)
+                if self.lineage
+                else None
+            ),
             grain=self.grain.with_merge(source, target, modifiers),
             namespace=self.namespace,
-            keys=(tuple(x.with_merge(source, target, modifiers) for x in self.keys) if self.keys else None),
+            keys=(
+                tuple(x.with_merge(source, target, modifiers) for x in self.keys)
+                if self.keys
+                else None
+            ),
             environment=self.environment,
             line_no=self.line_no,
         )
@@ -2830,7 +3236,11 @@ class UndefinedConcept(Concept, Mergeable, Namespaced):
             purpose=self.purpose,
             metadata=self.metadata,
             lineage=self.lineage.with_namespace(namespace) if self.lineage else None,
-            grain=(self.grain.with_namespace(namespace) if self.grain else Grain(components=[])),
+            grain=(
+                self.grain.with_namespace(namespace)
+                if self.grain
+                else Grain(components=[])
+            ),
             namespace=namespace,
             keys=self.keys,
             environment=self.environment,
@@ -2849,7 +3259,9 @@ class UndefinedConcept(Concept, Mergeable, Namespaced):
         if self.lineage:
             new_lineage = self.lineage
             if isinstance(self.lineage, SelectContext):
-                new_lineage = self.lineage.with_select_context(new_grain, conditional, environment)
+                new_lineage = self.lineage.with_select_context(
+                    new_grain, conditional, environment
+                )
         else:
             new_lineage = None
         return self.__class__(
@@ -2955,7 +3367,9 @@ class EnvironmentConceptDict(dict):
         except UndefinedConceptException:
             return default
 
-    def __getitem__(self, key, line_no: int | None = None, file: Path | None = None) -> Concept | UndefinedConcept:
+    def __getitem__(
+        self, key, line_no: int | None = None, file: Path | None = None
+    ) -> Concept | UndefinedConcept:
         try:
             return super(EnvironmentConceptDict, self).__getitem__(key)
 
@@ -2983,7 +3397,9 @@ class EnvironmentConceptDict(dict):
 
             if line_no:
                 if file:
-                    raise UndefinedConceptException(f"{file}: {line_no}: " + message, matches)
+                    raise UndefinedConceptException(
+                        f"{file}: {line_no}: " + message, matches
+                    )
                 raise UndefinedConceptException(f"line: {line_no}: " + message, matches)
             raise UndefinedConceptException(message, matches)
 
@@ -2993,7 +3409,9 @@ class EnvironmentConceptDict(dict):
                 return input[len(DEFAULT_NAMESPACE) + 1 :]
             return input
 
-        matches = difflib.get_close_matches(strip_local(concept_name), [strip_local(x) for x in self.keys()])
+        matches = difflib.get_close_matches(
+            strip_local(concept_name), [strip_local(x) for x in self.keys()]
+        )
         return matches
 
     def items(self) -> ItemsView[str, Concept]:  # type: ignore
@@ -3016,7 +3434,9 @@ def validate_concepts(v) -> EnvironmentConceptDict:
     if isinstance(v, EnvironmentConceptDict):
         return v
     elif isinstance(v, dict):
-        return EnvironmentConceptDict(**{x: Concept.model_validate(y) for x, y in v.items()})
+        return EnvironmentConceptDict(
+            **{x: Concept.model_validate(y) for x, y in v.items()}
+        )
     raise ValueError
 
 
@@ -3024,15 +3444,21 @@ def validate_datasources(v) -> EnvironmentDatasourceDict:
     if isinstance(v, EnvironmentDatasourceDict):
         return v
     elif isinstance(v, dict):
-        return EnvironmentDatasourceDict(**{x: Datasource.model_validate(y) for x, y in v.items()})
+        return EnvironmentDatasourceDict(
+            **{x: Datasource.model_validate(y) for x, y in v.items()}
+        )
     raise ValueError
 
 
 class Environment(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True, strict=False)
 
-    concepts: Annotated[EnvironmentConceptDict, PlainValidator(validate_concepts)] = Field(default_factory=EnvironmentConceptDict)
-    datasources: Annotated[EnvironmentDatasourceDict, PlainValidator(validate_datasources)] = Field(default_factory=EnvironmentDatasourceDict)
+    concepts: Annotated[EnvironmentConceptDict, PlainValidator(validate_concepts)] = (
+        Field(default_factory=EnvironmentConceptDict)
+    )
+    datasources: Annotated[
+        EnvironmentDatasourceDict, PlainValidator(validate_datasources)
+    ] = Field(default_factory=EnvironmentDatasourceDict)
     functions: Dict[str, Function] = Field(default_factory=dict)
     data_types: Dict[str, DataType] = Field(default_factory=dict)
     imports: Dict[str, list[ImportStatement]] = Field(
@@ -3123,7 +3549,9 @@ class Environment(BaseModel):
             return
 
         def handle_persist():
-            deriv_lookup = f"{existing.namespace}.{PERSISTED_CONCEPT_PREFIX}_{existing.name}"
+            deriv_lookup = (
+                f"{existing.namespace}.{PERSISTED_CONCEPT_PREFIX}_{existing.name}"
+            )
 
             alt_source = self.alias_origin_lookup.get(deriv_lookup)
             if not alt_source:
@@ -3134,14 +3562,20 @@ class Environment(BaseModel):
             if not new_concept.lineage:
                 return existing
             if str(alt_source.lineage) == str(new_concept.lineage):
-                logger.info(f"Persisted concept {existing.address} matched redeclaration, keeping current persistence binding.")
+                logger.info(
+                    f"Persisted concept {existing.address} matched redeclaration, keeping current persistence binding."
+                )
                 return existing
             logger.warning(
                 f"Persisted concept {existing.address} lineage {str(alt_source.lineage)} did not match redeclaration {str(new_concept.lineage)}, overwriting and invalidating persist binding."
             )
             for k, datasource in self.datasources.items():
                 if existing.address in datasource.output_concepts:
-                    datasource.columns = [x for x in datasource.columns if x.concept.address != existing.address]
+                    datasource.columns = [
+                        x
+                        for x in datasource.columns
+                        if x.concept.address != existing.address
+                    ]
             return None
 
         if existing and self.environment_config.allow_duplicate_declaration:
@@ -3155,19 +3589,35 @@ class Environment(BaseModel):
             if existing.metadata.concept_source == ConceptSource.AUTO_DERIVED:
                 return None
         elif meta and existing.metadata:
-            raise ValueError(f"Assignment to concept '{lookup}' on line {meta.line} is a duplicate" f" declaration; '{lookup}' was originally defined on line" f" {existing.metadata.line_number}")
+            raise ValueError(
+                f"Assignment to concept '{lookup}' on line {meta.line} is a duplicate"
+                f" declaration; '{lookup}' was originally defined on line"
+                f" {existing.metadata.line_number}"
+            )
         elif existing.metadata:
-            raise ValueError(f"Assignment to concept '{lookup}'  is a duplicate declaration;" f" '{lookup}' was originally defined on line" f" {existing.metadata.line_number}")
-        raise ValueError(f"Assignment to concept '{lookup}'  is a duplicate declaration;")
+            raise ValueError(
+                f"Assignment to concept '{lookup}'  is a duplicate declaration;"
+                f" '{lookup}' was originally defined on line"
+                f" {existing.metadata.line_number}"
+            )
+        raise ValueError(
+            f"Assignment to concept '{lookup}'  is a duplicate declaration;"
+        )
 
-    def add_import(self, alias: str, source: Environment, imp_stm: ImportStatement | None = None):
+    def add_import(
+        self, alias: str, source: Environment, imp_stm: ImportStatement | None = None
+    ):
         exists = False
         existing = self.imports[alias]
         if imp_stm:
-            if any([x.path == imp_stm.path and x.alias == imp_stm.alias for x in existing]):
+            if any(
+                [x.path == imp_stm.path and x.alias == imp_stm.alias for x in existing]
+            ):
                 exists = True
         else:
-            if any([x.path == source.working_path and x.alias == alias for x in existing]):
+            if any(
+                [x.path == source.working_path and x.alias == alias for x in existing]
+            ):
                 exists = True
             imp_stm = ImportStatement(alias=alias, path=Path(source.working_path))
         same_namespace = alias == self.namespace
@@ -3180,7 +3630,9 @@ class Environment(BaseModel):
             if same_namespace:
                 new = self.add_concept(concept, _ignore_cache=True)
             else:
-                new = self.add_concept(concept.with_namespace(alias), _ignore_cache=True)
+                new = self.add_concept(
+                    concept.with_namespace(alias), _ignore_cache=True
+                )
 
                 k = address_with_namespace(k, alias)
             # set this explicitly, to handle aliasing
@@ -3190,17 +3642,23 @@ class Environment(BaseModel):
             if same_namespace:
                 self.add_datasource(datasource, _ignore_cache=True)
             else:
-                self.add_datasource(datasource.with_namespace(alias), _ignore_cache=True)
+                self.add_datasource(
+                    datasource.with_namespace(alias), _ignore_cache=True
+                )
         for key, val in source.alias_origin_lookup.items():
             if same_namespace:
                 self.alias_origin_lookup[key] = val
             else:
-                self.alias_origin_lookup[address_with_namespace(key, alias)] = val.with_namespace(alias)
+                self.alias_origin_lookup[address_with_namespace(key, alias)] = (
+                    val.with_namespace(alias)
+                )
 
         self.gen_concept_list_caches()
         return self
 
-    def add_file_import(self, path: str | Path, alias: str, env: Environment | None = None):
+    def add_file_import(
+        self, path: str | Path, alias: str, env: Environment | None = None
+    ):
         from trilogy.parsing.parse_engine import (
             PARSER,
             ParseToObjects,
@@ -3237,13 +3695,17 @@ class Environment(BaseModel):
                 nparser.transform(PARSER.parse(text))
 
             except Exception as e:
-                raise ImportError(f"Unable to import file {target.parent}, parsing error: {e}")
+                raise ImportError(
+                    f"Unable to import file {target.parent}, parsing error: {e}"
+                )
             env = nparser.environment
         imps = ImportStatement(alias=alias, path=target)
         self.add_import(alias, source=env, imp_stm=imps)
         return imps
 
-    def parse(self, input: str, namespace: str | None = None, persist: bool = False) -> Tuple[Environment, list]:
+    def parse(
+        self, input: str, namespace: str | None = None, persist: bool = False
+    ) -> Tuple[Environment, list]:
         from trilogy import parse
         from trilogy.core.query_processor import process_persist
 
@@ -3313,17 +3775,26 @@ class Environment(BaseModel):
             if current_derivation not in (PurposeLineage.ROOT, PurposeLineage.CONSTANT):
                 persisted = f"{PERSISTED_CONCEPT_PREFIX}_" + current_concept.name
                 # override the current concept source to reflect that it's now coming from a datasource
-                if current_concept.metadata.concept_source != ConceptSource.PERSIST_STATEMENT:
+                if (
+                    current_concept.metadata.concept_source
+                    != ConceptSource.PERSIST_STATEMENT
+                ):
                     new_concept = current_concept.model_copy(deep=True)
                     new_concept.set_name(persisted)
-                    self.add_concept(new_concept, meta=meta, force=True, _ignore_cache=True)
-                    current_concept.metadata.concept_source = ConceptSource.PERSIST_STATEMENT
+                    self.add_concept(
+                        new_concept, meta=meta, force=True, _ignore_cache=True
+                    )
+                    current_concept.metadata.concept_source = (
+                        ConceptSource.PERSIST_STATEMENT
+                    )
                     # remove the associated lineage
                     # to make this a root for discovery purposes
                     # as it now "exists" in a table
                     current_concept.lineage = None
                     current_concept = current_concept.with_default_grain()
-                    self.add_concept(current_concept, meta=meta, force=True, _ignore_cache=True)
+                    self.add_concept(
+                        current_concept, meta=meta, force=True, _ignore_cache=True
+                    )
                     self.merge_concept(new_concept, current_concept, [])
                 else:
                     self.add_concept(current_concept, meta=meta, _ignore_cache=True)
@@ -3347,7 +3818,9 @@ class Environment(BaseModel):
             return True
         return False
 
-    def merge_concept(self, source: Concept, target: Concept, modifiers: List[Modifier]):
+    def merge_concept(
+        self, source: Concept, target: Concept, modifiers: List[Modifier]
+    ):
         replacements = {}
 
         # exit early if we've run this
@@ -3389,7 +3862,9 @@ class LazyEnvironment(Environment):
         ) or name.startswith("_"):
             return super().__getattribute__(name)
         if not self.loaded:
-            logger.info(f"lazily evaluating load path {self.load_path} to access {name}")
+            logger.info(
+                f"lazily evaluating load path {self.load_path} to access {name}"
+            )
             from trilogy import parse
 
             env = Environment(working_path=str(self.working_path))
@@ -3402,7 +3877,9 @@ class LazyEnvironment(Environment):
         return super().__getattribute__(name)
 
 
-class Comparison(ConceptArgs, Mergeable, Namespaced, ConstantInlineable, SelectContext, BaseModel):
+class Comparison(
+    ConceptArgs, Mergeable, Namespaced, ConstantInlineable, SelectContext, BaseModel
+):
     left: Union[
         int,
         str,
@@ -3441,20 +3918,38 @@ class Comparison(ConceptArgs, Mergeable, Namespaced, ConstantInlineable, SelectC
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         if self.operator in (ComparisonOperator.IS, ComparisonOperator.IS_NOT):
-            if self.right != MagicConstants.NULL and DataType.BOOL != arg_to_datatype(self.right):
-                raise SyntaxError(f"Cannot use {self.operator.value} with non-null or boolean value {self.right}")
+            if self.right != MagicConstants.NULL and DataType.BOOL != arg_to_datatype(
+                self.right
+            ):
+                raise SyntaxError(
+                    f"Cannot use {self.operator.value} with non-null or boolean value {self.right}"
+                )
         elif self.operator in (ComparisonOperator.IN, ComparisonOperator.NOT_IN):
             right = arg_to_datatype(self.right)
             if not isinstance(self.right, Concept) and not isinstance(right, ListType):
-                raise SyntaxError(f"Cannot use {self.operator.value} with non-list type {right} in {str(self)}")
+                raise SyntaxError(
+                    f"Cannot use {self.operator.value} with non-list type {right} in {str(self)}"
+                )
 
-            elif isinstance(right, ListType) and not is_compatible_datatype(arg_to_datatype(self.left), right.value_data_type):
-                raise SyntaxError(f"Cannot compare {arg_to_datatype(self.left)} and {right} with operator {self.operator} in {str(self)}")
-            elif isinstance(self.right, Concept) and not is_compatible_datatype(arg_to_datatype(self.left), arg_to_datatype(self.right)):
-                raise SyntaxError(f"Cannot compare {arg_to_datatype(self.left)} and {arg_to_datatype(self.right)} with operator {self.operator} in {str(self)}")
+            elif isinstance(right, ListType) and not is_compatible_datatype(
+                arg_to_datatype(self.left), right.value_data_type
+            ):
+                raise SyntaxError(
+                    f"Cannot compare {arg_to_datatype(self.left)} and {right} with operator {self.operator} in {str(self)}"
+                )
+            elif isinstance(self.right, Concept) and not is_compatible_datatype(
+                arg_to_datatype(self.left), arg_to_datatype(self.right)
+            ):
+                raise SyntaxError(
+                    f"Cannot compare {arg_to_datatype(self.left)} and {arg_to_datatype(self.right)} with operator {self.operator} in {str(self)}"
+                )
         else:
-            if not is_compatible_datatype(arg_to_datatype(self.left), arg_to_datatype(self.right)):
-                raise SyntaxError(f"Cannot compare {arg_to_datatype(self.left)} and {arg_to_datatype(self.right)} of different types with operator {self.operator} in {str(self)}")
+            if not is_compatible_datatype(
+                arg_to_datatype(self.left), arg_to_datatype(self.right)
+            ):
+                raise SyntaxError(
+                    f"Cannot compare {arg_to_datatype(self.left)} and {arg_to_datatype(self.right)} of different types with operator {self.operator} in {str(self)}"
+                )
 
     def __add__(self, other):
         if other is None:
@@ -3474,7 +3969,11 @@ class Comparison(ConceptArgs, Mergeable, Namespaced, ConstantInlineable, SelectC
     def __eq__(self, other):
         if not isinstance(other, Comparison):
             return False
-        return self.left == other.left and self.right == other.right and self.operator == other.operator
+        return (
+            self.left == other.left
+            and self.right == other.right
+            and self.operator == other.operator
+        )
 
     def inline_constant(self, constant: Concept):
         assert isinstance(constant.lineage, Function)
@@ -3501,15 +4000,31 @@ class Comparison(ConceptArgs, Mergeable, Namespaced, ConstantInlineable, SelectC
 
     def with_merge(self, source: Concept, target: Concept, modifiers: List[Modifier]):
         return self.__class__(
-            left=(self.left.with_merge(source, target, modifiers) if isinstance(self.left, Mergeable) else self.left),
-            right=(self.right.with_merge(source, target, modifiers) if isinstance(self.right, Mergeable) else self.right),
+            left=(
+                self.left.with_merge(source, target, modifiers)
+                if isinstance(self.left, Mergeable)
+                else self.left
+            ),
+            right=(
+                self.right.with_merge(source, target, modifiers)
+                if isinstance(self.right, Mergeable)
+                else self.right
+            ),
             operator=self.operator,
         )
 
     def with_namespace(self, namespace: str):
         return self.__class__(
-            left=(self.left.with_namespace(namespace) if isinstance(self.left, Namespaced) else self.left),
-            right=(self.right.with_namespace(namespace) if isinstance(self.right, Namespaced) else self.right),
+            left=(
+                self.left.with_namespace(namespace)
+                if isinstance(self.left, Namespaced)
+                else self.left
+            ),
+            right=(
+                self.right.with_namespace(namespace)
+                if isinstance(self.right, Namespaced)
+                else self.right
+            ),
             operator=self.operator,
         )
 
@@ -3520,9 +4035,17 @@ class Comparison(ConceptArgs, Mergeable, Namespaced, ConstantInlineable, SelectC
         environment: Environment | None = None,
     ):
         return self.__class__(
-            left=(self.left.with_select_context(grain, conditional, environment) if isinstance(self.left, SelectContext) else self.left),
+            left=(
+                self.left.with_select_context(grain, conditional, environment)
+                if isinstance(self.left, SelectContext)
+                else self.left
+            ),
             # the right side does NOT need to inherit select grain
-            right=(self.right.with_select_context(grain, conditional, environment) if isinstance(self.right, SelectContext) else self.right),
+            right=(
+                self.right.with_select_context(grain, conditional, environment)
+                if isinstance(self.right, SelectContext)
+                else self.right
+            ),
             operator=self.operator,
         )
 
@@ -3531,7 +4054,9 @@ class Comparison(ConceptArgs, Mergeable, Namespaced, ConstantInlineable, SelectC
         output: List[Concept] = []
         if isinstance(self.left, (Concept,)):
             output += [self.left]
-        if isinstance(self.left, (Comparison, SubselectComparison, Conditional, Parenthetical)):
+        if isinstance(
+            self.left, (Comparison, SubselectComparison, Conditional, Parenthetical)
+        ):
             output += self.left.input
         if isinstance(self.left, FilterItem):
             output += self.left.concept_arguments
@@ -3540,7 +4065,9 @@ class Comparison(ConceptArgs, Mergeable, Namespaced, ConstantInlineable, SelectC
 
         if isinstance(self.right, (Concept,)):
             output += [self.right]
-        if isinstance(self.right, (Comparison, SubselectComparison, Conditional, Parenthetical)):
+        if isinstance(
+            self.right, (Comparison, SubselectComparison, Conditional, Parenthetical)
+        ):
             output += self.right.input
         if isinstance(self.right, FilterItem):
             output += self.right.concept_arguments
@@ -3585,7 +4112,11 @@ class SubselectComparison(Comparison):
         if not isinstance(other, SubselectComparison):
             return False
 
-        comp = self.left == other.left and self.right == other.right and self.operator == other.operator
+        comp = (
+            self.left == other.left
+            and self.right == other.right
+            and self.operator == other.operator
+        )
         return comp
 
     @property
@@ -3604,7 +4135,11 @@ class SubselectComparison(Comparison):
     ):
         # there's no need to pass the select grain through to a subselect comparison on the right
         return self.__class__(
-            left=(self.left.with_select_context(grain, conditional, environment) if isinstance(self.left, SelectContext) else self.left),
+            left=(
+                self.left.with_select_context(grain, conditional, environment)
+                if isinstance(self.left, SelectContext)
+                else self.left
+            ),
             right=self.right,
             operator=self.operator,
         )
@@ -3644,8 +4179,14 @@ class CaseWhen(Namespaced, SelectContext, BaseModel):
         environment: Environment | None = None,
     ) -> CaseWhen:
         return CaseWhen(
-            comparison=self.comparison.with_select_context(grain, conditional, environment),
-            expr=((self.expr.with_select_context(grain, conditional, environment)) if isinstance(self.expr, SelectContext) else self.expr),
+            comparison=self.comparison.with_select_context(
+                grain, conditional, environment
+            ),
+            expr=(
+                (self.expr.with_select_context(grain, conditional, environment))
+                if isinstance(self.expr, SelectContext)
+                else self.expr
+            ),
         )
 
 
@@ -3690,7 +4231,9 @@ class CaseElse(Namespaced, SelectContext, BaseModel):
         )
 
 
-class Conditional(Mergeable, ConceptArgs, Namespaced, ConstantInlineable, SelectContext, BaseModel):
+class Conditional(
+    Mergeable, ConceptArgs, Namespaced, ConstantInlineable, SelectContext, BaseModel
+):
     left: Union[
         int,
         str,
@@ -3739,7 +4282,11 @@ class Conditional(Mergeable, ConceptArgs, Namespaced, ConstantInlineable, Select
     def __eq__(self, other):
         if not isinstance(other, Conditional):
             return False
-        return self.left == other.left and self.right == other.right and self.operator == other.operator
+        return (
+            self.left == other.left
+            and self.right == other.right
+            and self.operator == other.operator
+        )
 
     def inline_constant(self, constant: Concept) -> "Conditional":
         assert isinstance(constant.lineage, Function)
@@ -3769,15 +4316,33 @@ class Conditional(Mergeable, ConceptArgs, Namespaced, ConstantInlineable, Select
 
     def with_namespace(self, namespace: str) -> "Conditional":
         return Conditional(
-            left=(self.left.with_namespace(namespace) if isinstance(self.left, Namespaced) else self.left),
-            right=(self.right.with_namespace(namespace) if isinstance(self.right, Namespaced) else self.right),
+            left=(
+                self.left.with_namespace(namespace)
+                if isinstance(self.left, Namespaced)
+                else self.left
+            ),
+            right=(
+                self.right.with_namespace(namespace)
+                if isinstance(self.right, Namespaced)
+                else self.right
+            ),
             operator=self.operator,
         )
 
-    def with_merge(self, source: Concept, target: Concept, modifiers: List[Modifier]) -> "Conditional":
+    def with_merge(
+        self, source: Concept, target: Concept, modifiers: List[Modifier]
+    ) -> "Conditional":
         return Conditional(
-            left=(self.left.with_merge(source, target, modifiers) if isinstance(self.left, Mergeable) else self.left),
-            right=(self.right.with_merge(source, target, modifiers) if isinstance(self.right, Mergeable) else self.right),
+            left=(
+                self.left.with_merge(source, target, modifiers)
+                if isinstance(self.left, Mergeable)
+                else self.left
+            ),
+            right=(
+                self.right.with_merge(source, target, modifiers)
+                if isinstance(self.right, Mergeable)
+                else self.right
+            ),
             operator=self.operator,
         )
 
@@ -3788,8 +4353,16 @@ class Conditional(Mergeable, ConceptArgs, Namespaced, ConstantInlineable, Select
         environment: Environment | None = None,
     ):
         return Conditional(
-            left=(self.left.with_select_context(grain, conditional, environment) if isinstance(self.left, SelectContext) else self.left),
-            right=(self.right.with_select_context(grain, conditional, environment) if isinstance(self.right, SelectContext) else self.right),
+            left=(
+                self.left.with_select_context(grain, conditional, environment)
+                if isinstance(self.left, SelectContext)
+                else self.left
+            ),
+            right=(
+                self.right.with_select_context(grain, conditional, environment)
+                if isinstance(self.right, SelectContext)
+                else self.right
+            ),
             operator=self.operator,
         )
 
@@ -3881,7 +4454,11 @@ class AggregateWrapper(Mergeable, Namespaced, SelectContext, BaseModel):
     def with_merge(self, source: Concept, target: Concept, modifiers: List[Modifier]):
         return AggregateWrapper(
             function=self.function.with_merge(source, target, modifiers=modifiers),
-            by=([c.with_merge(source, target, modifiers) for c in self.by] if self.by else []),
+            by=(
+                [c.with_merge(source, target, modifiers) for c in self.by]
+                if self.by
+                else []
+            ),
         )
 
     def with_namespace(self, namespace: str) -> "AggregateWrapper":
@@ -3927,7 +4504,9 @@ class WhereClause(Mergeable, ConceptArgs, Namespaced, SelectContext, BaseModel):
         return self.conditional.existence_arguments
 
     def with_merge(self, source: Concept, target: Concept, modifiers: List[Modifier]):
-        return WhereClause(conditional=self.conditional.with_merge(source, target, modifiers))
+        return WhereClause(
+            conditional=self.conditional.with_merge(source, target, modifiers)
+        )
 
     def with_namespace(self, namespace: str) -> WhereClause:
         return WhereClause(conditional=self.conditional.with_namespace(namespace))
@@ -3938,7 +4517,11 @@ class WhereClause(Mergeable, ConceptArgs, Namespaced, SelectContext, BaseModel):
         conditional: Conditional | Comparison | Parenthetical | None,
         environment: Environment | None = None,
     ) -> WhereClause:
-        return WhereClause(conditional=self.conditional.with_select_context(grain, conditional, environment))
+        return WhereClause(
+            conditional=self.conditional.with_select_context(
+                grain, conditional, environment
+            )
+        )
 
     @property
     def grain(self) -> Grain:
@@ -4055,11 +4638,17 @@ class RowsetDerivationStatement(HasUUID, Namespaced, BaseModel):
                 name=name,
                 datatype=orig_concept.datatype,
                 purpose=orig_concept.purpose,
-                lineage=RowsetItem(content=orig_concept, where=self.select.where_clause, rowset=self),
+                lineage=RowsetItem(
+                    content=orig_concept, where=self.select.where_clause, rowset=self
+                ),
                 grain=orig_concept.grain,
                 # TODO: add proper metadata
                 metadata=Metadata(concept_source=ConceptSource.CTE),
-                namespace=(f"{self.name}.{orig_concept.namespace}" if orig_concept.namespace != self.namespace else self.name),
+                namespace=(
+                    f"{self.name}.{orig_concept.namespace}"
+                    if orig_concept.namespace != self.namespace
+                    else self.name
+                ),
                 keys=orig_concept.keys,
             )
             orig[orig_concept.address] = new_concept
@@ -4069,13 +4658,17 @@ class RowsetDerivationStatement(HasUUID, Namespaced, BaseModel):
         for x in output:
             if x.keys:
                 if all([k.address in orig for k in x.keys]):
-                    x.keys = tuple([orig[k.address] if k.address in orig else k for k in x.keys])
+                    x.keys = tuple(
+                        [orig[k.address] if k.address in orig else k for k in x.keys]
+                    )
                 else:
                     # TODO: fix this up
                     x.keys = tuple()
         for x in output:
             if all([c.address in orig for c in x.grain.components_copy]):
-                x.grain = Grain(components=[orig[c.address] for c in x.grain.components_copy])
+                x.grain = Grain(
+                    components=[orig[c.address] for c in x.grain.components_copy]
+                )
             else:
                 x.grain = default_grain
         return output
@@ -4098,7 +4691,9 @@ class RowsetItem(Mergeable, Namespaced, BaseModel):
     where: Optional["WhereClause"] = None
 
     def __repr__(self):
-        return f"<Rowset<{self.rowset.name}>: {str(self.content)} where {str(self.where)}>"
+        return (
+            f"<Rowset<{self.rowset.name}>: {str(self.content)} where {str(self.where)}>"
+        )
 
     def __str__(self):
         return self.__repr__()
@@ -4107,7 +4702,9 @@ class RowsetItem(Mergeable, Namespaced, BaseModel):
         return RowsetItem(
             content=self.content.with_merge(source, target, modifiers),
             rowset=self.rowset,
-            where=(self.where.with_merge(source, target, modifiers) if self.where else None),
+            where=(
+                self.where.with_merge(source, target, modifiers) if self.where else None
+            ),
         )
 
     def with_namespace(self, namespace: str) -> "RowsetItem":
@@ -4159,7 +4756,9 @@ class RowsetItem(Mergeable, Namespaced, BaseModel):
         return [self.content]
 
 
-class Parenthetical(ConceptArgs, Mergeable, Namespaced, ConstantInlineable, SelectContext, BaseModel):
+class Parenthetical(
+    ConceptArgs, Mergeable, Namespaced, ConstantInlineable, SelectContext, BaseModel
+):
     content: "Expr"
 
     def __str__(self):
@@ -4176,10 +4775,22 @@ class Parenthetical(ConceptArgs, Mergeable, Namespaced, ConstantInlineable, Sele
         return f"({str(self.content)})"
 
     def with_namespace(self, namespace: str):
-        return Parenthetical(content=(self.content.with_namespace(namespace) if isinstance(self.content, Namespaced) else self.content))
+        return Parenthetical(
+            content=(
+                self.content.with_namespace(namespace)
+                if isinstance(self.content, Namespaced)
+                else self.content
+            )
+        )
 
     def with_merge(self, source: Concept, target: Concept, modifiers: List[Modifier]):
-        return Parenthetical(content=(self.content.with_merge(source, target, modifiers) if isinstance(self.content, Mergeable) else self.content))
+        return Parenthetical(
+            content=(
+                self.content.with_merge(source, target, modifiers)
+                if isinstance(self.content, Mergeable)
+                else self.content
+            )
+        )
 
     def with_select_context(
         self,
@@ -4187,10 +4798,22 @@ class Parenthetical(ConceptArgs, Mergeable, Namespaced, ConstantInlineable, Sele
         conditional: Conditional | Comparison | Parenthetical | None,
         environment: Environment | None = None,
     ):
-        return Parenthetical(content=(self.content.with_select_context(grain, conditional, environment) if isinstance(self.content, SelectContext) else self.content))
+        return Parenthetical(
+            content=(
+                self.content.with_select_context(grain, conditional, environment)
+                if isinstance(self.content, SelectContext)
+                else self.content
+            )
+        )
 
     def inline_constant(self, concept: Concept):
-        return Parenthetical(content=(self.content.inline_constant(concept) if isinstance(self.content, ConstantInlineable) else self.content))
+        return Parenthetical(
+            content=(
+                self.content.inline_constant(concept)
+                if isinstance(self.content, ConstantInlineable)
+                else self.content
+            )
+        )
 
     @property
     def concept_arguments(self) -> List[Concept]:
@@ -4239,7 +4862,9 @@ class TupleWrapper(Generic[VT], tuple):
         # self.type = type
 
     @classmethod
-    def __get_pydantic_core_schema__(cls, source_type: Any, handler: Callable[[Any], core_schema.CoreSchema]) -> core_schema.CoreSchema:
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: Callable[[Any], core_schema.CoreSchema]
+    ) -> core_schema.CoreSchema:
         args = get_args(source_type)
         if args:
             schema = handler(Tuple[args])  # type: ignore
@@ -4270,7 +4895,22 @@ class ShowStatement(BaseModel):
     content: SelectStatement | PersistStatement | ShowCategory
 
 
-Expr = bool | MagicConstants | int | str | float | list | WindowItem | FilterItem | Concept | Comparison | Conditional | Parenthetical | Function | AggregateWrapper
+Expr = (
+    bool
+    | MagicConstants
+    | int
+    | str
+    | float
+    | list
+    | WindowItem
+    | FilterItem
+    | Concept
+    | Comparison
+    | Conditional
+    | Parenthetical
+    | Function
+    | AggregateWrapper
+)
 
 
 Concept.model_rebuild()
@@ -4329,7 +4969,11 @@ def merge_datatypes(
         return DataType.FLOAT
     if set(inputs) == {DataType.INTEGER, DataType.NUMERIC}:
         return DataType.NUMERIC
-    if any(isinstance(x, NumericType) for x in inputs) and all(isinstance(x, NumericType) or x in (DataType.INTEGER, DataType.FLOAT, DataType.NUMERIC) for x in inputs):
+    if any(isinstance(x, NumericType) for x in inputs) and all(
+        isinstance(x, NumericType)
+        or x in (DataType.INTEGER, DataType.FLOAT, DataType.NUMERIC)
+        for x in inputs
+    ):
         candidate = next(x for x in inputs if isinstance(x, NumericType))
         return candidate
     return inputs[0]

--- a/trilogy/core/optimization.py
+++ b/trilogy/core/optimization.py
@@ -55,7 +55,9 @@ def reorder_ctes(
             return input
         return [mapping[x] for x in topological_order]
     except nx.NetworkXUnfeasible as e:
-        print("The graph is not a DAG (contains cycles) and cannot be topologically sorted.")
+        print(
+            "The graph is not a DAG (contains cycles) and cannot be topologically sorted."
+        )
         raise e
 
 
@@ -133,9 +135,18 @@ def is_direct_return_eligible(cte: CTE | UnionCTE) -> CTE | UnionCTE | None:
         return None
 
     assert isinstance(cte, CTE)
-    derived_concepts = [c for c in cte.source.output_concepts + cte.source.hidden_concepts if c not in cte.source.input_concepts]
+    derived_concepts = [
+        c
+        for c in cte.source.output_concepts + cte.source.hidden_concepts
+        if c not in cte.source.input_concepts
+    ]
 
-    parent_derived_concepts = [c for c in direct_parent.source.output_concepts + direct_parent.source.hidden_concepts if c not in direct_parent.source.input_concepts]
+    parent_derived_concepts = [
+        c
+        for c in direct_parent.source.output_concepts
+        + direct_parent.source.hidden_concepts
+        if c not in direct_parent.source.input_concepts
+    ]
     condition_arguments = cte.condition.row_arguments if cte.condition else []
     for x in derived_concepts:
         if x.derivation == PurposeLineage.WINDOW:
@@ -152,7 +163,9 @@ def is_direct_return_eligible(cte: CTE | UnionCTE) -> CTE | UnionCTE | None:
         if x.derivation == PurposeLineage.WINDOW:
             return None
 
-    logger.info(f"[Optimization][EarlyReturn] Removing redundant output CTE with derived_concepts {[x.address for x in derived_concepts]}")
+    logger.info(
+        f"[Optimization][EarlyReturn] Removing redundant output CTE with derived_concepts {[x.address for x in derived_concepts]}"
+    )
     return direct_parent
 
 
@@ -162,10 +175,14 @@ def optimize_ctes(
     select: SelectStatement | MultiSelectStatement,
 ) -> list[CTE | UnionCTE]:
     direct_parent: CTE | UnionCTE | None = root_cte
-    while CONFIG.optimizations.direct_return and (direct_parent := is_direct_return_eligible(root_cte)):
+    while CONFIG.optimizations.direct_return and (
+        direct_parent := is_direct_return_eligible(root_cte)
+    ):
         direct_parent.order_by = root_cte.order_by
         direct_parent.limit = root_cte.limit
-        direct_parent.hidden_concepts = root_cte.hidden_concepts + direct_parent.hidden_concepts
+        direct_parent.hidden_concepts = (
+            root_cte.hidden_concepts + direct_parent.hidden_concepts
+        )
         if root_cte.condition:
             if direct_parent.condition:
                 direct_parent.condition = Conditional(

--- a/trilogy/core/optimizations/__init__.py
+++ b/trilogy/core/optimizations/__init__.py
@@ -1,7 +1,7 @@
+from .base_optimization import OptimizationRule
 from .inline_constant import InlineConstant
 from .inline_datasource import InlineDatasource
 from .predicate_pushdown import PredicatePushdown, PredicatePushdownRemove
-from .base_optimization import OptimizationRule
 
 __all__ = [
     "OptimizationRule",

--- a/trilogy/core/optimizations/base_optimization.py
+++ b/trilogy/core/optimizations/base_optimization.py
@@ -1,13 +1,13 @@
-from trilogy.core.models import (
-    CTE,
-)
+from trilogy.core.models import CTE, UnionCTE
 from trilogy.constants import logger
 from abc import ABC
 
 
 class OptimizationRule(ABC):
 
-    def optimize(self, cte: CTE, inverse_map: dict[str, list[CTE]]) -> bool:
+    def optimize(
+        self, cte: CTE | UnionCTE, inverse_map: dict[str, list[CTE | UnionCTE]]
+    ) -> bool:
         raise NotImplementedError
 
     def log(self, message: str):

--- a/trilogy/core/optimizations/base_optimization.py
+++ b/trilogy/core/optimizations/base_optimization.py
@@ -5,7 +5,9 @@ from trilogy.core.models import CTE, UnionCTE
 
 
 class OptimizationRule(ABC):
-    def optimize(self, cte: CTE | UnionCTE, inverse_map: dict[str, list[CTE | UnionCTE]]) -> bool:
+    def optimize(
+        self, cte: CTE | UnionCTE, inverse_map: dict[str, list[CTE | UnionCTE]]
+    ) -> bool:
         raise NotImplementedError
 
     def log(self, message: str):

--- a/trilogy/core/optimizations/base_optimization.py
+++ b/trilogy/core/optimizations/base_optimization.py
@@ -1,13 +1,11 @@
-from trilogy.core.models import CTE, UnionCTE
-from trilogy.constants import logger
 from abc import ABC
+
+from trilogy.constants import logger
+from trilogy.core.models import CTE, UnionCTE
 
 
 class OptimizationRule(ABC):
-
-    def optimize(
-        self, cte: CTE | UnionCTE, inverse_map: dict[str, list[CTE | UnionCTE]]
-    ) -> bool:
+    def optimize(self, cte: CTE | UnionCTE, inverse_map: dict[str, list[CTE | UnionCTE]]) -> bool:
         raise NotImplementedError
 
     def log(self, message: str):

--- a/trilogy/core/optimizations/inline_constant.py
+++ b/trilogy/core/optimizations/inline_constant.py
@@ -1,18 +1,14 @@
+from trilogy.core.enums import PurposeLineage
 from trilogy.core.models import (
     CTE,
-    UnionCTE,
     Concept,
+    UnionCTE,
 )
-from trilogy.core.enums import PurposeLineage
-
 from trilogy.core.optimizations.base_optimization import OptimizationRule
 
 
 class InlineConstant(OptimizationRule):
-
-    def optimize(
-        self, cte: CTE | UnionCTE, inverse_map: dict[str, list[CTE | UnionCTE]]
-    ) -> bool:
+    def optimize(self, cte: CTE | UnionCTE, inverse_map: dict[str, list[CTE | UnionCTE]]) -> bool:
         if isinstance(cte, UnionCTE):
             return any(self.optimize(x, inverse_map) for x in cte.internal_ctes)
 

--- a/trilogy/core/optimizations/inline_constant.py
+++ b/trilogy/core/optimizations/inline_constant.py
@@ -10,9 +10,11 @@ from trilogy.core.optimizations.base_optimization import OptimizationRule
 
 class InlineConstant(OptimizationRule):
 
-    def optimize(self, cte: CTE, inverse_map: dict[str, list[CTE]]) -> bool:
+    def optimize(
+        self, cte: CTE | UnionCTE, inverse_map: dict[str, list[CTE | UnionCTE]]
+    ) -> bool:
         if isinstance(cte, UnionCTE):
-            return False
+            return any(self.optimize(x, inverse_map) for x in cte.internal_ctes)
 
         to_inline: list[Concept] = []
         for x in cte.source.input_concepts:

--- a/trilogy/core/optimizations/inline_constant.py
+++ b/trilogy/core/optimizations/inline_constant.py
@@ -1,5 +1,6 @@
 from trilogy.core.models import (
     CTE,
+    UnionCTE,
     Concept,
 )
 from trilogy.core.enums import PurposeLineage
@@ -10,6 +11,8 @@ from trilogy.core.optimizations.base_optimization import OptimizationRule
 class InlineConstant(OptimizationRule):
 
     def optimize(self, cte: CTE, inverse_map: dict[str, list[CTE]]) -> bool:
+        if isinstance(cte, UnionCTE):
+            return False
 
         to_inline: list[Concept] = []
         for x in cte.source.input_concepts:

--- a/trilogy/core/optimizations/inline_constant.py
+++ b/trilogy/core/optimizations/inline_constant.py
@@ -8,7 +8,9 @@ from trilogy.core.optimizations.base_optimization import OptimizationRule
 
 
 class InlineConstant(OptimizationRule):
-    def optimize(self, cte: CTE | UnionCTE, inverse_map: dict[str, list[CTE | UnionCTE]]) -> bool:
+    def optimize(
+        self, cte: CTE | UnionCTE, inverse_map: dict[str, list[CTE | UnionCTE]]
+    ) -> bool:
         if isinstance(cte, UnionCTE):
             return any(self.optimize(x, inverse_map) for x in cte.internal_ctes)
 

--- a/trilogy/core/optimizations/inline_datasource.py
+++ b/trilogy/core/optimizations/inline_datasource.py
@@ -15,14 +15,20 @@ class InlineDatasource(OptimizationRule):
         self.candidates = defaultdict(lambda: set())
         self.count = defaultdict(lambda: 0)
 
-    def optimize(self, cte: CTE | UnionCTE, inverse_map: dict[str, list[CTE | UnionCTE]]) -> bool:
+    def optimize(
+        self, cte: CTE | UnionCTE, inverse_map: dict[str, list[CTE | UnionCTE]]
+    ) -> bool:
         if isinstance(cte, UnionCTE):
-            return any(self.optimize(x, inverse_map=inverse_map) for x in cte.internal_ctes)
+            return any(
+                self.optimize(x, inverse_map=inverse_map) for x in cte.internal_ctes
+            )
 
         if not cte.parent_ctes:
             return False
 
-        self.debug(f"Checking {cte.name} for consolidating inline tables with {len(cte.parent_ctes)} parents")
+        self.debug(
+            f"Checking {cte.name} for consolidating inline tables with {len(cte.parent_ctes)} parents"
+        )
         to_inline: list[CTE] = []
         force_group = False
         for parent_cte in cte.parent_ctes:
@@ -46,13 +52,19 @@ class InlineDatasource(OptimizationRule):
                 self.debug(f"Parent {parent_cte.name} datasource is not inlineable")
                 continue
             root_outputs = {x.address for x in root.output_concepts}
-            inherited = {x for x, v in cte.source_map.items() if v and parent_cte.name in v}
+            inherited = {
+                x for x, v in cte.source_map.items() if v and parent_cte.name in v
+            }
             if not inherited.issubset(root_outputs):
                 cte_missing = inherited - root_outputs
-                self.log(f"Not all {parent_cte.name} require inputs are found on datasource, missing {cte_missing}")
+                self.log(
+                    f"Not all {parent_cte.name} require inputs are found on datasource, missing {cte_missing}"
+                )
                 continue
             if not root.grain.issubset(parent_cte.grain):
-                self.log(f"{parent_cte.name} is at wrong grain to inline ({root.grain} vs {parent_cte.grain})")
+                self.log(
+                    f"{parent_cte.name} is at wrong grain to inline ({root.grain} vs {parent_cte.grain})"
+                )
                 continue
             to_inline.append(parent_cte)
 
@@ -62,15 +74,24 @@ class InlineDatasource(OptimizationRule):
                 self.candidates[cte.name].add(replaceable.name)
                 self.count[replaceable.source.identifier] += 1
                 return True
-            if self.count[replaceable.source.identifier] > CONFIG.optimizations.constant_inline_cutoff:
-                self.log(f"Skipping inlining raw datasource {replaceable.source.identifier} ({replaceable.name}) due to multiple references")
+            if (
+                self.count[replaceable.source.identifier]
+                > CONFIG.optimizations.constant_inline_cutoff
+            ):
+                self.log(
+                    f"Skipping inlining raw datasource {replaceable.source.identifier} ({replaceable.name}) due to multiple references"
+                )
                 continue
             if not replaceable.source.datasources[0].grain.issubset(replaceable.grain):
-                self.log(f"Forcing group ({parent_cte.grain} being replaced by inlined source {root.grain})")
+                self.log(
+                    f"Forcing group ({parent_cte.grain} being replaced by inlined source {root.grain})"
+                )
                 force_group = True
             result = cte.inline_parent_datasource(replaceable, force_group=force_group)
             if result:
-                self.log(f"Inlined parent {replaceable.name} with {replaceable.source.identifier}")
+                self.log(
+                    f"Inlined parent {replaceable.name} with {replaceable.source.identifier}"
+                )
                 optimized = True
             else:
                 self.log(f"Failed to inline {replaceable.name}")

--- a/trilogy/core/optimizations/inline_datasource.py
+++ b/trilogy/core/optimizations/inline_datasource.py
@@ -1,35 +1,28 @@
+from collections import defaultdict
+
+from trilogy.constants import CONFIG
 from trilogy.core.models import (
     CTE,
-    UnionCTE,
     Datasource,
+    UnionCTE,
 )
-
 from trilogy.core.optimizations.base_optimization import OptimizationRule
-from collections import defaultdict
-from trilogy.constants import CONFIG
 
 
 class InlineDatasource(OptimizationRule):
-
     def __init__(self):
         super().__init__()
         self.candidates = defaultdict(lambda: set())
         self.count = defaultdict(lambda: 0)
 
-    def optimize(
-        self, cte: CTE | UnionCTE, inverse_map: dict[str, list[CTE | UnionCTE]]
-    ) -> bool:
+    def optimize(self, cte: CTE | UnionCTE, inverse_map: dict[str, list[CTE | UnionCTE]]) -> bool:
         if isinstance(cte, UnionCTE):
-            return any(
-                self.optimize(x, inverse_map=inverse_map) for x in cte.internal_ctes
-            )
+            return any(self.optimize(x, inverse_map=inverse_map) for x in cte.internal_ctes)
 
         if not cte.parent_ctes:
             return False
 
-        self.debug(
-            f"Checking {cte.name} for consolidating inline tables with {len(cte.parent_ctes)} parents"
-        )
+        self.debug(f"Checking {cte.name} for consolidating inline tables with {len(cte.parent_ctes)} parents")
         to_inline: list[CTE] = []
         force_group = False
         for parent_cte in cte.parent_ctes:
@@ -53,19 +46,13 @@ class InlineDatasource(OptimizationRule):
                 self.debug(f"Parent {parent_cte.name} datasource is not inlineable")
                 continue
             root_outputs = {x.address for x in root.output_concepts}
-            inherited = {
-                x for x, v in cte.source_map.items() if v and parent_cte.name in v
-            }
+            inherited = {x for x, v in cte.source_map.items() if v and parent_cte.name in v}
             if not inherited.issubset(root_outputs):
                 cte_missing = inherited - root_outputs
-                self.log(
-                    f"Not all {parent_cte.name} require inputs are found on datasource, missing {cte_missing}"
-                )
+                self.log(f"Not all {parent_cte.name} require inputs are found on datasource, missing {cte_missing}")
                 continue
             if not root.grain.issubset(parent_cte.grain):
-                self.log(
-                    f"{parent_cte.name} is at wrong grain to inline ({root.grain} vs {parent_cte.grain})"
-                )
+                self.log(f"{parent_cte.name} is at wrong grain to inline ({root.grain} vs {parent_cte.grain})")
                 continue
             to_inline.append(parent_cte)
 
@@ -75,24 +62,15 @@ class InlineDatasource(OptimizationRule):
                 self.candidates[cte.name].add(replaceable.name)
                 self.count[replaceable.source.identifier] += 1
                 return True
-            if (
-                self.count[replaceable.source.identifier]
-                > CONFIG.optimizations.constant_inline_cutoff
-            ):
-                self.log(
-                    f"Skipping inlining raw datasource {replaceable.source.identifier} ({replaceable.name}) due to multiple references"
-                )
+            if self.count[replaceable.source.identifier] > CONFIG.optimizations.constant_inline_cutoff:
+                self.log(f"Skipping inlining raw datasource {replaceable.source.identifier} ({replaceable.name}) due to multiple references")
                 continue
             if not replaceable.source.datasources[0].grain.issubset(replaceable.grain):
-                self.log(
-                    f"Forcing group ({parent_cte.grain} being replaced by inlined source {root.grain})"
-                )
+                self.log(f"Forcing group ({parent_cte.grain} being replaced by inlined source {root.grain})")
                 force_group = True
             result = cte.inline_parent_datasource(replaceable, force_group=force_group)
             if result:
-                self.log(
-                    f"Inlined parent {replaceable.name} with {replaceable.source.identifier}"
-                )
+                self.log(f"Inlined parent {replaceable.name} with {replaceable.source.identifier}")
                 optimized = True
             else:
                 self.log(f"Failed to inline {replaceable.name}")

--- a/trilogy/core/optimizations/predicate_pushdown.py
+++ b/trilogy/core/optimizations/predicate_pushdown.py
@@ -1,5 +1,6 @@
 from trilogy.core.models import (
     CTE,
+    UnionCTE,
     BooleanOperator,
     Comparison,
     ConceptArgs,
@@ -18,7 +19,9 @@ def is_child_of(a, comparison):
     if base:
         return True
     if isinstance(comparison, Conditional):
-        return (is_child_of(a, comparison.left) or is_child_of(a, comparison.right)) and comparison.operator == BooleanOperator.AND
+        return (
+            is_child_of(a, comparison.left) or is_child_of(a, comparison.right)
+        ) and comparison.operator == BooleanOperator.AND
     return base
 
 
@@ -39,7 +42,9 @@ class PredicatePushdown(OptimizationRule):
         if not isinstance(parent_cte, CTE):
             return False
         row_conditions = {x.address for x in candidate.row_arguments}
-        existence_conditions = {y.address for x in candidate.existence_arguments for y in x}
+        existence_conditions = {
+            y.address for x in candidate.existence_arguments for y in x
+        }
         all_inputs = {x.address for x in candidate.concept_arguments}
         if is_child_of(candidate, parent_cte.condition):
             return False
@@ -61,17 +66,25 @@ class PredicatePushdown(OptimizationRule):
             return False
         # if it's a root datasource, we can filter on _any_ of the output concepts
         if parent_cte.is_root_datasource:
-            extra_check = {x.address for x in parent_cte.source.datasources[0].output_concepts}
+            extra_check = {
+                x.address for x in parent_cte.source.datasources[0].output_concepts
+            }
             if row_conditions.issubset(extra_check):
                 for x in row_conditions:
                     if x not in materialized:
                         materialized.add(x)
-                        parent_cte.source_map[x] = [parent_cte.source.datasources[0].name]
+                        parent_cte.source_map[x] = [
+                            parent_cte.source.datasources[0].name
+                        ]
         if row_conditions.issubset(materialized):
             children = inverse_map.get(parent_cte.name, [])
             if all([is_child_of(candidate, child.condition) for child in children]):
-                self.log(f"All concepts are found on {parent_cte.name} with existing {parent_cte.condition} and all it's {len(children)} children include same filter; pushing up {candidate}")
-                if parent_cte.condition and not is_scalar_condition(parent_cte.condition):
+                self.log(
+                    f"All concepts are found on {parent_cte.name} with existing {parent_cte.condition} and all it's {len(children)} children include same filter; pushing up {candidate}"
+                )
+                if parent_cte.condition and not is_scalar_condition(
+                    parent_cte.condition
+                ):
                     self.log("Parent condition is not scalar, not safe to push up")
                     return False
                 if parent_cte.condition:
@@ -86,14 +99,24 @@ class PredicatePushdown(OptimizationRule):
                 if all_inputs.difference(row_conditions):
                     for x in all_inputs.difference(row_conditions):
                         if x not in parent_cte.source_map and x in cte.source_map:
-                            sources = [parent for parent in cte.parent_ctes if parent.name in cte.source_map[x]]
+                            sources = [
+                                parent
+                                for parent in cte.parent_ctes
+                                if parent.name in cte.source_map[x]
+                            ]
                             parent_cte.source_map[x] = cte.source_map[x]
-                            parent_cte.parent_ctes = unique(parent_cte.parent_ctes + sources, "name")
+                            parent_cte.parent_ctes = unique(
+                                parent_cte.parent_ctes + sources, "name"
+                            )
                 return True
-        self.debug(f"conditions {row_conditions} not subset of parent {parent_cte.name} parent has {materialized} ")
+        self.debug(
+            f"conditions {row_conditions} not subset of parent {parent_cte.name} parent has {materialized} "
+        )
         return False
 
-    def optimize(self, cte: CTE | UnionCTE, inverse_map: dict[str, list[CTE | UnionCTE]]) -> bool:
+    def optimize(
+        self, cte: CTE | UnionCTE, inverse_map: dict[str, list[CTE | UnionCTE]]
+    ) -> bool:
         # TODO - pushdown through unions
         if isinstance(cte, UnionCTE):
             return False
@@ -111,18 +134,26 @@ class PredicatePushdown(OptimizationRule):
             self.debug("Have done this CTE before")
             return False
 
-        self.debug(f"Checking {cte.name} for predicate pushdown with {len(cte.parent_ctes)} parents")
+        self.debug(
+            f"Checking {cte.name} for predicate pushdown with {len(cte.parent_ctes)} parents"
+        )
         if isinstance(cte.condition, Conditional):
             candidates = cte.condition.decompose()
         else:
             candidates = [cte.condition]
-        self.debug(f"Have {len(candidates)} candidates to try to push down from parent {type(cte.condition)}")
+        self.debug(
+            f"Have {len(candidates)} candidates to try to push down from parent {type(cte.condition)}"
+        )
         optimized = False
         for candidate in candidates:
             if not is_scalar_condition(candidate):
-                self.debug(f"Skipping {candidate} as not a basic [no aggregate, etc] condition")
+                self.debug(
+                    f"Skipping {candidate} as not a basic [no aggregate, etc] condition"
+                )
                 continue
-            self.debug(f"Checking candidate {candidate}, {type(candidate)}, scalar: {is_scalar_condition(candidate)}")
+            self.debug(
+                f"Checking candidate {candidate}, {type(candidate)}, scalar: {is_scalar_condition(candidate)}"
+            )
             for parent_cte in cte.parent_ctes:
                 local_pushdown = self._check_parent(
                     cte=cte,
@@ -134,7 +165,9 @@ class PredicatePushdown(OptimizationRule):
                 if local_pushdown:
                     # taint a CTE again when something is pushed up to it.
                     self.complete[parent_cte.name] = False
-                self.debug(f"Pushed down {candidate} from {cte.name} to {parent_cte.name}")
+                self.debug(
+                    f"Pushed down {candidate} from {cte.name} to {parent_cte.name}"
+                )
 
         self.complete[cte.name] = True
         return optimized
@@ -145,7 +178,9 @@ class PredicatePushdownRemove(OptimizationRule):
         super().__init__(*args, **kwargs)
         self.complete: dict[str, bool] = {}
 
-    def optimize(self, cte: CTE | UnionCTE, inverse_map: dict[str, list[CTE | UnionCTE]]) -> bool:
+    def optimize(
+        self, cte: CTE | UnionCTE, inverse_map: dict[str, list[CTE | UnionCTE]]
+    ) -> bool:
         if isinstance(cte, UnionCTE):
             return False
         optimized = False
@@ -159,20 +194,42 @@ class PredicatePushdownRemove(OptimizationRule):
             self.debug(f"No CTE condition for {cte.name}")
             return False
 
-        parent_filter_status = {parent.name: is_child_of(cte.condition, parent.condition) for parent in cte.parent_ctes}
+        parent_filter_status = {
+            parent.name: is_child_of(cte.condition, parent.condition)
+            for parent in cte.parent_ctes
+        }
         # flatten existnce argument tuples to a list
 
-        flattened_existence = [x.address for y in cte.condition.existence_arguments for x in y]
+        flattened_existence = [
+            x.address for y in cte.condition.existence_arguments for x in y
+        ]
 
-        existence_only = [parent.name for parent in cte.parent_ctes if all([x.address in flattened_existence for x in parent.output_columns]) and len(flattened_existence) > 0]
-        if all([value for key, value in parent_filter_status.items() if key not in existence_only]) and not any([isinstance(x, Datasource) for x in cte.source.datasources]):
-            self.log(f"All parents of {cte.name} have same filter or are existence only inputs, removing filter from {cte.name}")
+        existence_only = [
+            parent.name
+            for parent in cte.parent_ctes
+            if all([x.address in flattened_existence for x in parent.output_columns])
+            and len(flattened_existence) > 0
+        ]
+        if all(
+            [
+                value
+                for key, value in parent_filter_status.items()
+                if key not in existence_only
+            ]
+        ) and not any([isinstance(x, Datasource) for x in cte.source.datasources]):
+            self.log(
+                f"All parents of {cte.name} have same filter or are existence only inputs, removing filter from {cte.name}"
+            )
             cte.condition = None
             # remove any "parent" CTEs that provided only existence inputs
             if existence_only:
                 original = [y.name for y in cte.parent_ctes]
-                cte.parent_ctes = [x for x in cte.parent_ctes if x.name not in existence_only]
-                self.log(f"new parents for {cte.name} are {[x.name for x in cte.parent_ctes]}, vs {original}")
+                cte.parent_ctes = [
+                    x for x in cte.parent_ctes if x.name not in existence_only
+                ]
+                self.log(
+                    f"new parents for {cte.name} are {[x.name for x in cte.parent_ctes]}, vs {original}"
+                )
             return True
 
         self.complete[cte.name] = True

--- a/trilogy/core/optimizations/predicate_pushdown.py
+++ b/trilogy/core/optimizations/predicate_pushdown.py
@@ -1,12 +1,12 @@
 from trilogy.core.models import (
     CTE,
-    UnionCTE,
     BooleanOperator,
     Comparison,
     ConceptArgs,
     Conditional,
     Datasource,
     Parenthetical,
+    UnionCTE,
     WindowItem,
 )
 from trilogy.core.optimizations.base_optimization import OptimizationRule

--- a/trilogy/core/optimizations/predicate_pushdown.py
+++ b/trilogy/core/optimizations/predicate_pushdown.py
@@ -32,12 +32,14 @@ class PredicatePushdown(OptimizationRule):
 
     def _check_parent(
         self,
-        cte: CTE,
-        parent_cte: CTE,
+        cte: CTE | UnionCTE,
+        parent_cte: CTE | UnionCTE,
         candidate: Conditional | Comparison | Parenthetical | None,
-        inverse_map: dict[str, list[CTE]],
+        inverse_map: dict[str, list[CTE | UnionCTE]],
     ):
         if not isinstance(candidate, ConceptArgs):
+            return False
+        if not isinstance(parent_cte, CTE):
             return False
         row_conditions = {x.address for x in candidate.row_arguments}
         existence_conditions = {
@@ -112,7 +114,9 @@ class PredicatePushdown(OptimizationRule):
         )
         return False
 
-    def optimize(self, cte: CTE, inverse_map: dict[str, list[CTE]]) -> bool:
+    def optimize(
+        self, cte: CTE | UnionCTE, inverse_map: dict[str, list[CTE | UnionCTE]]
+    ) -> bool:
         # TODO - pushdown through unions
         if isinstance(cte, UnionCTE):
             return False
@@ -175,7 +179,9 @@ class PredicatePushdownRemove(OptimizationRule):
         super().__init__(*args, **kwargs)
         self.complete: dict[str, bool] = {}
 
-    def optimize(self, cte: CTE, inverse_map: dict[str, list[CTE]]) -> bool:
+    def optimize(
+        self, cte: CTE | UnionCTE, inverse_map: dict[str, list[CTE | UnionCTE]]
+    ) -> bool:
         if isinstance(cte, UnionCTE):
             return False
         optimized = False

--- a/trilogy/core/optimizations/predicate_pushdown.py
+++ b/trilogy/core/optimizations/predicate_pushdown.py
@@ -1,10 +1,10 @@
 from trilogy.core.models import (
     CTE,
-    Conditional,
     BooleanOperator,
-    Datasource,
-    ConceptArgs,
     Comparison,
+    ConceptArgs,
+    Conditional,
+    Datasource,
     Parenthetical,
     WindowItem,
 )
@@ -18,14 +18,11 @@ def is_child_of(a, comparison):
     if base:
         return True
     if isinstance(comparison, Conditional):
-        return (
-            is_child_of(a, comparison.left) or is_child_of(a, comparison.right)
-        ) and comparison.operator == BooleanOperator.AND
+        return (is_child_of(a, comparison.left) or is_child_of(a, comparison.right)) and comparison.operator == BooleanOperator.AND
     return base
 
 
 class PredicatePushdown(OptimizationRule):
-
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.complete: dict[str, bool] = {}
@@ -42,9 +39,7 @@ class PredicatePushdown(OptimizationRule):
         if not isinstance(parent_cte, CTE):
             return False
         row_conditions = {x.address for x in candidate.row_arguments}
-        existence_conditions = {
-            y.address for x in candidate.existence_arguments for y in x
-        }
+        existence_conditions = {y.address for x in candidate.existence_arguments for y in x}
         all_inputs = {x.address for x in candidate.concept_arguments}
         if is_child_of(candidate, parent_cte.condition):
             return False
@@ -66,25 +61,17 @@ class PredicatePushdown(OptimizationRule):
             return False
         # if it's a root datasource, we can filter on _any_ of the output concepts
         if parent_cte.is_root_datasource:
-            extra_check = {
-                x.address for x in parent_cte.source.datasources[0].output_concepts
-            }
+            extra_check = {x.address for x in parent_cte.source.datasources[0].output_concepts}
             if row_conditions.issubset(extra_check):
                 for x in row_conditions:
                     if x not in materialized:
                         materialized.add(x)
-                        parent_cte.source_map[x] = [
-                            parent_cte.source.datasources[0].name
-                        ]
+                        parent_cte.source_map[x] = [parent_cte.source.datasources[0].name]
         if row_conditions.issubset(materialized):
             children = inverse_map.get(parent_cte.name, [])
             if all([is_child_of(candidate, child.condition) for child in children]):
-                self.log(
-                    f"All concepts are found on {parent_cte.name} with existing {parent_cte.condition} and all it's {len(children)} children include same filter; pushing up {candidate}"
-                )
-                if parent_cte.condition and not is_scalar_condition(
-                    parent_cte.condition
-                ):
+                self.log(f"All concepts are found on {parent_cte.name} with existing {parent_cte.condition} and all it's {len(children)} children include same filter; pushing up {candidate}")
+                if parent_cte.condition and not is_scalar_condition(parent_cte.condition):
                     self.log("Parent condition is not scalar, not safe to push up")
                     return False
                 if parent_cte.condition:
@@ -99,24 +86,14 @@ class PredicatePushdown(OptimizationRule):
                 if all_inputs.difference(row_conditions):
                     for x in all_inputs.difference(row_conditions):
                         if x not in parent_cte.source_map and x in cte.source_map:
-                            sources = [
-                                parent
-                                for parent in cte.parent_ctes
-                                if parent.name in cte.source_map[x]
-                            ]
+                            sources = [parent for parent in cte.parent_ctes if parent.name in cte.source_map[x]]
                             parent_cte.source_map[x] = cte.source_map[x]
-                            parent_cte.parent_ctes = unique(
-                                parent_cte.parent_ctes + sources, "name"
-                            )
+                            parent_cte.parent_ctes = unique(parent_cte.parent_ctes + sources, "name")
                 return True
-        self.debug(
-            f"conditions {row_conditions} not subset of parent {parent_cte.name} parent has {materialized} "
-        )
+        self.debug(f"conditions {row_conditions} not subset of parent {parent_cte.name} parent has {materialized} ")
         return False
 
-    def optimize(
-        self, cte: CTE | UnionCTE, inverse_map: dict[str, list[CTE | UnionCTE]]
-    ) -> bool:
+    def optimize(self, cte: CTE | UnionCTE, inverse_map: dict[str, list[CTE | UnionCTE]]) -> bool:
         # TODO - pushdown through unions
         if isinstance(cte, UnionCTE):
             return False
@@ -134,26 +111,18 @@ class PredicatePushdown(OptimizationRule):
             self.debug("Have done this CTE before")
             return False
 
-        self.debug(
-            f"Checking {cte.name} for predicate pushdown with {len(cte.parent_ctes)} parents"
-        )
+        self.debug(f"Checking {cte.name} for predicate pushdown with {len(cte.parent_ctes)} parents")
         if isinstance(cte.condition, Conditional):
             candidates = cte.condition.decompose()
         else:
             candidates = [cte.condition]
-        self.debug(
-            f"Have {len(candidates)} candidates to try to push down from parent {type(cte.condition)}"
-        )
+        self.debug(f"Have {len(candidates)} candidates to try to push down from parent {type(cte.condition)}")
         optimized = False
         for candidate in candidates:
             if not is_scalar_condition(candidate):
-                self.debug(
-                    f"Skipping {candidate} as not a basic [no aggregate, etc] condition"
-                )
+                self.debug(f"Skipping {candidate} as not a basic [no aggregate, etc] condition")
                 continue
-            self.debug(
-                f"Checking candidate {candidate}, {type(candidate)}, scalar: {is_scalar_condition(candidate)}"
-            )
+            self.debug(f"Checking candidate {candidate}, {type(candidate)}, scalar: {is_scalar_condition(candidate)}")
             for parent_cte in cte.parent_ctes:
                 local_pushdown = self._check_parent(
                     cte=cte,
@@ -165,23 +134,18 @@ class PredicatePushdown(OptimizationRule):
                 if local_pushdown:
                     # taint a CTE again when something is pushed up to it.
                     self.complete[parent_cte.name] = False
-                self.debug(
-                    f"Pushed down {candidate} from {cte.name} to {parent_cte.name}"
-                )
+                self.debug(f"Pushed down {candidate} from {cte.name} to {parent_cte.name}")
 
         self.complete[cte.name] = True
         return optimized
 
 
 class PredicatePushdownRemove(OptimizationRule):
-
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.complete: dict[str, bool] = {}
 
-    def optimize(
-        self, cte: CTE | UnionCTE, inverse_map: dict[str, list[CTE | UnionCTE]]
-    ) -> bool:
+    def optimize(self, cte: CTE | UnionCTE, inverse_map: dict[str, list[CTE | UnionCTE]]) -> bool:
         if isinstance(cte, UnionCTE):
             return False
         optimized = False
@@ -195,42 +159,20 @@ class PredicatePushdownRemove(OptimizationRule):
             self.debug(f"No CTE condition for {cte.name}")
             return False
 
-        parent_filter_status = {
-            parent.name: is_child_of(cte.condition, parent.condition)
-            for parent in cte.parent_ctes
-        }
+        parent_filter_status = {parent.name: is_child_of(cte.condition, parent.condition) for parent in cte.parent_ctes}
         # flatten existnce argument tuples to a list
 
-        flattened_existence = [
-            x.address for y in cte.condition.existence_arguments for x in y
-        ]
+        flattened_existence = [x.address for y in cte.condition.existence_arguments for x in y]
 
-        existence_only = [
-            parent.name
-            for parent in cte.parent_ctes
-            if all([x.address in flattened_existence for x in parent.output_columns])
-            and len(flattened_existence) > 0
-        ]
-        if all(
-            [
-                value
-                for key, value in parent_filter_status.items()
-                if key not in existence_only
-            ]
-        ) and not any([isinstance(x, Datasource) for x in cte.source.datasources]):
-            self.log(
-                f"All parents of {cte.name} have same filter or are existence only inputs, removing filter from {cte.name}"
-            )
+        existence_only = [parent.name for parent in cte.parent_ctes if all([x.address in flattened_existence for x in parent.output_columns]) and len(flattened_existence) > 0]
+        if all([value for key, value in parent_filter_status.items() if key not in existence_only]) and not any([isinstance(x, Datasource) for x in cte.source.datasources]):
+            self.log(f"All parents of {cte.name} have same filter or are existence only inputs, removing filter from {cte.name}")
             cte.condition = None
             # remove any "parent" CTEs that provided only existence inputs
             if existence_only:
                 original = [y.name for y in cte.parent_ctes]
-                cte.parent_ctes = [
-                    x for x in cte.parent_ctes if x.name not in existence_only
-                ]
-                self.log(
-                    f"new parents for {cte.name} are {[x.name for x in cte.parent_ctes]}, vs {original}"
-                )
+                cte.parent_ctes = [x for x in cte.parent_ctes if x.name not in existence_only]
+                self.log(f"new parents for {cte.name} are {[x.name for x in cte.parent_ctes]}, vs {original}")
             return True
 
         self.complete[cte.name] = True

--- a/trilogy/core/optimizations/predicate_pushdown.py
+++ b/trilogy/core/optimizations/predicate_pushdown.py
@@ -113,6 +113,9 @@ class PredicatePushdown(OptimizationRule):
         return False
 
     def optimize(self, cte: CTE, inverse_map: dict[str, list[CTE]]) -> bool:
+        # TODO - pushdown through unions
+        if isinstance(cte, UnionCTE):
+            return False
         optimized = False
 
         if not cte.parent_ctes:
@@ -173,6 +176,8 @@ class PredicatePushdownRemove(OptimizationRule):
         self.complete: dict[str, bool] = {}
 
     def optimize(self, cte: CTE, inverse_map: dict[str, list[CTE]]) -> bool:
+        if isinstance(cte, UnionCTE):
+            return False
         optimized = False
 
         if not cte.parent_ctes:

--- a/trilogy/core/processing/concept_strategies_v3.py
+++ b/trilogy/core/processing/concept_strategies_v3.py
@@ -1,42 +1,41 @@
 from collections import defaultdict
+from enum import Enum
 from typing import List, Optional, Protocol, Union
 
 from trilogy.constants import logger
-from trilogy.core.enums import PurposeLineage, Granularity, FunctionType
+from trilogy.core.enums import FunctionType, Granularity, PurposeLineage
 from trilogy.core.env_processor import generate_graph
 from trilogy.core.graph_models import ReferenceGraph
 from trilogy.core.models import (
     Concept,
     Environment,
     Function,
-    WhereClause,
     RowsetItem,
+    WhereClause,
+)
+from trilogy.core.processing.node_generators import (
+    gen_basic_node,
+    gen_filter_node,
+    gen_group_node,
+    gen_group_to_node,
+    gen_merge_node,
+    gen_multiselect_node,
+    gen_rowset_node,
+    gen_union_node,
+    gen_unnest_node,
+    gen_window_node,
+)
+from trilogy.core.processing.nodes import (
+    ConstantNode,
+    GroupNode,
+    History,
+    MergeNode,
+    StrategyNode,
 )
 from trilogy.core.processing.utility import (
     get_disconnected_components,
 )
 from trilogy.utility import unique
-from trilogy.core.processing.nodes import (
-    ConstantNode,
-    MergeNode,
-    GroupNode,
-    StrategyNode,
-    History,
-)
-from trilogy.core.processing.node_generators import (
-    gen_filter_node,
-    gen_window_node,
-    gen_group_node,
-    gen_basic_node,
-    gen_unnest_node,
-    gen_union_node,
-    gen_merge_node,
-    gen_group_to_node,
-    gen_rowset_node,
-    gen_multiselect_node,
-)
-
-from enum import Enum
 
 
 class ValidationResult(Enum):
@@ -85,23 +84,14 @@ def get_priority_concept(
     depth: int,
 ) -> Concept:
     # optimized search for missing concepts
-    pass_one = [
-        c
-        for c in all_concepts
-        if c.address not in attempted_addresses and c.address not in found_concepts
-    ]
+    pass_one = [c for c in all_concepts if c.address not in attempted_addresses and c.address not in found_concepts]
     # sometimes we need to scan intermediate concepts to get merge keys or filter keys,
     # so do an exhaustive search
     # pass_two = [c for c in all_concepts+filter_only if c.address not in attempted_addresses]
     for remaining_concept in (pass_one,):
         priority = (
             # find anything that needs no joins first, so we can exit early
-            [
-                c
-                for c in remaining_concept
-                if c.derivation == PurposeLineage.CONSTANT
-                and c.granularity == Granularity.SINGLE_ROW
-            ]
+            [c for c in remaining_concept if c.derivation == PurposeLineage.CONSTANT and c.granularity == Granularity.SINGLE_ROW]
             +
             # then multiselects to remove them from scope
             [c for c in remaining_concept if c.derivation == PurposeLineage.MULTISELECT]
@@ -123,26 +113,18 @@ def get_priority_concept(
             + [c for c in remaining_concept if c.derivation == PurposeLineage.UNNEST]
             + [c for c in remaining_concept if c.derivation == PurposeLineage.BASIC]
             # finally our plain selects
-            + [
-                c for c in remaining_concept if c.derivation == PurposeLineage.ROOT
-            ]  # and any non-single row constants
+            + [c for c in remaining_concept if c.derivation == PurposeLineage.ROOT]  # and any non-single row constants
             + [c for c in remaining_concept if c.derivation == PurposeLineage.CONSTANT]
         )
 
-        priority += [
-            c
-            for c in remaining_concept
-            if c.address not in [x.address for x in priority]
-        ]
+        priority += [c for c in remaining_concept if c.address not in [x.address for x in priority]]
         final = []
         # if any thing is derived from another concept
         # get the derived copy first
         # as this will usually resolve cleaner
         for x in priority:
             if any([x.address in get_upstream_concepts(c) for c in priority]):
-                logger.info(
-                    f"{depth_to_prefix(depth)}{LOGGER_PREFIX} delaying fetch of {x.address} as parent of another concept"
-                )
+                logger.info(f"{depth_to_prefix(depth)}{LOGGER_PREFIX} delaying fetch of {x.address} as parent of another concept")
                 continue
             final.append(x)
         # then append anything we didn't get
@@ -151,9 +133,7 @@ def get_priority_concept(
                 final.append(x2)
         if final:
             return final[0]
-    raise ValueError(
-        f"Cannot resolve query. No remaining priority concepts, have attempted {attempted_addresses}"
-    )
+    raise ValueError(f"Cannot resolve query. No remaining priority concepts, have attempted {attempted_addresses}")
 
 
 def generate_candidates_restrictive(
@@ -169,10 +149,7 @@ def generate_candidates_restrictive(
     local_candidates = [
         x
         for x in list(candidates)
-        if x.address not in exhausted
-        and x.granularity != Granularity.SINGLE_ROW
-        and x.address not in priority_concept.pseudonyms
-        and priority_concept.address not in x.pseudonyms
+        if x.address not in exhausted and x.granularity != Granularity.SINGLE_ROW and x.address not in priority_concept.pseudonyms and priority_concept.address not in x.pseudonyms
     ]
     if conditions and priority_concept.derivation in (
         PurposeLineage.ROOT,
@@ -212,9 +189,7 @@ def generate_node(
         return candidate
 
     if concept.derivation == PurposeLineage.WINDOW:
-        logger.info(
-            f"{depth_to_prefix(depth)}{LOGGER_PREFIX} for {concept.address}, generating window node with optional {[x.address for x in local_optional]}"
-        )
+        logger.info(f"{depth_to_prefix(depth)}{LOGGER_PREFIX} for {concept.address}, generating window node with optional {[x.address for x in local_optional]}")
         return gen_window_node(
             concept,
             local_optional,
@@ -227,9 +202,7 @@ def generate_node(
         )
 
     elif concept.derivation == PurposeLineage.FILTER:
-        logger.info(
-            f"{depth_to_prefix(depth)}{LOGGER_PREFIX} for {concept.address}, generating filter node with optional {[x.address for x in local_optional]}"
-        )
+        logger.info(f"{depth_to_prefix(depth)}{LOGGER_PREFIX} for {concept.address}, generating filter node with optional {[x.address for x in local_optional]}")
         return gen_filter_node(
             concept,
             local_optional,
@@ -241,9 +214,7 @@ def generate_node(
             conditions=conditions,
         )
     elif concept.derivation == PurposeLineage.UNNEST:
-        logger.info(
-            f"{depth_to_prefix(depth)}{LOGGER_PREFIX} for {concept.address}, generating unnest node with optional {[x.address for x in local_optional]} and condition {conditions}"
-        )
+        logger.info(f"{depth_to_prefix(depth)}{LOGGER_PREFIX} for {concept.address}, generating unnest node with optional {[x.address for x in local_optional]} and condition {conditions}")
         return gen_unnest_node(
             concept,
             local_optional,
@@ -255,9 +226,7 @@ def generate_node(
             conditions=conditions,
         )
     elif concept.derivation == PurposeLineage.UNION:
-        logger.info(
-            f"{depth_to_prefix(depth)}{LOGGER_PREFIX} for {concept.address}, generating union node with optional {[x.address for x in local_optional]} and condition {conditions}"
-        )
+        logger.info(f"{depth_to_prefix(depth)}{LOGGER_PREFIX} for {concept.address}, generating union node with optional {[x.address for x in local_optional]} and condition {conditions}")
         return gen_union_node(
             concept,
             local_optional,
@@ -274,13 +243,9 @@ def generate_node(
         # to avoid constants multiplication changing default aggregation results
         # ex sum(x) * 2 w/ no grain should return sum(x) * 2, not sum(x*2)
         # these should always be sourceable independently
-        agg_optional = [
-            x for x in local_optional if x.granularity != Granularity.SINGLE_ROW
-        ]
+        agg_optional = [x for x in local_optional if x.granularity != Granularity.SINGLE_ROW]
 
-        logger.info(
-            f"{depth_to_prefix(depth)}{LOGGER_PREFIX} for {concept.address}, generating aggregate node with {[x.address for x in agg_optional]}"
-        )
+        logger.info(f"{depth_to_prefix(depth)}{LOGGER_PREFIX} for {concept.address}, generating aggregate node with {[x.address for x in agg_optional]}")
         return gen_group_node(
             concept,
             agg_optional,
@@ -292,9 +257,7 @@ def generate_node(
             conditions=conditions,
         )
     elif concept.derivation == PurposeLineage.ROWSET:
-        logger.info(
-            f"{depth_to_prefix(depth)}{LOGGER_PREFIX} for {concept.address}, generating rowset node with optional {[x.address for x in local_optional]}"
-        )
+        logger.info(f"{depth_to_prefix(depth)}{LOGGER_PREFIX} for {concept.address}, generating rowset node with optional {[x.address for x in local_optional]}")
         return gen_rowset_node(
             concept,
             local_optional,
@@ -306,9 +269,7 @@ def generate_node(
             conditions=conditions,
         )
     elif concept.derivation == PurposeLineage.MULTISELECT:
-        logger.info(
-            f"{depth_to_prefix(depth)}{LOGGER_PREFIX} for {concept.address}, generating multiselect node with optional {[x.address for x in local_optional]}"
-        )
+        logger.info(f"{depth_to_prefix(depth)}{LOGGER_PREFIX} for {concept.address}, generating multiselect node with optional {[x.address for x in local_optional]}")
         return gen_multiselect_node(
             concept,
             local_optional,
@@ -321,22 +282,12 @@ def generate_node(
         )
     elif concept.derivation == PurposeLineage.CONSTANT:
         constant_targets = [concept] + local_optional
-        logger.info(
-            f"{depth_to_prefix(depth)}{LOGGER_PREFIX} for {concept.address}, generating constant node"
-        )
+        logger.info(f"{depth_to_prefix(depth)}{LOGGER_PREFIX} for {concept.address}, generating constant node")
         if any([x.derivation != PurposeLineage.CONSTANT for x in local_optional]):
-            non_root = [
-                x.address
-                for x in local_optional
-                if x.derivation != PurposeLineage.CONSTANT
-            ]
-            logger.info(
-                f"{depth_to_prefix(depth)}{LOGGER_PREFIX} including filter concepts, there is non root filter requirements {non_root}. Recursing with all of these as mandatory"
-            )
+            non_root = [x.address for x in local_optional if x.derivation != PurposeLineage.CONSTANT]
+            logger.info(f"{depth_to_prefix(depth)}{LOGGER_PREFIX} including filter concepts, there is non root filter requirements {non_root}. Recursing with all of these as mandatory")
 
-            if not history.check_started(
-                constant_targets, accept_partial=accept_partial, conditions=conditions
-            ):
+            if not history.check_started(constant_targets, accept_partial=accept_partial, conditions=conditions):
                 history.log_start(
                     constant_targets,
                     accept_partial=accept_partial,
@@ -365,13 +316,8 @@ def generate_node(
         )
     elif concept.derivation == PurposeLineage.BASIC:
         # this is special case handling for group bys
-        if (
-            isinstance(concept.lineage, Function)
-            and concept.lineage.operator == FunctionType.GROUP
-        ):
-            logger.info(
-                f"{depth_to_prefix(depth)}{LOGGER_PREFIX} for {concept.address}, generating group to grain node with {[x.address for x in local_optional]}"
-            )
+        if isinstance(concept.lineage, Function) and concept.lineage.operator == FunctionType.GROUP:
+            logger.info(f"{depth_to_prefix(depth)}{LOGGER_PREFIX} for {concept.address}, generating group to grain node with {[x.address for x in local_optional]}")
             return gen_group_to_node(
                 concept,
                 local_optional,
@@ -382,9 +328,7 @@ def generate_node(
                 history,
                 conditions=conditions,
             )
-        logger.info(
-            f"{depth_to_prefix(depth)}{LOGGER_PREFIX} for {concept.address}, generating basic node with optional {[x.address for x in local_optional]}"
-        )
+        logger.info(f"{depth_to_prefix(depth)}{LOGGER_PREFIX} for {concept.address}, generating basic node with optional {[x.address for x in local_optional]}")
         return gen_basic_node(
             concept,
             local_optional,
@@ -397,34 +341,17 @@ def generate_node(
         )
 
     elif concept.derivation == PurposeLineage.ROOT:
-        logger.info(
-            f"{depth_to_prefix(depth)}{LOGGER_PREFIX} for {concept.address}, generating select node with optional including condition inputs {[x.address for x in local_optional]}"
-        )
+        logger.info(f"{depth_to_prefix(depth)}{LOGGER_PREFIX} for {concept.address}, generating select node with optional including condition inputs {[x.address for x in local_optional]}")
         # we've injected in any conditional concepts that may exist
         # so if we don't still have just roots, we need to go up
         root_targets = [concept] + local_optional
 
-        if any(
-            [
-                x.derivation not in (PurposeLineage.ROOT, PurposeLineage.CONSTANT)
-                for x in local_optional
-            ]
-        ):
-            non_root = [
-                x.address
-                for x in local_optional
-                if x.derivation not in (PurposeLineage.ROOT, PurposeLineage.CONSTANT)
-            ]
-            logger.info(
-                f"{depth_to_prefix(depth)}{LOGGER_PREFIX} including filter concepts, there is non root filter requirements {non_root}. Recursing with all of these as mandatory"
-            )
+        if any([x.derivation not in (PurposeLineage.ROOT, PurposeLineage.CONSTANT) for x in local_optional]):
+            non_root = [x.address for x in local_optional if x.derivation not in (PurposeLineage.ROOT, PurposeLineage.CONSTANT)]
+            logger.info(f"{depth_to_prefix(depth)}{LOGGER_PREFIX} including filter concepts, there is non root filter requirements {non_root}. Recursing with all of these as mandatory")
 
-            if not history.check_started(
-                root_targets, accept_partial=accept_partial, conditions=conditions
-            ):
-                history.log_start(
-                    root_targets, accept_partial=accept_partial, conditions=conditions
-                )
+            if not history.check_started(root_targets, accept_partial=accept_partial, conditions=conditions):
+                history.log_start(root_targets, accept_partial=accept_partial, conditions=conditions)
                 return source_concepts(
                     mandatory_list=root_targets,
                     environment=environment,
@@ -450,9 +377,7 @@ def generate_node(
             conditions=conditions,
         )
         if not check:
-            logger.info(
-                f"{depth_to_prefix(depth)}{LOGGER_PREFIX} Could not resolve root concepts, checking for expanded concepts"
-            )
+            logger.info(f"{depth_to_prefix(depth)}{LOGGER_PREFIX} Could not resolve root concepts, checking for expanded concepts")
             for accept_partial in [False, True]:
                 expanded = gen_merge_node(
                     all_concepts=root_targets,
@@ -467,34 +392,19 @@ def generate_node(
 
                 if expanded:
                     ex_resolve = expanded.resolve()
-                    extra = [
-                        x
-                        for x in ex_resolve.output_concepts
-                        if x.address not in [y.address for y in root_targets]
-                        and x not in ex_resolve.grain.components
-                    ]
+                    extra = [x for x in ex_resolve.output_concepts if x.address not in [y.address for y in root_targets] and x not in ex_resolve.grain.components]
 
-                    pseudonyms = [
-                        x
-                        for x in extra
-                        if any(x.address in y.pseudonyms for y in root_targets)
-                    ]
+                    pseudonyms = [x for x in extra if any(x.address in y.pseudonyms for y in root_targets)]
                     # if we're only connected by a pseudonym, keep those in output
                     expanded.set_output_concepts(root_targets + pseudonyms)
                     # but hide them
                     if pseudonyms:
-                        logger.info(
-                            f"{depth_to_prefix(depth)}{LOGGER_PREFIX} Hiding pseudonyms{[c.address for c in pseudonyms]}"
-                        )
+                        logger.info(f"{depth_to_prefix(depth)}{LOGGER_PREFIX} Hiding pseudonyms{[c.address for c in pseudonyms]}")
                         expanded.hide_output_concepts(pseudonyms)
 
-                    logger.info(
-                        f"{depth_to_prefix(depth)}{LOGGER_PREFIX} Found connections for {[c.address for c in root_targets]} via concept addition; removing extra {[c.address for c in extra]}"
-                    )
+                    logger.info(f"{depth_to_prefix(depth)}{LOGGER_PREFIX} Found connections for {[c.address for c in root_targets]} via concept addition; removing extra {[c.address for c in extra]}")
                     return expanded
-            logger.info(
-                f"{depth_to_prefix(depth)}{LOGGER_PREFIX} could not find additional concept to inject"
-            )
+            logger.info(f"{depth_to_prefix(depth)}{LOGGER_PREFIX} could not find additional concept to inject")
             return None
     else:
         raise ValueError(f"Unknown derivation {concept.derivation}")
@@ -513,11 +423,9 @@ def validate_concept(
     seen: set[str],
     environment: Environment,
 ):
-
     found_map[str(node)].add(concept)
     seen.add(concept.address)
     if concept not in node.partial_concepts:
-
         found_addresses.add(concept.address)
         non_partial_addresses.add(concept.address)
         # remove it from our partial tracking
@@ -591,9 +499,7 @@ def validate_stack(
     if not conditions:
         conditions_met = True
     else:
-        conditions_met = all(
-            [node.preexisting_conditions == conditions.conditional for node in stack]
-        ) or all([c.address in found_addresses for c in mandatory_with_filter])
+        conditions_met = all([node.preexisting_conditions == conditions.conditional for node in stack]) or all([c.address in found_addresses for c in mandatory_with_filter])
     # zip in those we know we found
     if not all([c.address in found_addresses for c in concepts]) or not conditions_met:
         if not all([c.address in found_addresses for c in concepts]):
@@ -649,21 +555,13 @@ def append_existence_check(
             if not subselect:
                 continue
             if all([x.address in node.input_concepts for x in subselect]):
-                logger.info(
-                    f"{LOGGER_PREFIX} existance clause inputs already found {[str(c) for c in subselect]}"
-                )
+                logger.info(f"{LOGGER_PREFIX} existance clause inputs already found {[str(c) for c in subselect]}")
                 continue
-            logger.info(
-                f"{LOGGER_PREFIX} fetching existence clause inputs {[str(c) for c in subselect]}"
-            )
-            parent = source_query_concepts(
-                [*subselect], environment=environment, g=graph, history=history
-            )
+            logger.info(f"{LOGGER_PREFIX} fetching existence clause inputs {[str(c) for c in subselect]}")
+            parent = source_query_concepts([*subselect], environment=environment, g=graph, history=history)
             assert parent, "Could not resolve existence clause"
             node.add_parents([parent])
-            logger.info(
-                f"{LOGGER_PREFIX} fetching existence clause inputs {[str(c) for c in subselect]}"
-            )
+            logger.info(f"{LOGGER_PREFIX} fetching existence clause inputs {[str(c) for c in subselect]}")
             node.add_existence_concepts([*subselect])
 
 
@@ -676,11 +574,8 @@ def search_concepts(
     history: History | None = None,
     conditions: WhereClause | None = None,
 ) -> StrategyNode | None:
-
     history = history or History()
-    hist = history.get_history(
-        search=mandatory_list, accept_partial=accept_partial, conditions=conditions
-    )
+    hist = history.get_history(search=mandatory_list, accept_partial=accept_partial, conditions=conditions)
     if hist is not False:
         logger.info(
             f"{depth_to_prefix(depth)}{LOGGER_PREFIX} Returning search node from history ({'exists' if hist is not None else 'does not exist'}) for {[c.address for c in mandatory_list]} with accept_partial {accept_partial}"
@@ -716,7 +611,6 @@ def _search_concepts(
     accept_partial: bool = False,
     conditions: WhereClause | None = None,
 ) -> StrategyNode | None:
-
     # these are the concepts we need in the output projection
     mandatory_list = unique(mandatory_list, "address")
 
@@ -726,18 +620,10 @@ def _search_concepts(
 
     # if we have a filter, we may need to get more values to support that.
     if conditions:
-        completion_mandatory = unique(
-            mandatory_list + conditions.row_arguments, "address"
-        )
+        completion_mandatory = unique(mandatory_list + conditions.row_arguments, "address")
         # if anything we need to get is in the filter set and it's a computed value
         # we need to get _everything_ in this loop
-        if any(
-            [
-                x.derivation not in (PurposeLineage.ROOT, PurposeLineage.CONSTANT)
-                and x.address in conditions.row_arguments
-                for x in mandatory_list
-            ]
-        ):
+        if any([x.derivation not in (PurposeLineage.ROOT, PurposeLineage.CONSTANT) and x.address in conditions.row_arguments for x in mandatory_list]):
             mandatory_list = completion_mandatory
             must_evaluate_condition_on_this_level_not_push_down = True
     else:
@@ -762,48 +648,23 @@ def _search_concepts(
         # always pass the filter up when we aren't looking at all filter inputs
         # or there are any non-filter complex types
         if conditions:
-            should_evaluate_filter_on_this_level_not_push_down = all(
-                [x.address in mandatory_list for x in conditions.row_arguments]
-            ) and not any(
-                [
-                    x.derivation not in (PurposeLineage.ROOT, PurposeLineage.CONSTANT)
-                    for x in mandatory_list
-                    if x.address not in conditions.row_arguments
-                ]
+            should_evaluate_filter_on_this_level_not_push_down = all([x.address in mandatory_list for x in conditions.row_arguments]) and not any(
+                [x.derivation not in (PurposeLineage.ROOT, PurposeLineage.CONSTANT) for x in mandatory_list if x.address not in conditions.row_arguments]
             )
         else:
             should_evaluate_filter_on_this_level_not_push_down = True
-        local_conditions = (
-            conditions
-            if conditions
-            and not must_evaluate_condition_on_this_level_not_push_down
-            and not should_evaluate_filter_on_this_level_not_push_down
-            else None
-        )
+        local_conditions = conditions if conditions and not must_evaluate_condition_on_this_level_not_push_down and not should_evaluate_filter_on_this_level_not_push_down else None
         # but if it's not basic, and it's not condition;
         # we do need to push it down (and have another layer of filter evaluation)
         # to ensure filtering happens before something like a SUM
-        if (
-            conditions
-            and priority_concept.derivation
-            not in (PurposeLineage.ROOT, PurposeLineage.CONSTANT)
-            and priority_concept.address not in conditions.row_arguments
-        ):
-            logger.info(
-                f"{depth_to_prefix(depth)}{LOGGER_PREFIX} Force including conditions to push filtering above complex condition that is not condition member or parent"
-            )
+        if conditions and priority_concept.derivation not in (PurposeLineage.ROOT, PurposeLineage.CONSTANT) and priority_concept.address not in conditions.row_arguments:
+            logger.info(f"{depth_to_prefix(depth)}{LOGGER_PREFIX} Force including conditions to push filtering above complex condition that is not condition member or parent")
             local_conditions = conditions
 
-        logger.info(
-            f"{depth_to_prefix(depth)}{LOGGER_PREFIX} priority concept is {str(priority_concept)} derivation {priority_concept.derivation} with conditions {local_conditions}"
-        )
+        logger.info(f"{depth_to_prefix(depth)}{LOGGER_PREFIX} priority concept is {str(priority_concept)} derivation {priority_concept.derivation} with conditions {local_conditions}")
 
-        candidates = [
-            c for c in mandatory_list if c.address != priority_concept.address
-        ]
-        candidate_lists = generate_candidates_restrictive(
-            priority_concept, candidates, skip, conditions=conditions
-        )
+        candidates = [c for c in mandatory_list if c.address != priority_concept.address]
+        candidate_lists = generate_candidates_restrictive(priority_concept, candidates, skip, conditions=conditions)
         for clist in candidate_lists:
             logger.info(
                 f"{depth_to_prefix(depth)}{LOGGER_PREFIX} Beginning sourcing loop for {priority_concept.address}, accept_partial {accept_partial}, optional {[v.address for v in clist]}, exhausted {[c for c in skip]}"
@@ -824,9 +685,7 @@ def _search_concepts(
                 try:
                     node.resolve()
                 except Exception as e:
-                    logger.error(
-                        f"{depth_to_prefix(depth)}{LOGGER_PREFIX} Could not resolve node {node} {e}"
-                    )
+                    logger.error(f"{depth_to_prefix(depth)}{LOGGER_PREFIX} Could not resolve node {node} {e}")
                     raise e
                 # these concepts should not be attempted to be sourced again
                 # as fetching them requires operating on a subset of concepts
@@ -861,16 +720,12 @@ def _search_concepts(
         # early exit if we have a complete stack with one node
         # we can only early exit if we have a complete stack
         # and we are not looking for more non-partial sources
-        if complete == ValidationResult.COMPLETE and (
-            not accept_partial or (accept_partial and not partial)
-        ):
+        if complete == ValidationResult.COMPLETE and (not accept_partial or (accept_partial and not partial)):
             break
         # if we have attempted on root node, we've tried them all.
         # inject in another search with filter concepts
         if priority_concept.derivation == PurposeLineage.ROOT:
-            logger.info(
-                f"{depth_to_prefix(depth)}{LOGGER_PREFIX} Breaking as attempted root with no results"
-            )
+            logger.info(f"{depth_to_prefix(depth)}{LOGGER_PREFIX} Breaking as attempted root with no results")
             break
 
     logger.info(
@@ -888,18 +743,11 @@ def _search_concepts(
             non_virtual = [c for c in mandatory_list if c.address not in virtual]
 
         if conditions and not condition_required:
-            parent_map = {
-                str(x): x.preexisting_conditions == conditions.conditional
-                for x in stack
-            }
-            logger.info(
-                f"Condition {conditions} not required, parents included filtering! {parent_map }"
-            )
+            parent_map = {str(x): x.preexisting_conditions == conditions.conditional for x in stack}
+            logger.info(f"Condition {conditions} not required, parents included filtering! {parent_map }")
         if len(stack) == 1:
             output: StrategyNode = stack[0]
-            logger.info(
-                f"{depth_to_prefix(depth)}{LOGGER_PREFIX} Source stack has single node, returning that {type(output)}"
-            )
+            logger.info(f"{depth_to_prefix(depth)}{LOGGER_PREFIX} Source stack has single node, returning that {type(output)}")
         else:
             output = MergeNode(
                 input_concepts=non_virtual,
@@ -914,21 +762,15 @@ def _search_concepts(
         if condition_required and conditions:
             output.add_condition(conditions.conditional)
             if conditions.existence_arguments:
-                append_existence_check(
-                    output, environment, g, where=conditions, history=history
-                )
-        logger.info(
-            f"{depth_to_prefix(depth)}{LOGGER_PREFIX} Graph is connected, returning merge node, partial {[c.address for c in output.partial_concepts]}"
-        )
+                append_existence_check(output, environment, g, where=conditions, history=history)
+        logger.info(f"{depth_to_prefix(depth)}{LOGGER_PREFIX} Graph is connected, returning merge node, partial {[c.address for c in output.partial_concepts]}")
         return output
 
     # if we can't find it after expanding to a merge, then
     # accept partials in join paths
 
     if not accept_partial:
-        logger.info(
-            f"{depth_to_prefix(depth)}{LOGGER_PREFIX} Stack is not connected graph, flag for accepting partial addresses is {accept_partial}, changing flag"
-        )
+        logger.info(f"{depth_to_prefix(depth)}{LOGGER_PREFIX} Stack is not connected graph, flag for accepting partial addresses is {accept_partial}, changing flag")
         partial_search = search_concepts(
             mandatory_list=mandatory_list,
             environment=environment,
@@ -939,13 +781,9 @@ def _search_concepts(
             conditions=conditions,
         )
         if partial_search:
-            logger.info(
-                f"{depth_to_prefix(depth)}{LOGGER_PREFIX} Found {[c.address for c in mandatory_list]} by accepting partials"
-            )
+            logger.info(f"{depth_to_prefix(depth)}{LOGGER_PREFIX} Found {[c.address for c in mandatory_list]} by accepting partials")
             return partial_search
-    logger.error(
-        f"{depth_to_prefix(depth)}{LOGGER_PREFIX} Could not resolve concepts {[c.address for c in mandatory_list]}, network outcome was {complete}, missing {all_mandatory - found},"
-    )
+    logger.error(f"{depth_to_prefix(depth)}{LOGGER_PREFIX} Could not resolve concepts {[c.address for c in mandatory_list]}, network outcome was {complete}, missing {all_mandatory - found},")
     return None
 
 
@@ -972,19 +810,11 @@ def source_query_concepts(
     )
 
     if not root:
-        error_strings = [
-            f"{c.address}<{c.purpose}>{c.derivation}>" for c in output_concepts
-        ]
-        raise ValueError(
-            f"Could not resolve conections between {error_strings} from environment graph."
-        )
+        error_strings = [f"{c.address}<{c.purpose}>{c.derivation}>" for c in output_concepts]
+        raise ValueError(f"Could not resolve conections between {error_strings} from environment graph.")
     candidate = GroupNode(
-        output_concepts=[
-            x for x in root.output_concepts if x.address not in root.hidden_concepts
-        ],
-        input_concepts=[
-            x for x in root.output_concepts if x.address not in root.hidden_concepts
-        ],
+        output_concepts=[x for x in root.output_concepts if x.address not in root.hidden_concepts],
+        input_concepts=[x for x in root.output_concepts if x.address not in root.hidden_concepts],
         environment=environment,
         g=g,
         parents=[root],

--- a/trilogy/core/processing/concept_strategies_v3.py
+++ b/trilogy/core/processing/concept_strategies_v3.py
@@ -29,6 +29,7 @@ from trilogy.core.processing.node_generators import (
     gen_group_node,
     gen_basic_node,
     gen_unnest_node,
+    gen_union_node,
     gen_merge_node,
     gen_group_to_node,
     gen_rowset_node,
@@ -107,6 +108,9 @@ def get_priority_concept(
             +
             # then rowsets to remove them from scope, as they cannot get partials
             [c for c in remaining_concept if c.derivation == PurposeLineage.ROWSET]
+            +
+            # then rowsets to remove them from scope, as they cannot get partials
+            [c for c in remaining_concept if c.derivation == PurposeLineage.UNION]
             # we should be home-free here
             +
             # then aggregates to remove them from scope, as they cannot get partials
@@ -241,6 +245,20 @@ def generate_node(
             f"{depth_to_prefix(depth)}{LOGGER_PREFIX} for {concept.address}, generating unnest node with optional {[x.address for x in local_optional]} and condition {conditions}"
         )
         return gen_unnest_node(
+            concept,
+            local_optional,
+            environment,
+            g,
+            depth + 1,
+            source_concepts,
+            history,
+            conditions=conditions,
+        )
+    elif concept.derivation == PurposeLineage.UNION:
+        logger.info(
+            f"{depth_to_prefix(depth)}{LOGGER_PREFIX} for {concept.address}, generating union node with optional {[x.address for x in local_optional]} and condition {conditions}"
+        )
+        return gen_union_node(
             concept,
             local_optional,
             environment,

--- a/trilogy/core/processing/graph_utils.py
+++ b/trilogy/core/processing/graph_utils.py
@@ -1,18 +1,15 @@
-from typing import Dict, List
-from trilogy.core.models import Concept
 from collections import defaultdict
+from typing import Dict, List
+
+from trilogy.core.models import Concept
 from trilogy.utility import unique
 
 
-def extract_required_subgraphs(
-    assocs: defaultdict[str, list], path: List[str]
-) -> defaultdict[str, list]:
-
+def extract_required_subgraphs(assocs: defaultdict[str, list], path: List[str]) -> defaultdict[str, list]:
     ds = path[0]
     current: list[str] = []
     for idx, val in enumerate(path):
         if val.startswith("ds~"):
-
             if current:
                 assocs[ds] += current
                 current = [path[idx - 1]] if idx > 0 else []
@@ -36,9 +33,5 @@ def extract_mandatory_subgraphs(paths: Dict[str, List[str]], g) -> List[List[Con
         final.append(v)
     final_concepts = []
     for value in final:
-        final_concepts.append(
-            unique(
-                [g.nodes[v]["concept"] for v in value if v.startswith("c~")], "address"
-            )
-        )
+        final_concepts.append(unique([g.nodes[v]["concept"] for v in value if v.startswith("c~")], "address"))
     return final_concepts

--- a/trilogy/core/processing/graph_utils.py
+++ b/trilogy/core/processing/graph_utils.py
@@ -5,7 +5,9 @@ from trilogy.core.models import Concept
 from trilogy.utility import unique
 
 
-def extract_required_subgraphs(assocs: defaultdict[str, list], path: List[str]) -> defaultdict[str, list]:
+def extract_required_subgraphs(
+    assocs: defaultdict[str, list], path: List[str]
+) -> defaultdict[str, list]:
     ds = path[0]
     current: list[str] = []
     for idx, val in enumerate(path):
@@ -33,5 +35,9 @@ def extract_mandatory_subgraphs(paths: Dict[str, List[str]], g) -> List[List[Con
         final.append(v)
     final_concepts = []
     for value in final:
-        final_concepts.append(unique([g.nodes[v]["concept"] for v in value if v.startswith("c~")], "address"))
+        final_concepts.append(
+            unique(
+                [g.nodes[v]["concept"] for v in value if v.startswith("c~")], "address"
+            )
+        )
     return final_concepts

--- a/trilogy/core/processing/node_generators/__init__.py
+++ b/trilogy/core/processing/node_generators/__init__.py
@@ -5,6 +5,7 @@ from .group_to_node import gen_group_to_node
 from .basic_node import gen_basic_node
 from .select_node import gen_select_node
 from .unnest_node import gen_unnest_node
+from .union_node import gen_union_node
 from .node_merge_node import gen_merge_node
 from .rowset_node import gen_rowset_node
 from .multiselect_node import gen_multiselect_node
@@ -16,6 +17,7 @@ __all__ = [
     "gen_select_node",
     "gen_basic_node",
     "gen_unnest_node",
+    "gen_union_node",
     "gen_merge_node",
     "gen_group_to_node",
     "gen_rowset_node",

--- a/trilogy/core/processing/node_generators/__init__.py
+++ b/trilogy/core/processing/node_generators/__init__.py
@@ -1,14 +1,14 @@
+from .basic_node import gen_basic_node
 from .filter_node import gen_filter_node
-from .window_node import gen_window_node
 from .group_node import gen_group_node
 from .group_to_node import gen_group_to_node
-from .basic_node import gen_basic_node
-from .select_node import gen_select_node
-from .unnest_node import gen_unnest_node
-from .union_node import gen_union_node
+from .multiselect_node import gen_multiselect_node
 from .node_merge_node import gen_merge_node
 from .rowset_node import gen_rowset_node
-from .multiselect_node import gen_multiselect_node
+from .select_node import gen_select_node
+from .union_node import gen_union_node
+from .unnest_node import gen_unnest_node
+from .window_node import gen_window_node
 
 __all__ = [
     "gen_filter_node",

--- a/trilogy/core/processing/node_generators/basic_node.py
+++ b/trilogy/core/processing/node_generators/basic_node.py
@@ -11,8 +11,7 @@ from trilogy.core.processing.nodes import StrategyNode, History
 from trilogy.core.processing.node_generators.common import (
     resolve_function_parent_concepts,
 )
-from trilogy.constants import logger
-from trilogy.core.enums import SourceType
+from trilogy.core.processing.nodes import History, StrategyNode
 
 LOGGER_PREFIX = "[GEN_BASIC_NODE]"
 
@@ -46,9 +45,7 @@ def gen_basic_node(
     depth_prefix = "\t" * depth
     parent_concepts = resolve_function_parent_concepts(concept)
 
-    logger.info(
-        f"{depth_prefix}{LOGGER_PREFIX} basic node for {concept} has parents {[x.address for x in parent_concepts]}"
-    )
+    logger.info(f"{depth_prefix}{LOGGER_PREFIX} basic node for {concept} has parents {[x.address for x in parent_concepts]}")
 
     equivalent_optional = [
         x
@@ -75,9 +72,7 @@ def gen_basic_node(
     )
 
     if not parent_node:
-        logger.info(
-            f"{depth_prefix}{LOGGER_PREFIX} No basic node could be generated for {concept}"
-        )
+        logger.info(f"{depth_prefix}{LOGGER_PREFIX} No basic node could be generated for {concept}")
         return None
 
     parent_node.source_type = SourceType.BASIC
@@ -85,15 +80,7 @@ def gen_basic_node(
     for x in equivalent_optional:
         parent_node.add_output_concept(x)
 
-    parent_node.remove_output_concepts(
-        [
-            x
-            for x in parent_node.output_concepts
-            if x.address not in [concept] + local_optional
-        ]
-    )
+    parent_node.remove_output_concepts([x for x in parent_node.output_concepts if x.address not in [concept] + local_optional])
 
-    logger.info(
-        f"{depth_prefix}{LOGGER_PREFIX} Returning basic select for {concept}: output {[x.address for x in parent_node.output_concepts]}"
-    )
+    logger.info(f"{depth_prefix}{LOGGER_PREFIX} Returning basic select for {concept}: output {[x.address for x in parent_node.output_concepts]}")
     return parent_node

--- a/trilogy/core/processing/node_generators/basic_node.py
+++ b/trilogy/core/processing/node_generators/basic_node.py
@@ -1,18 +1,18 @@
 # directly select out a basic derivation
 from typing import List
 
+from trilogy.constants import logger
+from trilogy.core.enums import SourceType
 from trilogy.core.models import (
     Concept,
-    WhereClause,
     Function,
     FunctionClass,
+    WhereClause,
 )
-from trilogy.core.processing.nodes import StrategyNode, History
 from trilogy.core.processing.node_generators.common import (
     resolve_function_parent_concepts,
 )
-from trilogy.constants import logger
-from trilogy.core.enums import SourceType
+from trilogy.core.processing.nodes import History, StrategyNode
 
 LOGGER_PREFIX = "[GEN_BASIC_NODE]"
 

--- a/trilogy/core/processing/node_generators/basic_node.py
+++ b/trilogy/core/processing/node_generators/basic_node.py
@@ -11,7 +11,8 @@ from trilogy.core.processing.nodes import StrategyNode, History
 from trilogy.core.processing.node_generators.common import (
     resolve_function_parent_concepts,
 )
-from trilogy.core.processing.nodes import History, StrategyNode
+from trilogy.constants import logger
+from trilogy.core.enums import SourceType
 
 LOGGER_PREFIX = "[GEN_BASIC_NODE]"
 
@@ -45,7 +46,9 @@ def gen_basic_node(
     depth_prefix = "\t" * depth
     parent_concepts = resolve_function_parent_concepts(concept)
 
-    logger.info(f"{depth_prefix}{LOGGER_PREFIX} basic node for {concept} has parents {[x.address for x in parent_concepts]}")
+    logger.info(
+        f"{depth_prefix}{LOGGER_PREFIX} basic node for {concept} has parents {[x.address for x in parent_concepts]}"
+    )
 
     equivalent_optional = [
         x
@@ -72,7 +75,9 @@ def gen_basic_node(
     )
 
     if not parent_node:
-        logger.info(f"{depth_prefix}{LOGGER_PREFIX} No basic node could be generated for {concept}")
+        logger.info(
+            f"{depth_prefix}{LOGGER_PREFIX} No basic node could be generated for {concept}"
+        )
         return None
 
     parent_node.source_type = SourceType.BASIC
@@ -80,7 +85,15 @@ def gen_basic_node(
     for x in equivalent_optional:
         parent_node.add_output_concept(x)
 
-    parent_node.remove_output_concepts([x for x in parent_node.output_concepts if x.address not in [concept] + local_optional])
+    parent_node.remove_output_concepts(
+        [
+            x
+            for x in parent_node.output_concepts
+            if x.address not in [concept] + local_optional
+        ]
+    )
 
-    logger.info(f"{depth_prefix}{LOGGER_PREFIX} Returning basic select for {concept}: output {[x.address for x in parent_node.output_concepts]}")
+    logger.info(
+        f"{depth_prefix}{LOGGER_PREFIX} Returning basic select for {concept}: output {[x.address for x in parent_node.output_concepts]}"
+    )
     return parent_node

--- a/trilogy/core/processing/node_generators/common.py
+++ b/trilogy/core/processing/node_generators/common.py
@@ -1,23 +1,23 @@
-from typing import List, Tuple, Callable
+from collections import defaultdict
+from typing import Callable, List, Tuple
 
-from trilogy.core.enums import PurposeLineage, Purpose
+from trilogy.core.enums import Purpose, PurposeLineage
 from trilogy.core.models import (
-    Concept,
-    Function,
     AggregateWrapper,
-    FilterItem,
+    Concept,
     Environment,
+    FilterItem,
+    Function,
     LooseConceptList,
     WhereClause,
 )
-from trilogy.utility import unique
-from trilogy.core.processing.nodes.base_node import StrategyNode
-from trilogy.core.processing.nodes.merge_node import MergeNode
-from trilogy.core.processing.nodes import History
 from trilogy.core.processing.nodes import (
+    History,
     NodeJoin,
 )
-from collections import defaultdict
+from trilogy.core.processing.nodes.base_node import StrategyNode
+from trilogy.core.processing.nodes.merge_node import MergeNode
+from trilogy.utility import unique
 
 
 def resolve_function_parent_concepts(concept: Concept) -> List[Concept]:
@@ -58,24 +58,16 @@ def resolve_filter_parent_concepts(
     concept: Concept,
 ) -> Tuple[Concept, List[Concept], List[Tuple[Concept, ...]]]:
     if not isinstance(concept.lineage, FilterItem):
-        raise ValueError(
-            f"Concept {concept} lineage is not filter item, is {type(concept.lineage)}"
-        )
+        raise ValueError(f"Concept {concept} lineage is not filter item, is {type(concept.lineage)}")
     direct_parent = concept.lineage.content
     base_existence = []
     base_rows = [direct_parent]
-    condition_rows, condition_existence = resolve_condition_parent_concepts(
-        concept.lineage.where
-    )
+    condition_rows, condition_existence = resolve_condition_parent_concepts(concept.lineage.where)
     base_rows += condition_rows
     base_existence += condition_existence
     if direct_parent.grain:
         base_rows += direct_parent.grain.components_copy
-    if (
-        isinstance(direct_parent, Concept)
-        and direct_parent.purpose == Purpose.PROPERTY
-        and direct_parent.keys
-    ):
+    if isinstance(direct_parent, Concept) and direct_parent.purpose == Purpose.PROPERTY and direct_parent.keys:
         base_rows += direct_parent.keys
     if concept.lineage.where.existence_arguments:
         return (
@@ -108,8 +100,7 @@ def gen_property_enrichment_node(
         log_lambda(f"Generating enrichment node for {_k} with {vs}")
         ks = _k.split("-")
         enrich_node: StrategyNode = source_concepts(
-            mandatory_list=[environment.concepts[k] for k in ks]
-            + [environment.concepts[v] for v in vs],
+            mandatory_list=[environment.concepts[k] for k in ks] + [environment.concepts[v] for v in vs],
             environment=environment,
             g=g,
             depth=depth + 1,
@@ -119,13 +110,7 @@ def gen_property_enrichment_node(
         final_nodes.append(enrich_node)
     return MergeNode(
         input_concepts=unique(
-            base_node.output_concepts
-            + extra_properties
-            + [
-                environment.concepts[v]
-                for k, values in required_keys.items()
-                for v in values
-            ],
+            base_node.output_concepts + extra_properties + [environment.concepts[v] for k, values in required_keys.items() for v in values],
             "address",
         ),
         output_concepts=base_node.output_concepts + extra_properties,
@@ -151,25 +136,15 @@ def gen_enrichment_node(
     history: History | None = None,
     conditions: WhereClause | None = None,
 ):
-
     local_opts = LooseConceptList(concepts=local_optional)
 
-    extra_required = [
-        x
-        for x in local_opts
-        if x not in base_node.output_lcl or x in base_node.partial_lcl
-    ]
+    extra_required = [x for x in local_opts if x not in base_node.output_lcl or x in base_node.partial_lcl]
 
     # property lookup optimization
     # this helps when evaluating a normalized star schema as you only want to lookup the missing properties based on the relevant keys
     if all([x.purpose == Purpose.PROPERTY for x in extra_required]):
-        if all(
-            x.keys and all([key in base_node.output_lcl for key in x.keys])
-            for x in extra_required
-        ):
-            log_lambda(
-                f"{str(type(base_node).__name__)} returning property optimized enrichment node"
-            )
+        if all(x.keys and all([key in base_node.output_lcl for key in x.keys]) for x in extra_required):
+            log_lambda(f"{str(type(base_node).__name__)} returning property optimized enrichment node")
             return gen_property_enrichment_node(
                 base_node,
                 extra_required,
@@ -181,9 +156,7 @@ def gen_enrichment_node(
                 conditions=conditions,
                 log_lambda=log_lambda,
             )
-    log_lambda(
-        f"{str(type(base_node).__name__)} searching for join keys {LooseConceptList(concepts=join_keys)} and extra required {local_opts}"
-    )
+    log_lambda(f"{str(type(base_node).__name__)} searching for join keys {LooseConceptList(concepts=join_keys)} and extra required {local_opts}")
     enrich_node: StrategyNode = source_concepts(  # this fetches the parent + join keys
         # to then connect to the rest of the query
         mandatory_list=join_keys + extra_required,
@@ -194,18 +167,10 @@ def gen_enrichment_node(
         conditions=conditions,
     )
     if not enrich_node:
-        log_lambda(
-            f"{str(type(base_node).__name__)} enrichment node unresolvable, returning just group node"
-        )
+        log_lambda(f"{str(type(base_node).__name__)} enrichment node unresolvable, returning just group node")
         return base_node
-    log_lambda(
-        f"{str(type(base_node).__name__)} returning merge node with group node + enrichment node"
-    )
-    non_hidden = [
-        x
-        for x in base_node.output_concepts
-        if x.address not in [y.address for y in base_node.hidden_concepts]
-    ]
+    log_lambda(f"{str(type(base_node).__name__)} returning merge node with group node + enrichment node")
+    non_hidden = [x for x in base_node.output_concepts if x.address not in [y.address for y in base_node.hidden_concepts]]
     return MergeNode(
         input_concepts=unique(join_keys + extra_required + non_hidden, "address"),
         output_concepts=unique(join_keys + extra_required + non_hidden, "address"),
@@ -232,9 +197,7 @@ def resolve_join_order(joins: List[NodeJoin]) -> List[NodeJoin]:
     potential_basis = left.difference(right)
     base_candidates = [x for x in final_joins_pre if x.left_node in potential_basis]
     if not base_candidates:
-        raise SyntaxError(
-            f"Unresolvable join dependencies, left requires {left} and right requires {right}"
-        )
+        raise SyntaxError(f"Unresolvable join dependencies, left requires {left} and right requires {right}")
     base = base_candidates[0]
     final_joins.append(base)
     available_aliases.add(base.left_node)

--- a/trilogy/core/processing/node_generators/filter_node.py
+++ b/trilogy/core/processing/node_generators/filter_node.py
@@ -27,7 +27,9 @@ def gen_filter_node(
     history: History | None = None,
     conditions: WhereClause | None = None,
 ) -> StrategyNode | None:
-    immediate_parent, parent_row_concepts, parent_existence_concepts = resolve_filter_parent_concepts(concept)
+    immediate_parent, parent_row_concepts, parent_existence_concepts = (
+        resolve_filter_parent_concepts(concept)
+    )
     if not isinstance(concept.lineage, FilterItem):
         raise SyntaxError('Filter node must have a lineage of type "FilterItem"')
     where = concept.lineage.where
@@ -37,7 +39,9 @@ def gen_filter_node(
     for x in local_optional:
         if isinstance(x.lineage, FilterItem):
             if concept.lineage.where == where:
-                logger.info(f"{padding(depth)}{LOGGER_PREFIX} fetching {x.lineage.content.address} as optional parent with same filter conditions ")
+                logger.info(
+                    f"{padding(depth)}{LOGGER_PREFIX} fetching {x.lineage.content.address} as optional parent with same filter conditions "
+                )
                 parent_row_concepts.append(x.lineage.content)
                 optional_included.append(x)
                 continue
@@ -64,7 +68,9 @@ def gen_filter_node(
         for existence_tuple in parent_existence_concepts:
             if not existence_tuple:
                 continue
-            logger.info(f"{padding(depth)}{LOGGER_PREFIX} fetching filter node existence parents {[x.address for x in existence_tuple]}")
+            logger.info(
+                f"{padding(depth)}{LOGGER_PREFIX} fetching filter node existence parents {[x.address for x in existence_tuple]}"
+            )
             parent_existence = source_concepts(
                 mandatory_list=list(existence_tuple),
                 environment=environment,
@@ -73,11 +79,15 @@ def gen_filter_node(
                 history=history,
             )
             if not parent_existence:
-                logger.info(f"{padding(depth)}{LOGGER_PREFIX} filter existence node parents could not be found")
+                logger.info(
+                    f"{padding(depth)}{LOGGER_PREFIX} filter existence node parents could not be found"
+                )
                 return None
             core_parents.append(parent_existence)
     if not row_parent:
-        logger.info(f"{padding(depth)}{LOGGER_PREFIX} filter node row parents {[x.address for x in parent_row_concepts]} could not be found")
+        logger.info(
+            f"{padding(depth)}{LOGGER_PREFIX} filter node row parents {[x.address for x in parent_row_concepts]} could not be found"
+        )
         return None
 
     optimized_pushdown = False
@@ -86,15 +96,23 @@ def gen_filter_node(
     elif not local_optional:
         optimized_pushdown = True
     elif conditions and conditions == where:
-        logger.info(f"{padding(depth)}{LOGGER_PREFIX} query conditions are the same as filter conditions, can optimize across all concepts")
+        logger.info(
+            f"{padding(depth)}{LOGGER_PREFIX} query conditions are the same as filter conditions, can optimize across all concepts"
+        )
         optimized_pushdown = True
     elif optional_included == local_optional:
-        logger.info(f"{padding(depth)}{LOGGER_PREFIX} all optional concepts are included in the filter, can optimize across all concepts")
+        logger.info(
+            f"{padding(depth)}{LOGGER_PREFIX} all optional concepts are included in the filter, can optimize across all concepts"
+        )
         optimized_pushdown = True
     if optimized_pushdown:
-        logger.info(f"{padding(depth)}{LOGGER_PREFIX} returning optimized filter node with pushdown to parent with condition {where.conditional}")
+        logger.info(
+            f"{padding(depth)}{LOGGER_PREFIX} returning optimized filter node with pushdown to parent with condition {where.conditional}"
+        )
         if isinstance(row_parent, SelectNode):
-            logger.info(f"{padding(depth)}{LOGGER_PREFIX} nesting select node in strategy node")
+            logger.info(
+                f"{padding(depth)}{LOGGER_PREFIX} nesting select node in strategy node"
+            )
             parent = StrategyNode(
                 input_concepts=row_parent.output_concepts,
                 output_concepts=[concept] + row_parent.output_concepts,
@@ -108,12 +126,28 @@ def gen_filter_node(
         else:
             parent = row_parent
 
-        expected_output = [concept] + [x for x in local_optional if x.address in [y for y in parent.output_concepts] or x.address in [y for y in optional_included]]
+        expected_output = [concept] + [
+            x
+            for x in local_optional
+            if x.address in [y for y in parent.output_concepts]
+            or x.address in [y for y in optional_included]
+        ]
         parent.add_parents(core_parents)
         parent.add_condition(where.conditional)
-        parent.add_existence_concepts(flattened_existence, False).set_output_concepts(expected_output, False)
+        parent.add_existence_concepts(flattened_existence, False).set_output_concepts(
+            expected_output, False
+        )
         parent.grain = Grain(
-            components=(list(immediate_parent.keys) if immediate_parent.keys else [immediate_parent]) + [x for x in local_optional if x.address in [y.address for y in parent.output_concepts]]
+            components=(
+                list(immediate_parent.keys)
+                if immediate_parent.keys
+                else [immediate_parent]
+            )
+            + [
+                x
+                for x in local_optional
+                if x.address in [y.address for y in parent.output_concepts]
+            ]
         )
         parent.rebuild_cache()
         filter_node = parent
@@ -135,9 +169,15 @@ def gen_filter_node(
             preexisting_conditions=conditions.conditional if conditions else None,
         )
 
-    if not local_optional or all([x.address in filter_node.output_concepts for x in local_optional]):
-        optional_outputs = [x for x in filter_node.output_concepts if x.address in local_optional]
-        logger.info(f"{padding(depth)}{LOGGER_PREFIX} no extra enrichment needed for filter node, has all of {[x.address for x in local_optional]}")
+    if not local_optional or all(
+        [x.address in filter_node.output_concepts for x in local_optional]
+    ):
+        optional_outputs = [
+            x for x in filter_node.output_concepts if x.address in local_optional
+        ]
+        logger.info(
+            f"{padding(depth)}{LOGGER_PREFIX} no extra enrichment needed for filter node, has all of {[x.address for x in local_optional]}"
+        )
         filter_node.set_output_concepts(
             [
                 concept,

--- a/trilogy/core/processing/node_generators/group_node.py
+++ b/trilogy/core/processing/node_generators/group_node.py
@@ -1,23 +1,22 @@
+from typing import List
+
+from trilogy.constants import logger
 from trilogy.core.models import (
+    AggregateWrapper,
     Concept,
     Environment,
+    Function,
+    Grain,
     LooseConceptList,
     WhereClause,
-    Function,
-    AggregateWrapper,
-    Grain,
 )
-from trilogy.utility import unique
-from trilogy.core.processing.nodes import GroupNode, StrategyNode, History
-from typing import List
-from trilogy.core.processing.node_generators.common import (
-    resolve_function_parent_concepts,
-)
-from trilogy.constants import logger
-from trilogy.core.processing.utility import padding, create_log_lambda
 from trilogy.core.processing.node_generators.common import (
     gen_enrichment_node,
+    resolve_function_parent_concepts,
 )
+from trilogy.core.processing.nodes import GroupNode, History, StrategyNode
+from trilogy.core.processing.utility import create_log_lambda, padding
+from trilogy.utility import unique
 
 LOGGER_PREFIX = "[GEN_GROUP_NODE]"
 
@@ -34,47 +33,31 @@ def gen_group_node(
 ) -> StrategyNode | None:
     # aggregates MUST always group to the proper grain
     # except when the
-    parent_concepts: List[Concept] = unique(
-        resolve_function_parent_concepts(concept), "address"
-    )
-    logger.info(
-        f"{padding(depth)}{LOGGER_PREFIX} parent concepts are {[x.address for x in parent_concepts]} from group grain {concept.grain}"
-    )
+    parent_concepts: List[Concept] = unique(resolve_function_parent_concepts(concept), "address")
+    logger.info(f"{padding(depth)}{LOGGER_PREFIX} parent concepts are {[x.address for x in parent_concepts]} from group grain {concept.grain}")
 
     # if the aggregation has a grain, we need to ensure these are the ONLY optional in the output of the select
     output_concepts = [concept]
 
     if concept.grain and len(concept.grain.components_copy) > 0:
-        grain_components = (
-            concept.grain.components_copy if not concept.grain.abstract else []
-        )
+        grain_components = concept.grain.components_copy if not concept.grain.abstract else []
         parent_concepts += grain_components
         output_concepts += grain_components
         for possible_agg in local_optional:
             if not isinstance(possible_agg.lineage, (AggregateWrapper, Function)):
                 continue
             if possible_agg.grain and possible_agg.grain == concept.grain:
-                agg_parents: List[Concept] = resolve_function_parent_concepts(
-                    possible_agg
-                )
-                if set([x.address for x in agg_parents]).issubset(
-                    set([x.address for x in parent_concepts])
-                ):
+                agg_parents: List[Concept] = resolve_function_parent_concepts(possible_agg)
+                if set([x.address for x in agg_parents]).issubset(set([x.address for x in parent_concepts])):
                     output_concepts.append(possible_agg)
-                    logger.info(
-                        f"{padding(depth)}{LOGGER_PREFIX} found equivalent group by optional concept {possible_agg.address} for {concept.address}"
-                    )
+                    logger.info(f"{padding(depth)}{LOGGER_PREFIX} found equivalent group by optional concept {possible_agg.address} for {concept.address}")
                 elif Grain(components=agg_parents) == Grain(components=parent_concepts):
                     extra = [x for x in agg_parents if x.address not in parent_concepts]
                     parent_concepts += extra
                     output_concepts.append(possible_agg)
-                    logger.info(
-                        f"{padding(depth)}{LOGGER_PREFIX} found equivalent group by optional concept {possible_agg.address} for {concept.address}"
-                    )
+                    logger.info(f"{padding(depth)}{LOGGER_PREFIX} found equivalent group by optional concept {possible_agg.address} for {concept.address}")
     if parent_concepts:
-        logger.info(
-            f"{padding(depth)}{LOGGER_PREFIX} fetching group node parents {LooseConceptList(concepts=parent_concepts)}"
-        )
+        logger.info(f"{padding(depth)}{LOGGER_PREFIX} fetching group node parents {LooseConceptList(concepts=parent_concepts)}")
         parent_concepts = unique(parent_concepts, "address")
         parent = source_concepts(
             mandatory_list=parent_concepts,
@@ -85,9 +68,7 @@ def gen_group_node(
             conditions=conditions,
         )
         if not parent:
-            logger.info(
-                f"{padding(depth)}{LOGGER_PREFIX} group by node parents unresolvable"
-            )
+            logger.info(f"{padding(depth)}{LOGGER_PREFIX} group by node parents unresolvable")
             return None
         parents: List[StrategyNode] = [parent]
     else:
@@ -111,17 +92,11 @@ def gen_group_node(
 
     if not local_optional:
         return group_node
-    missing_optional = [
-        x.address for x in local_optional if x.address not in group_node.output_concepts
-    ]
+    missing_optional = [x.address for x in local_optional if x.address not in group_node.output_concepts]
     if not missing_optional:
-        logger.info(
-            f"{padding(depth)}{LOGGER_PREFIX} no extra enrichment needed for group node, has all of {[x.address for x in local_optional]}"
-        )
+        logger.info(f"{padding(depth)}{LOGGER_PREFIX} no extra enrichment needed for group node, has all of {[x.address for x in local_optional]}")
         return group_node
-    logger.info(
-        f"{padding(depth)}{LOGGER_PREFIX} group node requires enrichment, missing {missing_optional}"
-    )
+    logger.info(f"{padding(depth)}{LOGGER_PREFIX} group node requires enrichment, missing {missing_optional}")
     return gen_enrichment_node(
         group_node,
         join_keys=group_key_parents,

--- a/trilogy/core/processing/node_generators/group_node.py
+++ b/trilogy/core/processing/node_generators/group_node.py
@@ -33,31 +33,47 @@ def gen_group_node(
 ) -> StrategyNode | None:
     # aggregates MUST always group to the proper grain
     # except when the
-    parent_concepts: List[Concept] = unique(resolve_function_parent_concepts(concept), "address")
-    logger.info(f"{padding(depth)}{LOGGER_PREFIX} parent concepts are {[x.address for x in parent_concepts]} from group grain {concept.grain}")
+    parent_concepts: List[Concept] = unique(
+        resolve_function_parent_concepts(concept), "address"
+    )
+    logger.info(
+        f"{padding(depth)}{LOGGER_PREFIX} parent concepts are {[x.address for x in parent_concepts]} from group grain {concept.grain}"
+    )
 
     # if the aggregation has a grain, we need to ensure these are the ONLY optional in the output of the select
     output_concepts = [concept]
 
     if concept.grain and len(concept.grain.components_copy) > 0:
-        grain_components = concept.grain.components_copy if not concept.grain.abstract else []
+        grain_components = (
+            concept.grain.components_copy if not concept.grain.abstract else []
+        )
         parent_concepts += grain_components
         output_concepts += grain_components
         for possible_agg in local_optional:
             if not isinstance(possible_agg.lineage, (AggregateWrapper, Function)):
                 continue
             if possible_agg.grain and possible_agg.grain == concept.grain:
-                agg_parents: List[Concept] = resolve_function_parent_concepts(possible_agg)
-                if set([x.address for x in agg_parents]).issubset(set([x.address for x in parent_concepts])):
+                agg_parents: List[Concept] = resolve_function_parent_concepts(
+                    possible_agg
+                )
+                if set([x.address for x in agg_parents]).issubset(
+                    set([x.address for x in parent_concepts])
+                ):
                     output_concepts.append(possible_agg)
-                    logger.info(f"{padding(depth)}{LOGGER_PREFIX} found equivalent group by optional concept {possible_agg.address} for {concept.address}")
+                    logger.info(
+                        f"{padding(depth)}{LOGGER_PREFIX} found equivalent group by optional concept {possible_agg.address} for {concept.address}"
+                    )
                 elif Grain(components=agg_parents) == Grain(components=parent_concepts):
                     extra = [x for x in agg_parents if x.address not in parent_concepts]
                     parent_concepts += extra
                     output_concepts.append(possible_agg)
-                    logger.info(f"{padding(depth)}{LOGGER_PREFIX} found equivalent group by optional concept {possible_agg.address} for {concept.address}")
+                    logger.info(
+                        f"{padding(depth)}{LOGGER_PREFIX} found equivalent group by optional concept {possible_agg.address} for {concept.address}"
+                    )
     if parent_concepts:
-        logger.info(f"{padding(depth)}{LOGGER_PREFIX} fetching group node parents {LooseConceptList(concepts=parent_concepts)}")
+        logger.info(
+            f"{padding(depth)}{LOGGER_PREFIX} fetching group node parents {LooseConceptList(concepts=parent_concepts)}"
+        )
         parent_concepts = unique(parent_concepts, "address")
         parent = source_concepts(
             mandatory_list=parent_concepts,
@@ -68,7 +84,9 @@ def gen_group_node(
             conditions=conditions,
         )
         if not parent:
-            logger.info(f"{padding(depth)}{LOGGER_PREFIX} group by node parents unresolvable")
+            logger.info(
+                f"{padding(depth)}{LOGGER_PREFIX} group by node parents unresolvable"
+            )
             return None
         parents: List[StrategyNode] = [parent]
     else:
@@ -92,11 +110,17 @@ def gen_group_node(
 
     if not local_optional:
         return group_node
-    missing_optional = [x.address for x in local_optional if x.address not in group_node.output_concepts]
+    missing_optional = [
+        x.address for x in local_optional if x.address not in group_node.output_concepts
+    ]
     if not missing_optional:
-        logger.info(f"{padding(depth)}{LOGGER_PREFIX} no extra enrichment needed for group node, has all of {[x.address for x in local_optional]}")
+        logger.info(
+            f"{padding(depth)}{LOGGER_PREFIX} no extra enrichment needed for group node, has all of {[x.address for x in local_optional]}"
+        )
         return group_node
-    logger.info(f"{padding(depth)}{LOGGER_PREFIX} group node requires enrichment, missing {missing_optional}")
+    logger.info(
+        f"{padding(depth)}{LOGGER_PREFIX} group node requires enrichment, missing {missing_optional}"
+    )
     return gen_enrichment_node(
         group_node,
         join_keys=group_key_parents,

--- a/trilogy/core/processing/node_generators/group_to_node.py
+++ b/trilogy/core/processing/node_generators/group_to_node.py
@@ -1,13 +1,13 @@
-from trilogy.core.models import Concept, Environment, Function, WhereClause
-from trilogy.core.processing.nodes import (
-    GroupNode,
-    StrategyNode,
-    MergeNode,
-    History,
-)
 from typing import List
 
 from trilogy.constants import logger
+from trilogy.core.models import Concept, Environment, Function, WhereClause
+from trilogy.core.processing.nodes import (
+    GroupNode,
+    History,
+    MergeNode,
+    StrategyNode,
+)
 from trilogy.core.processing.utility import padding
 
 LOGGER_PREFIX = "[GEN_GROUP_TO_NODE]"
@@ -27,9 +27,7 @@ def gen_group_to_node(
     if not isinstance(concept.lineage, Function):
         raise SyntaxError("Group to should have function lineage")
     parent_concepts: List[Concept] = concept.lineage.concept_arguments
-    logger.info(
-        f"{padding(depth)}{LOGGER_PREFIX} group by node has required parents {[x.address for x in parent_concepts]}"
-    )
+    logger.info(f"{padding(depth)}{LOGGER_PREFIX} group by node has required parents {[x.address for x in parent_concepts]}")
     parents: List[StrategyNode] = [
         source_concepts(
             mandatory_list=parent_concepts,
@@ -65,15 +63,11 @@ def gen_group_to_node(
         history=history,
     )
     if not enrich_node:
-        logger.info(
-            f"{padding(depth)}{LOGGER_PREFIX} group by node enrich node, returning group node only."
-        )
+        logger.info(f"{padding(depth)}{LOGGER_PREFIX} group by node enrich node, returning group node only.")
         return group_node
 
     return MergeNode(
-        input_concepts=[concept]
-        + local_optional
-        + [x for x in parent_concepts if x.address != concept.address],
+        input_concepts=[concept] + local_optional + [x for x in parent_concepts if x.address != concept.address],
         output_concepts=[concept] + local_optional,
         environment=environment,
         g=g,

--- a/trilogy/core/processing/node_generators/group_to_node.py
+++ b/trilogy/core/processing/node_generators/group_to_node.py
@@ -27,7 +27,9 @@ def gen_group_to_node(
     if not isinstance(concept.lineage, Function):
         raise SyntaxError("Group to should have function lineage")
     parent_concepts: List[Concept] = concept.lineage.concept_arguments
-    logger.info(f"{padding(depth)}{LOGGER_PREFIX} group by node has required parents {[x.address for x in parent_concepts]}")
+    logger.info(
+        f"{padding(depth)}{LOGGER_PREFIX} group by node has required parents {[x.address for x in parent_concepts]}"
+    )
     parents: List[StrategyNode] = [
         source_concepts(
             mandatory_list=parent_concepts,
@@ -63,11 +65,15 @@ def gen_group_to_node(
         history=history,
     )
     if not enrich_node:
-        logger.info(f"{padding(depth)}{LOGGER_PREFIX} group by node enrich node, returning group node only.")
+        logger.info(
+            f"{padding(depth)}{LOGGER_PREFIX} group by node enrich node, returning group node only."
+        )
         return group_node
 
     return MergeNode(
-        input_concepts=[concept] + local_optional + [x for x in parent_concepts if x.address != concept.address],
+        input_concepts=[concept]
+        + local_optional
+        + [x for x in parent_concepts if x.address != concept.address],
         output_concepts=[concept] + local_optional,
         environment=environment,
         g=g,

--- a/trilogy/core/processing/node_generators/multiselect_node.py
+++ b/trilogy/core/processing/node_generators/multiselect_node.py
@@ -30,7 +30,9 @@ from trilogy.core.processing.utility import concept_to_relevant_joins, padding
 LOGGER_PREFIX = "[GEN_MULTISELECT_NODE]"
 
 
-def extra_align_joins(base: MultiSelectStatement, parents: List[StrategyNode]) -> List[NodeJoin]:
+def extra_align_joins(
+    base: MultiSelectStatement, parents: List[StrategyNode]
+) -> List[NodeJoin]:
     node_merge_concept_map = defaultdict(list)
     output = []
     for align in base.align.items:
@@ -43,7 +45,11 @@ def extra_align_joins(base: MultiSelectStatement, parents: List[StrategyNode]) -
                     node_merge_concept_map[node].append(jc)
 
     for left, right in combinations(node_merge_concept_map.keys(), 2):
-        matched_concepts = [x for x in node_merge_concept_map[left] if x in node_merge_concept_map[right]]
+        matched_concepts = [
+            x
+            for x in node_merge_concept_map[left]
+            if x in node_merge_concept_map[right]
+        ]
         output.append(
             NodeJoin(
                 left_node=left,
@@ -66,7 +72,9 @@ def gen_multiselect_node(
     conditions: WhereClause | None = None,
 ) -> MergeNode | None:
     if not isinstance(concept.lineage, MultiSelectStatement):
-        logger.info(f"{padding(depth)}{LOGGER_PREFIX} Cannot generate multiselect node for {concept}")
+        logger.info(
+            f"{padding(depth)}{LOGGER_PREFIX} Cannot generate multiselect node for {concept}"
+        )
         return None
     lineage: MultiSelectStatement = concept.lineage
 
@@ -81,7 +89,9 @@ def gen_multiselect_node(
             conditions=select.where_clause,
         )
         if not snode:
-            logger.info(f"{padding(depth)}{LOGGER_PREFIX} Cannot generate multiselect node for {concept}")
+            logger.info(
+                f"{padding(depth)}{LOGGER_PREFIX} Cannot generate multiselect node for {concept}"
+            )
             return None
         if select.having_clause:
             if snode.conditions:
@@ -117,8 +127,14 @@ def gen_multiselect_node(
 
     enrichment = set([x.address for x in local_optional])
 
-    rowset_relevant = [x for x in lineage.derived_concepts if x.address == concept.address or x.address in enrichment]
-    additional_relevant = [x for x in select.output_components if x.address in enrichment]
+    rowset_relevant = [
+        x
+        for x in lineage.derived_concepts
+        if x.address == concept.address or x.address in enrichment
+    ]
+    additional_relevant = [
+        x for x in select.output_components if x.address in enrichment
+    ]
     # add in other other concepts
     for item in rowset_relevant:
         node.output_concepts.append(item)
@@ -133,16 +149,26 @@ def gen_multiselect_node(
 
     # assume grain to be output of select
     # but don't include anything aggregate at this point
-    node.resolution_cache.grain = concept_list_to_grain(node.output_concepts, parent_sources=node.resolution_cache.datasources)
+    node.resolution_cache.grain = concept_list_to_grain(
+        node.output_concepts, parent_sources=node.resolution_cache.datasources
+    )
     possible_joins = concept_to_relevant_joins(additional_relevant)
     if not local_optional:
-        logger.info(f"{padding(depth)}{LOGGER_PREFIX} no enriched required for rowset node; exiting early")
+        logger.info(
+            f"{padding(depth)}{LOGGER_PREFIX} no enriched required for rowset node; exiting early"
+        )
         return node
     if not possible_joins:
-        logger.info(f"{padding(depth)}{LOGGER_PREFIX} no possible joins for rowset node; exiting early")
+        logger.info(
+            f"{padding(depth)}{LOGGER_PREFIX} no possible joins for rowset node; exiting early"
+        )
         return node
-    if all([x.address in [y.address for y in node.output_concepts] for x in local_optional]):
-        logger.info(f"{padding(depth)}{LOGGER_PREFIX} all enriched concepts returned from base rowset node; exiting early")
+    if all(
+        [x.address in [y.address for y in node.output_concepts] for x in local_optional]
+    ):
+        logger.info(
+            f"{padding(depth)}{LOGGER_PREFIX} all enriched concepts returned from base rowset node; exiting early"
+        )
         return node
     enrich_node: MergeNode = source_concepts(  # this fetches the parent + join keys
         # to then connect to the rest of the query
@@ -154,7 +180,9 @@ def gen_multiselect_node(
         conditions=conditions,
     )
     if not enrich_node:
-        logger.info(f"{padding(depth)}{LOGGER_PREFIX} Cannot generate rowset enrichment node for {concept} with optional {local_optional}, returning just rowset node")
+        logger.info(
+            f"{padding(depth)}{LOGGER_PREFIX} Cannot generate rowset enrichment node for {concept} with optional {local_optional}, returning just rowset node"
+        )
         return node
 
     return MergeNode(

--- a/trilogy/core/processing/node_generators/multiselect_node.py
+++ b/trilogy/core/processing/node_generators/multiselect_node.py
@@ -3,21 +3,18 @@ from itertools import combinations
 from typing import List
 
 from trilogy.constants import logger
-from trilogy.core.enums import JoinType, Purpose
+from trilogy.core.enums import BooleanOperator, JoinType, Purpose
 from trilogy.core.models import (
     Concept,
+    Conditional,
     Environment,
     MultiSelectStatement,
     WhereClause,
-    Conditional,
 )
-from trilogy.core.processing.nodes import MergeNode, NodeJoin, History
-from trilogy.core.processing.nodes.base_node import concept_list_to_grain, StrategyNode
-
-from trilogy.core.processing.utility import padding
-from trilogy.core.processing.utility import concept_to_relevant_joins
-from trilogy.core.enums import BooleanOperator
 from trilogy.core.processing.node_generators.common import resolve_join_order
+from trilogy.core.processing.nodes import History, MergeNode, NodeJoin
+from trilogy.core.processing.nodes.base_node import StrategyNode, concept_list_to_grain
+from trilogy.core.processing.utility import concept_to_relevant_joins, padding
 
 LOGGER_PREFIX = "[GEN_MULTISELECT_NODE]"
 

--- a/trilogy/core/processing/node_generators/multiselect_node.py
+++ b/trilogy/core/processing/node_generators/multiselect_node.py
@@ -1,3 +1,9 @@
+from collections import defaultdict
+from itertools import combinations
+from typing import List
+
+from trilogy.constants import logger
+from trilogy.core.enums import JoinType, Purpose
 from trilogy.core.models import (
     Concept,
     Environment,
@@ -17,13 +23,14 @@ from collections import defaultdict
 from itertools import combinations
 from trilogy.core.enums import Purpose, BooleanOperator
 from trilogy.core.processing.node_generators.common import resolve_join_order
+from trilogy.core.processing.nodes import History, MergeNode, NodeJoin
+from trilogy.core.processing.nodes.base_node import StrategyNode, concept_list_to_grain
+from trilogy.core.processing.utility import concept_to_relevant_joins, padding
 
 LOGGER_PREFIX = "[GEN_MULTISELECT_NODE]"
 
 
-def extra_align_joins(
-    base: MultiSelectStatement, parents: List[StrategyNode]
-) -> List[NodeJoin]:
+def extra_align_joins(base: MultiSelectStatement, parents: List[StrategyNode]) -> List[NodeJoin]:
     node_merge_concept_map = defaultdict(list)
     output = []
     for align in base.align.items:
@@ -36,11 +43,7 @@ def extra_align_joins(
                     node_merge_concept_map[node].append(jc)
 
     for left, right in combinations(node_merge_concept_map.keys(), 2):
-        matched_concepts = [
-            x
-            for x in node_merge_concept_map[left]
-            if x in node_merge_concept_map[right]
-        ]
+        matched_concepts = [x for x in node_merge_concept_map[left] if x in node_merge_concept_map[right]]
         output.append(
             NodeJoin(
                 left_node=left,
@@ -63,9 +66,7 @@ def gen_multiselect_node(
     conditions: WhereClause | None = None,
 ) -> MergeNode | None:
     if not isinstance(concept.lineage, MultiSelectStatement):
-        logger.info(
-            f"{padding(depth)}{LOGGER_PREFIX} Cannot generate multiselect node for {concept}"
-        )
+        logger.info(f"{padding(depth)}{LOGGER_PREFIX} Cannot generate multiselect node for {concept}")
         return None
     lineage: MultiSelectStatement = concept.lineage
 
@@ -80,9 +81,7 @@ def gen_multiselect_node(
             conditions=select.where_clause,
         )
         if not snode:
-            logger.info(
-                f"{padding(depth)}{LOGGER_PREFIX} Cannot generate multiselect node for {concept}"
-            )
+            logger.info(f"{padding(depth)}{LOGGER_PREFIX} Cannot generate multiselect node for {concept}")
             return None
         if select.having_clause:
             if snode.conditions:
@@ -118,14 +117,8 @@ def gen_multiselect_node(
 
     enrichment = set([x.address for x in local_optional])
 
-    rowset_relevant = [
-        x
-        for x in lineage.derived_concepts
-        if x.address == concept.address or x.address in enrichment
-    ]
-    additional_relevant = [
-        x for x in select.output_components if x.address in enrichment
-    ]
+    rowset_relevant = [x for x in lineage.derived_concepts if x.address == concept.address or x.address in enrichment]
+    additional_relevant = [x for x in select.output_components if x.address in enrichment]
     # add in other other concepts
     for item in rowset_relevant:
         node.output_concepts.append(item)
@@ -140,26 +133,16 @@ def gen_multiselect_node(
 
     # assume grain to be output of select
     # but don't include anything aggregate at this point
-    node.resolution_cache.grain = concept_list_to_grain(
-        node.output_concepts, parent_sources=node.resolution_cache.datasources
-    )
+    node.resolution_cache.grain = concept_list_to_grain(node.output_concepts, parent_sources=node.resolution_cache.datasources)
     possible_joins = concept_to_relevant_joins(additional_relevant)
     if not local_optional:
-        logger.info(
-            f"{padding(depth)}{LOGGER_PREFIX} no enriched required for rowset node; exiting early"
-        )
+        logger.info(f"{padding(depth)}{LOGGER_PREFIX} no enriched required for rowset node; exiting early")
         return node
     if not possible_joins:
-        logger.info(
-            f"{padding(depth)}{LOGGER_PREFIX} no possible joins for rowset node; exiting early"
-        )
+        logger.info(f"{padding(depth)}{LOGGER_PREFIX} no possible joins for rowset node; exiting early")
         return node
-    if all(
-        [x.address in [y.address for y in node.output_concepts] for x in local_optional]
-    ):
-        logger.info(
-            f"{padding(depth)}{LOGGER_PREFIX} all enriched concepts returned from base rowset node; exiting early"
-        )
+    if all([x.address in [y.address for y in node.output_concepts] for x in local_optional]):
+        logger.info(f"{padding(depth)}{LOGGER_PREFIX} all enriched concepts returned from base rowset node; exiting early")
         return node
     enrich_node: MergeNode = source_concepts(  # this fetches the parent + join keys
         # to then connect to the rest of the query
@@ -171,9 +154,7 @@ def gen_multiselect_node(
         conditions=conditions,
     )
     if not enrich_node:
-        logger.info(
-            f"{padding(depth)}{LOGGER_PREFIX} Cannot generate rowset enrichment node for {concept} with optional {local_optional}, returning just rowset node"
-        )
+        logger.info(f"{padding(depth)}{LOGGER_PREFIX} Cannot generate rowset enrichment node for {concept} with optional {local_optional}, returning just rowset node")
         return node
 
     return MergeNode(

--- a/trilogy/core/processing/node_generators/multiselect_node.py
+++ b/trilogy/core/processing/node_generators/multiselect_node.py
@@ -13,19 +13,11 @@ from trilogy.core.models import (
 )
 from trilogy.core.processing.nodes import MergeNode, NodeJoin, History
 from trilogy.core.processing.nodes.base_node import concept_list_to_grain, StrategyNode
-from typing import List
 
-from trilogy.core.enums import JoinType
-from trilogy.constants import logger
 from trilogy.core.processing.utility import padding
 from trilogy.core.processing.utility import concept_to_relevant_joins
-from collections import defaultdict
-from itertools import combinations
-from trilogy.core.enums import Purpose, BooleanOperator
+from trilogy.core.enums import BooleanOperator
 from trilogy.core.processing.node_generators.common import resolve_join_order
-from trilogy.core.processing.nodes import History, MergeNode, NodeJoin
-from trilogy.core.processing.nodes.base_node import StrategyNode, concept_list_to_grain
-from trilogy.core.processing.utility import concept_to_relevant_joins, padding
 
 LOGGER_PREFIX = "[GEN_MULTISELECT_NODE]"
 

--- a/trilogy/core/processing/node_generators/rowset_node.py
+++ b/trilogy/core/processing/node_generators/rowset_node.py
@@ -1,19 +1,19 @@
+from typing import List
+
+from trilogy.constants import logger
+from trilogy.core.enums import PurposeLineage
 from trilogy.core.models import (
     Concept,
     Environment,
-    SelectStatement,
+    MultiSelectStatement,
     RowsetDerivationStatement,
     RowsetItem,
-    MultiSelectStatement,
+    SelectStatement,
     WhereClause,
 )
-from trilogy.core.processing.nodes import MergeNode, History, StrategyNode
-from typing import List
-
-from trilogy.core.enums import PurposeLineage
-from trilogy.constants import logger
-from trilogy.core.processing.utility import padding, concept_to_relevant_joins
+from trilogy.core.processing.nodes import History, MergeNode, StrategyNode
 from trilogy.core.processing.nodes.base_node import concept_list_to_grain
+from trilogy.core.processing.utility import concept_to_relevant_joins, padding
 
 LOGGER_PREFIX = "[GEN_ROWSET_NODE]"
 
@@ -31,31 +31,20 @@ def gen_rowset_node(
     from trilogy.core.query_processor import get_query_node
 
     if not isinstance(concept.lineage, RowsetItem):
-        raise SyntaxError(
-            f"Invalid lineage passed into rowset fetch, got {type(concept.lineage)}, expected {RowsetItem}"
-        )
+        raise SyntaxError(f"Invalid lineage passed into rowset fetch, got {type(concept.lineage)}, expected {RowsetItem}")
     lineage: RowsetItem = concept.lineage
     rowset: RowsetDerivationStatement = lineage.rowset
     select: SelectStatement | MultiSelectStatement = lineage.rowset.select
     node = get_query_node(environment, select, graph=g, history=history)
 
     if not node:
-        logger.info(
-            f"{padding(depth)}{LOGGER_PREFIX} Cannot generate parent rowset node for {concept}"
-        )
+        logger.info(f"{padding(depth)}{LOGGER_PREFIX} Cannot generate parent rowset node for {concept}")
         return None
     enrichment = set([x.address for x in local_optional])
     rowset_relevant = [x for x in rowset.derived_concepts]
     select_hidden = set([x.address for x in select.hidden_components])
-    rowset_hidden = [
-        x
-        for x in rowset.derived_concepts
-        if isinstance(x.lineage, RowsetItem)
-        and x.lineage.content.address in select_hidden
-    ]
-    additional_relevant = [
-        x for x in select.output_components if x.address in enrichment
-    ]
+    rowset_hidden = [x for x in rowset.derived_concepts if isinstance(x.lineage, RowsetItem) and x.lineage.content.address in select_hidden]
+    additional_relevant = [x for x in select.output_components if x.address in enrichment]
     # add in other other concepts
 
     node.add_output_concepts(rowset_relevant + additional_relevant)
@@ -63,44 +52,26 @@ def gen_rowset_node(
         for item in additional_relevant:
             node.partial_concepts.append(item)
 
-    final_hidden = rowset_hidden + [
-        x
-        for x in node.output_concepts
-        if x.address not in local_optional + [concept]
-        and x.derivation != PurposeLineage.ROWSET
-    ]
+    final_hidden = rowset_hidden + [x for x in node.output_concepts if x.address not in local_optional + [concept] and x.derivation != PurposeLineage.ROWSET]
     node.hide_output_concepts(final_hidden)
     assert node.resolution_cache
     # assume grain to be output of select
     # but don't include anything hidden(the non-rowset concepts)
     node.grain = concept_list_to_grain(
-        [
-            x
-            for x in node.output_concepts
-            if x.address
-            not in [
-                y for y in node.hidden_concepts if y.derivation != PurposeLineage.ROWSET
-            ]
-        ],
+        [x for x in node.output_concepts if x.address not in [y for y in node.hidden_concepts if y.derivation != PurposeLineage.ROWSET]],
         parent_sources=node.resolution_cache.datasources,
     )
 
     node.rebuild_cache()
 
-    if not local_optional or all(
-        x.address in node.output_concepts for x in local_optional
-    ):
-        logger.info(
-            f"{padding(depth)}{LOGGER_PREFIX} no enrichment required for rowset node as all optional found or no optional; exiting early."
-        )
+    if not local_optional or all(x.address in node.output_concepts for x in local_optional):
+        logger.info(f"{padding(depth)}{LOGGER_PREFIX} no enrichment required for rowset node as all optional found or no optional; exiting early.")
         # node.set_preexisting_conditions(conditions.conditional if conditions else None)
         return node
 
     possible_joins = concept_to_relevant_joins(node.output_concepts)
     if not possible_joins:
-        logger.info(
-            f"{padding(depth)}{LOGGER_PREFIX} no possible joins for rowset node to get {[x.address for x in local_optional]}; have {[x.address for x in node.output_concepts]}"
-        )
+        logger.info(f"{padding(depth)}{LOGGER_PREFIX} no possible joins for rowset node to get {[x.address for x in local_optional]}; have {[x.address for x in node.output_concepts]}")
         return node
     enrich_node: MergeNode = source_concepts(  # this fetches the parent + join keys
         # to then connect to the rest of the query
@@ -111,9 +82,7 @@ def gen_rowset_node(
         conditions=conditions,
     )
     if not enrich_node:
-        logger.info(
-            f"{padding(depth)}{LOGGER_PREFIX} Cannot generate rowset enrichment node for {concept} with optional {local_optional}, returning just rowset node"
-        )
+        logger.info(f"{padding(depth)}{LOGGER_PREFIX} Cannot generate rowset enrichment node for {concept} with optional {local_optional}, returning just rowset node")
         return node
     return MergeNode(
         input_concepts=enrich_node.output_concepts + node.output_concepts,

--- a/trilogy/core/processing/node_generators/rowset_node.py
+++ b/trilogy/core/processing/node_generators/rowset_node.py
@@ -31,20 +31,31 @@ def gen_rowset_node(
     from trilogy.core.query_processor import get_query_node
 
     if not isinstance(concept.lineage, RowsetItem):
-        raise SyntaxError(f"Invalid lineage passed into rowset fetch, got {type(concept.lineage)}, expected {RowsetItem}")
+        raise SyntaxError(
+            f"Invalid lineage passed into rowset fetch, got {type(concept.lineage)}, expected {RowsetItem}"
+        )
     lineage: RowsetItem = concept.lineage
     rowset: RowsetDerivationStatement = lineage.rowset
     select: SelectStatement | MultiSelectStatement = lineage.rowset.select
     node = get_query_node(environment, select, graph=g, history=history)
 
     if not node:
-        logger.info(f"{padding(depth)}{LOGGER_PREFIX} Cannot generate parent rowset node for {concept}")
+        logger.info(
+            f"{padding(depth)}{LOGGER_PREFIX} Cannot generate parent rowset node for {concept}"
+        )
         return None
     enrichment = set([x.address for x in local_optional])
     rowset_relevant = [x for x in rowset.derived_concepts]
     select_hidden = set([x.address for x in select.hidden_components])
-    rowset_hidden = [x for x in rowset.derived_concepts if isinstance(x.lineage, RowsetItem) and x.lineage.content.address in select_hidden]
-    additional_relevant = [x for x in select.output_components if x.address in enrichment]
+    rowset_hidden = [
+        x
+        for x in rowset.derived_concepts
+        if isinstance(x.lineage, RowsetItem)
+        and x.lineage.content.address in select_hidden
+    ]
+    additional_relevant = [
+        x for x in select.output_components if x.address in enrichment
+    ]
     # add in other other concepts
 
     node.add_output_concepts(rowset_relevant + additional_relevant)
@@ -52,26 +63,44 @@ def gen_rowset_node(
         for item in additional_relevant:
             node.partial_concepts.append(item)
 
-    final_hidden = rowset_hidden + [x for x in node.output_concepts if x.address not in local_optional + [concept] and x.derivation != PurposeLineage.ROWSET]
+    final_hidden = rowset_hidden + [
+        x
+        for x in node.output_concepts
+        if x.address not in local_optional + [concept]
+        and x.derivation != PurposeLineage.ROWSET
+    ]
     node.hide_output_concepts(final_hidden)
     assert node.resolution_cache
     # assume grain to be output of select
     # but don't include anything hidden(the non-rowset concepts)
     node.grain = concept_list_to_grain(
-        [x for x in node.output_concepts if x.address not in [y for y in node.hidden_concepts if y.derivation != PurposeLineage.ROWSET]],
+        [
+            x
+            for x in node.output_concepts
+            if x.address
+            not in [
+                y for y in node.hidden_concepts if y.derivation != PurposeLineage.ROWSET
+            ]
+        ],
         parent_sources=node.resolution_cache.datasources,
     )
 
     node.rebuild_cache()
 
-    if not local_optional or all(x.address in node.output_concepts for x in local_optional):
-        logger.info(f"{padding(depth)}{LOGGER_PREFIX} no enrichment required for rowset node as all optional found or no optional; exiting early.")
+    if not local_optional or all(
+        x.address in node.output_concepts for x in local_optional
+    ):
+        logger.info(
+            f"{padding(depth)}{LOGGER_PREFIX} no enrichment required for rowset node as all optional found or no optional; exiting early."
+        )
         # node.set_preexisting_conditions(conditions.conditional if conditions else None)
         return node
 
     possible_joins = concept_to_relevant_joins(node.output_concepts)
     if not possible_joins:
-        logger.info(f"{padding(depth)}{LOGGER_PREFIX} no possible joins for rowset node to get {[x.address for x in local_optional]}; have {[x.address for x in node.output_concepts]}")
+        logger.info(
+            f"{padding(depth)}{LOGGER_PREFIX} no possible joins for rowset node to get {[x.address for x in local_optional]}; have {[x.address for x in node.output_concepts]}"
+        )
         return node
     enrich_node: MergeNode = source_concepts(  # this fetches the parent + join keys
         # to then connect to the rest of the query
@@ -82,7 +111,9 @@ def gen_rowset_node(
         conditions=conditions,
     )
     if not enrich_node:
-        logger.info(f"{padding(depth)}{LOGGER_PREFIX} Cannot generate rowset enrichment node for {concept} with optional {local_optional}, returning just rowset node")
+        logger.info(
+            f"{padding(depth)}{LOGGER_PREFIX} Cannot generate rowset enrichment node for {concept} with optional {local_optional}, returning just rowset node"
+        )
         return node
     return MergeNode(
         input_concepts=enrich_node.output_concepts + node.output_concepts,

--- a/trilogy/core/processing/node_generators/select_merge_node.py
+++ b/trilogy/core/processing/node_generators/select_merge_node.py
@@ -1,23 +1,25 @@
 from typing import List, Optional
 
+import networkx as nx
+
+from trilogy.constants import logger
+from trilogy.core.enums import PurposeLineage
+from trilogy.core.graph_models import concept_to_node
 from trilogy.core.models import (
     Concept,
+    Datasource,
     Environment,
     Grain,
-    Datasource,
-    WhereClause,
     LooseConceptList,
+    WhereClause,
 )
 from trilogy.core.processing.nodes import (
-    MergeNode,
-    StrategyNode,
-    GroupNode,
     ConstantNode,
+    GroupNode,
+    MergeNode,
     SelectNode,
+    StrategyNode,
 )
-import networkx as nx
-from trilogy.core.graph_models import concept_to_node
-from trilogy.constants import logger
 from trilogy.core.processing.utility import padding
 from trilogy.core.enums import PurposeLineage
 from trilogy.core.processing.nodes.base_node import (
@@ -31,9 +33,7 @@ def extract_address(node: str):
     return node.split("~")[1].split("@")[0]
 
 
-def get_graph_partial_nodes(
-    g: nx.DiGraph, conditions: WhereClause | None
-) -> dict[str, list[str]]:
+def get_graph_partial_nodes(g: nx.DiGraph, conditions: WhereClause | None) -> dict[str, list[str]]:
     datasources: dict[str, Datasource] = nx.get_node_attributes(g, "datasource")
     partial: dict[str, list[str]] = {}
     for node in g.nodes:
@@ -79,26 +79,16 @@ def create_pruned_concept_graph(
         partial = get_graph_partial_nodes(g, conditions)
         to_remove = []
         for edge in g.edges:
-            if (
-                edge[0] in datasources
-                and (pnodes := partial.get(edge[0], []))
-                and edge[1] in pnodes
-            ):
+            if edge[0] in datasources and (pnodes := partial.get(edge[0], [])) and edge[1] in pnodes:
                 to_remove.append(edge)
-            if (
-                edge[1] in datasources
-                and (pnodes := partial.get(edge[1], []))
-                and edge[0] in pnodes
-            ):
+            if edge[1] in datasources and (pnodes := partial.get(edge[1], [])) and edge[0] in pnodes:
                 to_remove.append(edge)
         for edge in to_remove:
             g.remove_edge(*edge)
     for n in g.nodes():
         if not n.startswith("ds~"):
             continue
-        actual_neighbors = [
-            x for x in relevant_concepts if x in (nx.all_neighbors(g, n))
-        ]
+        actual_neighbors = [x for x in relevant_concepts if x in (nx.all_neighbors(g, n))]
         if actual_neighbors:
             relevent_datasets.append(n)
 
@@ -117,13 +107,7 @@ def create_pruned_concept_graph(
             if len(neighbors) > 1:
                 relevant_concepts.append(n)
             roots[root] = set()
-    g.remove_nodes_from(
-        [
-            n
-            for n in g.nodes()
-            if n not in relevent_datasets and n not in relevant_concepts
-        ]
-    )
+    g.remove_nodes_from([n for n in g.nodes() if n not in relevent_datasets and n not in relevant_concepts])
 
     subgraphs = list(nx.connected_components(g.to_undirected()))
     if not subgraphs:
@@ -139,23 +123,14 @@ def create_pruned_concept_graph(
     return g
 
 
-def resolve_subgraphs(
-    g: nx.DiGraph, conditions: WhereClause | None
-) -> dict[str, list[str]]:
+def resolve_subgraphs(g: nx.DiGraph, conditions: WhereClause | None) -> dict[str, list[str]]:
     datasources = [n for n in g.nodes if n.startswith("ds~")]
-    subgraphs: dict[str, list[str]] = {
-        ds: list(set(list(nx.all_neighbors(g, ds)))) for ds in datasources
-    }
+    subgraphs: dict[str, list[str]] = {ds: list(set(list(nx.all_neighbors(g, ds)))) for ds in datasources}
     partial_map = get_graph_partial_nodes(g, conditions)
     grain_length = get_graph_grain_length(g)
     concepts: dict[str, Concept] = nx.get_node_attributes(g, "concept")
-    non_partial_map = {
-        ds: [concepts[c].address for c in subgraphs[ds] if c not in partial_map[ds]]
-        for ds in datasources
-    }
-    concept_map = {
-        ds: [concepts[c].address for c in subgraphs[ds]] for ds in datasources
-    }
+    non_partial_map = {ds: [concepts[c].address for c in subgraphs[ds] if c not in partial_map[ds]] for ds in datasources}
+    concept_map = {ds: [concepts[c].address for c in subgraphs[ds]] for ds in datasources}
     pruned_subgraphs = {}
     for key, nodes in subgraphs.items():
         value = non_partial_map[key]
@@ -166,20 +141,12 @@ def resolve_subgraphs(
         for other_key, other_all_concepts in concept_map.items():
             other_value = non_partial_map[other_key]
             # needs to be a subset of non partial and a subset of all
-            if (
-                key != other_key
-                and set(value).issubset(set(other_value))
-                and set(all_concepts).issubset(set(other_all_concepts))
-            ):
+            if key != other_key and set(value).issubset(set(other_value)) and set(all_concepts).issubset(set(other_all_concepts)):
                 if len(value) < len(other_value):
                     is_subset = True
-                    logger.debug(
-                        f"Dropping subgraph {key} with {value} as it is a subset of {other_key} with {other_value}"
-                    )
+                    logger.debug(f"Dropping subgraph {key} with {value} as it is a subset of {other_key} with {other_value}")
                     break
-                elif len(value) == len(other_value) and len(all_concepts) == len(
-                    other_all_concepts
-                ):
+                elif len(value) == len(other_value) and len(all_concepts) == len(other_all_concepts):
                     matches.add(other_key)
                     matches.add(key)
         if matches:
@@ -199,15 +166,11 @@ def create_select_node(
     conditions: WhereClause | None = None,
 ) -> StrategyNode:
     ds_name = ds_name.split("~")[1]
-    all_concepts = [
-        environment.concepts[extract_address(c)] for c in subgraph if c.startswith("c~")
-    ]
+    all_concepts = [environment.concepts[extract_address(c)] for c in subgraph if c.startswith("c~")]
 
     all_lcl = LooseConceptList(concepts=all_concepts)
     if all([c.derivation == PurposeLineage.CONSTANT for c in all_concepts]):
-        logger.info(
-            f"{padding(depth)}{LOGGER_PREFIX} All concepts {[x.address for x in all_concepts]} are constants, returning constant node"
-        )
+        logger.info(f"{padding(depth)}{LOGGER_PREFIX} All concepts {[x.address for x in all_concepts]} are constants, returning constant node")
         return ConstantNode(
             output_concepts=all_concepts,
             input_concepts=[],
@@ -225,15 +188,9 @@ def create_select_node(
     force_group = False
     if not datasource.grain.issubset(target_grain):
         force_group = True
-    partial_concepts = [
-        c.concept
-        for c in datasource.columns
-        if not c.is_complete and c.concept in all_lcl
-    ]
+    partial_concepts = [c.concept for c in datasource.columns if not c.is_complete and c.concept in all_lcl]
     partial_lcl = LooseConceptList(concepts=partial_concepts)
-    nullable_concepts = [
-        c.concept for c in datasource.columns if c.is_nullable and c.concept in all_lcl
-    ]
+    nullable_concepts = [c.concept for c in datasource.columns if c.is_nullable and c.concept in all_lcl]
     nullable_lcl = LooseConceptList(concepts=nullable_concepts)
     partial_is_full = conditions and (conditions == datasource.non_partial_for)
     bcandidate: StrategyNode = SelectNode(
@@ -243,17 +200,13 @@ def create_select_node(
         g=g,
         parents=[],
         depth=depth,
-        partial_concepts=(
-            [] if partial_is_full else [c for c in all_concepts if c in partial_lcl]
-        ),
+        partial_concepts=([] if partial_is_full else [c for c in all_concepts if c in partial_lcl]),
         nullable_concepts=[c for c in all_concepts if c in nullable_lcl],
         accept_partial=accept_partial,
         datasource=datasource,
         grain=Grain(components=all_concepts),
         conditions=datasource.where.conditional if datasource.where else None,
-        preexisting_conditions=(
-            conditions.conditional if partial_is_full and conditions else None
-        ),
+        preexisting_conditions=(conditions.conditional if partial_is_full and conditions else None),
     )
 
     # we need to nest the group node one further
@@ -267,9 +220,7 @@ def create_select_node(
             depth=depth,
             partial_concepts=bcandidate.partial_concepts,
             nullable_concepts=bcandidate.nullable_concepts,
-            preexisting_conditions=(
-                conditions.conditional if partial_is_full and conditions else None
-            ),
+            preexisting_conditions=(conditions.conditional if partial_is_full and conditions else None),
         )
     else:
         candidate = bcandidate
@@ -298,19 +249,13 @@ def gen_select_merge_node(
             force_group=False,
         )
     for attempt in [False, True]:
-        pruned_concept_graph = create_pruned_concept_graph(
-            g, non_constant, attempt, conditions
-        )
+        pruned_concept_graph = create_pruned_concept_graph(g, non_constant, attempt, conditions)
         if pruned_concept_graph:
-            logger.info(
-                f"{padding(depth)}{LOGGER_PREFIX} found covering graph w/ partial flag {attempt}"
-            )
+            logger.info(f"{padding(depth)}{LOGGER_PREFIX} found covering graph w/ partial flag {attempt}")
             break
 
     if not pruned_concept_graph:
-        logger.info(
-            f"{padding(depth)}{LOGGER_PREFIX} no covering graph found {attempt}"
-        )
+        logger.info(f"{padding(depth)}{LOGGER_PREFIX} no covering graph found {attempt}")
         return None
 
     sub_nodes = resolve_subgraphs(pruned_concept_graph, conditions)
@@ -348,13 +293,7 @@ def gen_select_merge_node(
     if len(parents) == 1:
         return parents[0]
     preexisting_conditions = None
-    if conditions and all(
-        [
-            x.preexisting_conditions
-            and x.preexisting_conditions == conditions.conditional
-            for x in parents
-        ]
-    ):
+    if conditions and all([x.preexisting_conditions and x.preexisting_conditions == conditions.conditional for x in parents]):
         preexisting_conditions = conditions.conditional
     base = MergeNode(
         output_concepts=all_concepts,

--- a/trilogy/core/processing/node_generators/select_merge_node.py
+++ b/trilogy/core/processing/node_generators/select_merge_node.py
@@ -21,7 +21,6 @@ from trilogy.core.processing.nodes import (
     StrategyNode,
 )
 from trilogy.core.processing.utility import padding
-from trilogy.core.enums import PurposeLineage
 from trilogy.core.processing.nodes.base_node import (
     concept_list_to_grain,
 )

--- a/trilogy/core/processing/node_generators/select_merge_node.py
+++ b/trilogy/core/processing/node_generators/select_merge_node.py
@@ -20,10 +20,10 @@ from trilogy.core.processing.nodes import (
     SelectNode,
     StrategyNode,
 )
-from trilogy.core.processing.utility import padding
 from trilogy.core.processing.nodes.base_node import (
     concept_list_to_grain,
 )
+from trilogy.core.processing.utility import padding
 
 LOGGER_PREFIX = "[GEN_ROOT_MERGE_NODE]"
 

--- a/trilogy/core/processing/node_generators/select_merge_node.py
+++ b/trilogy/core/processing/node_generators/select_merge_node.py
@@ -33,7 +33,9 @@ def extract_address(node: str):
     return node.split("~")[1].split("@")[0]
 
 
-def get_graph_partial_nodes(g: nx.DiGraph, conditions: WhereClause | None) -> dict[str, list[str]]:
+def get_graph_partial_nodes(
+    g: nx.DiGraph, conditions: WhereClause | None
+) -> dict[str, list[str]]:
     datasources: dict[str, Datasource] = nx.get_node_attributes(g, "datasource")
     partial: dict[str, list[str]] = {}
     for node in g.nodes:
@@ -79,16 +81,26 @@ def create_pruned_concept_graph(
         partial = get_graph_partial_nodes(g, conditions)
         to_remove = []
         for edge in g.edges:
-            if edge[0] in datasources and (pnodes := partial.get(edge[0], [])) and edge[1] in pnodes:
+            if (
+                edge[0] in datasources
+                and (pnodes := partial.get(edge[0], []))
+                and edge[1] in pnodes
+            ):
                 to_remove.append(edge)
-            if edge[1] in datasources and (pnodes := partial.get(edge[1], [])) and edge[0] in pnodes:
+            if (
+                edge[1] in datasources
+                and (pnodes := partial.get(edge[1], []))
+                and edge[0] in pnodes
+            ):
                 to_remove.append(edge)
         for edge in to_remove:
             g.remove_edge(*edge)
     for n in g.nodes():
         if not n.startswith("ds~"):
             continue
-        actual_neighbors = [x for x in relevant_concepts if x in (nx.all_neighbors(g, n))]
+        actual_neighbors = [
+            x for x in relevant_concepts if x in (nx.all_neighbors(g, n))
+        ]
         if actual_neighbors:
             relevent_datasets.append(n)
 
@@ -107,7 +119,13 @@ def create_pruned_concept_graph(
             if len(neighbors) > 1:
                 relevant_concepts.append(n)
             roots[root] = set()
-    g.remove_nodes_from([n for n in g.nodes() if n not in relevent_datasets and n not in relevant_concepts])
+    g.remove_nodes_from(
+        [
+            n
+            for n in g.nodes()
+            if n not in relevent_datasets and n not in relevant_concepts
+        ]
+    )
 
     subgraphs = list(nx.connected_components(g.to_undirected()))
     if not subgraphs:
@@ -123,14 +141,23 @@ def create_pruned_concept_graph(
     return g
 
 
-def resolve_subgraphs(g: nx.DiGraph, conditions: WhereClause | None) -> dict[str, list[str]]:
+def resolve_subgraphs(
+    g: nx.DiGraph, conditions: WhereClause | None
+) -> dict[str, list[str]]:
     datasources = [n for n in g.nodes if n.startswith("ds~")]
-    subgraphs: dict[str, list[str]] = {ds: list(set(list(nx.all_neighbors(g, ds)))) for ds in datasources}
+    subgraphs: dict[str, list[str]] = {
+        ds: list(set(list(nx.all_neighbors(g, ds)))) for ds in datasources
+    }
     partial_map = get_graph_partial_nodes(g, conditions)
     grain_length = get_graph_grain_length(g)
     concepts: dict[str, Concept] = nx.get_node_attributes(g, "concept")
-    non_partial_map = {ds: [concepts[c].address for c in subgraphs[ds] if c not in partial_map[ds]] for ds in datasources}
-    concept_map = {ds: [concepts[c].address for c in subgraphs[ds]] for ds in datasources}
+    non_partial_map = {
+        ds: [concepts[c].address for c in subgraphs[ds] if c not in partial_map[ds]]
+        for ds in datasources
+    }
+    concept_map = {
+        ds: [concepts[c].address for c in subgraphs[ds]] for ds in datasources
+    }
     pruned_subgraphs = {}
     for key, nodes in subgraphs.items():
         value = non_partial_map[key]
@@ -141,12 +168,20 @@ def resolve_subgraphs(g: nx.DiGraph, conditions: WhereClause | None) -> dict[str
         for other_key, other_all_concepts in concept_map.items():
             other_value = non_partial_map[other_key]
             # needs to be a subset of non partial and a subset of all
-            if key != other_key and set(value).issubset(set(other_value)) and set(all_concepts).issubset(set(other_all_concepts)):
+            if (
+                key != other_key
+                and set(value).issubset(set(other_value))
+                and set(all_concepts).issubset(set(other_all_concepts))
+            ):
                 if len(value) < len(other_value):
                     is_subset = True
-                    logger.debug(f"Dropping subgraph {key} with {value} as it is a subset of {other_key} with {other_value}")
+                    logger.debug(
+                        f"Dropping subgraph {key} with {value} as it is a subset of {other_key} with {other_value}"
+                    )
                     break
-                elif len(value) == len(other_value) and len(all_concepts) == len(other_all_concepts):
+                elif len(value) == len(other_value) and len(all_concepts) == len(
+                    other_all_concepts
+                ):
                     matches.add(other_key)
                     matches.add(key)
         if matches:
@@ -166,11 +201,15 @@ def create_select_node(
     conditions: WhereClause | None = None,
 ) -> StrategyNode:
     ds_name = ds_name.split("~")[1]
-    all_concepts = [environment.concepts[extract_address(c)] for c in subgraph if c.startswith("c~")]
+    all_concepts = [
+        environment.concepts[extract_address(c)] for c in subgraph if c.startswith("c~")
+    ]
 
     all_lcl = LooseConceptList(concepts=all_concepts)
     if all([c.derivation == PurposeLineage.CONSTANT for c in all_concepts]):
-        logger.info(f"{padding(depth)}{LOGGER_PREFIX} All concepts {[x.address for x in all_concepts]} are constants, returning constant node")
+        logger.info(
+            f"{padding(depth)}{LOGGER_PREFIX} All concepts {[x.address for x in all_concepts]} are constants, returning constant node"
+        )
         return ConstantNode(
             output_concepts=all_concepts,
             input_concepts=[],
@@ -188,9 +227,15 @@ def create_select_node(
     force_group = False
     if not datasource.grain.issubset(target_grain):
         force_group = True
-    partial_concepts = [c.concept for c in datasource.columns if not c.is_complete and c.concept in all_lcl]
+    partial_concepts = [
+        c.concept
+        for c in datasource.columns
+        if not c.is_complete and c.concept in all_lcl
+    ]
     partial_lcl = LooseConceptList(concepts=partial_concepts)
-    nullable_concepts = [c.concept for c in datasource.columns if c.is_nullable and c.concept in all_lcl]
+    nullable_concepts = [
+        c.concept for c in datasource.columns if c.is_nullable and c.concept in all_lcl
+    ]
     nullable_lcl = LooseConceptList(concepts=nullable_concepts)
     partial_is_full = conditions and (conditions == datasource.non_partial_for)
     bcandidate: StrategyNode = SelectNode(
@@ -200,13 +245,17 @@ def create_select_node(
         g=g,
         parents=[],
         depth=depth,
-        partial_concepts=([] if partial_is_full else [c for c in all_concepts if c in partial_lcl]),
+        partial_concepts=(
+            [] if partial_is_full else [c for c in all_concepts if c in partial_lcl]
+        ),
         nullable_concepts=[c for c in all_concepts if c in nullable_lcl],
         accept_partial=accept_partial,
         datasource=datasource,
         grain=Grain(components=all_concepts),
         conditions=datasource.where.conditional if datasource.where else None,
-        preexisting_conditions=(conditions.conditional if partial_is_full and conditions else None),
+        preexisting_conditions=(
+            conditions.conditional if partial_is_full and conditions else None
+        ),
     )
 
     # we need to nest the group node one further
@@ -220,7 +269,9 @@ def create_select_node(
             depth=depth,
             partial_concepts=bcandidate.partial_concepts,
             nullable_concepts=bcandidate.nullable_concepts,
-            preexisting_conditions=(conditions.conditional if partial_is_full and conditions else None),
+            preexisting_conditions=(
+                conditions.conditional if partial_is_full and conditions else None
+            ),
         )
     else:
         candidate = bcandidate
@@ -249,13 +300,19 @@ def gen_select_merge_node(
             force_group=False,
         )
     for attempt in [False, True]:
-        pruned_concept_graph = create_pruned_concept_graph(g, non_constant, attempt, conditions)
+        pruned_concept_graph = create_pruned_concept_graph(
+            g, non_constant, attempt, conditions
+        )
         if pruned_concept_graph:
-            logger.info(f"{padding(depth)}{LOGGER_PREFIX} found covering graph w/ partial flag {attempt}")
+            logger.info(
+                f"{padding(depth)}{LOGGER_PREFIX} found covering graph w/ partial flag {attempt}"
+            )
             break
 
     if not pruned_concept_graph:
-        logger.info(f"{padding(depth)}{LOGGER_PREFIX} no covering graph found {attempt}")
+        logger.info(
+            f"{padding(depth)}{LOGGER_PREFIX} no covering graph found {attempt}"
+        )
         return None
 
     sub_nodes = resolve_subgraphs(pruned_concept_graph, conditions)
@@ -293,7 +350,13 @@ def gen_select_merge_node(
     if len(parents) == 1:
         return parents[0]
     preexisting_conditions = None
-    if conditions and all([x.preexisting_conditions and x.preexisting_conditions == conditions.conditional for x in parents]):
+    if conditions and all(
+        [
+            x.preexisting_conditions
+            and x.preexisting_conditions == conditions.conditional
+            for x in parents
+        ]
+    ):
         preexisting_conditions = conditions.conditional
     base = MergeNode(
         output_concepts=all_concepts,

--- a/trilogy/core/processing/node_generators/select_node.py
+++ b/trilogy/core/processing/node_generators/select_node.py
@@ -1,19 +1,19 @@
+from trilogy.constants import logger
 from trilogy.core.enums import PurposeLineage
+from trilogy.core.exceptions import NoDatasourceException
 from trilogy.core.models import (
     Concept,
     Environment,
     LooseConceptList,
     WhereClause,
 )
-from trilogy.core.processing.nodes import (
-    StrategyNode,
-)
-from trilogy.core.exceptions import NoDatasourceException
-from trilogy.constants import logger
-from trilogy.core.processing.utility import padding
 from trilogy.core.processing.node_generators.select_merge_node import (
     gen_select_merge_node,
 )
+from trilogy.core.processing.nodes import (
+    StrategyNode,
+)
+from trilogy.core.processing.utility import padding
 
 LOGGER_PREFIX = "[GEN_SELECT_NODE]"
 

--- a/trilogy/core/processing/node_generators/union_node.py
+++ b/trilogy/core/processing/node_generators/union_node.py
@@ -36,7 +36,10 @@ def gen_union_node(
     for arg in arguments:
         relevant_parents: list[Concept] = []
         for other_union in remaining:
-            potential_parents = [z for z in other_union.lineage.arguments if isinstance(z, Concept)]
+            assert other_union.lineage
+            potential_parents = [
+                z for z in other_union.lineage.arguments if isinstance(z, Concept)
+            ]
             relevant_parents += [
                 x for x in potential_parents if x.keys and arg.address in x.keys
             ]
@@ -64,11 +67,10 @@ def gen_union_node(
             )
             return None
 
-    base = UnionNode(
+    return UnionNode(
         input_concepts=[concept] + local_optional,
         output_concepts=[concept] + local_optional,
         environment=environment,
         g=g,
         parents=parents,
     )
-    return base

--- a/trilogy/core/processing/node_generators/union_node.py
+++ b/trilogy/core/processing/node_generators/union_node.py
@@ -1,11 +1,10 @@
 from typing import List
 
-
-from trilogy.core.models import Concept, Function, WhereClause
-from trilogy.core.processing.nodes import UnionNode, History, StrategyNode
-from trilogy.core.processing.utility import padding
-from trilogy.core.enums import FunctionType, Purpose
 from trilogy.constants import logger
+from trilogy.core.enums import FunctionType, Purpose
+from trilogy.core.models import Concept, Function, WhereClause
+from trilogy.core.processing.nodes import History, StrategyNode, UnionNode
+from trilogy.core.processing.utility import padding
 
 LOGGER_PREFIX = "[GEN_UNION_NODE]"
 
@@ -37,15 +36,9 @@ def gen_union_node(
         relevant_parents: list[Concept] = []
         for other_union in remaining:
             assert other_union.lineage
-            potential_parents = [
-                z for z in other_union.lineage.arguments if isinstance(z, Concept)
-            ]
-            relevant_parents += [
-                x for x in potential_parents if x.keys and arg.address in x.keys
-            ]
-        logger.info(
-            f"For parent arg {arg.address}, including additional union inputs {[c.address for c in relevant_parents]}"
-        )
+            potential_parents = [z for z in other_union.lineage.arguments if isinstance(z, Concept)]
+            relevant_parents += [x for x in potential_parents if x.keys and arg.address in x.keys]
+        logger.info(f"For parent arg {arg.address}, including additional union inputs {[c.address for c in relevant_parents]}")
         parent: StrategyNode = source_concepts(
             mandatory_list=[arg] + relevant_parents,
             environment=environment,
@@ -62,9 +55,7 @@ def gen_union_node(
 
         parents.append(parent)
         if not parent:
-            logger.info(
-                f"{padding(depth)}{LOGGER_PREFIX} could not find union node parents"
-            )
+            logger.info(f"{padding(depth)}{LOGGER_PREFIX} could not find union node parents")
             return None
 
     return UnionNode(

--- a/trilogy/core/processing/node_generators/union_node.py
+++ b/trilogy/core/processing/node_generators/union_node.py
@@ -36,9 +36,15 @@ def gen_union_node(
         relevant_parents: list[Concept] = []
         for other_union in remaining:
             assert other_union.lineage
-            potential_parents = [z for z in other_union.lineage.arguments if isinstance(z, Concept)]
-            relevant_parents += [x for x in potential_parents if x.keys and arg.address in x.keys]
-        logger.info(f"For parent arg {arg.address}, including additional union inputs {[c.address for c in relevant_parents]}")
+            potential_parents = [
+                z for z in other_union.lineage.arguments if isinstance(z, Concept)
+            ]
+            relevant_parents += [
+                x for x in potential_parents if x.keys and arg.address in x.keys
+            ]
+        logger.info(
+            f"For parent arg {arg.address}, including additional union inputs {[c.address for c in relevant_parents]}"
+        )
         parent: StrategyNode = source_concepts(
             mandatory_list=[arg] + relevant_parents,
             environment=environment,
@@ -55,7 +61,9 @@ def gen_union_node(
 
         parents.append(parent)
         if not parent:
-            logger.info(f"{padding(depth)}{LOGGER_PREFIX} could not find union node parents")
+            logger.info(
+                f"{padding(depth)}{LOGGER_PREFIX} could not find union node parents"
+            )
             return None
 
     return UnionNode(

--- a/trilogy/core/processing/node_generators/union_node.py
+++ b/trilogy/core/processing/node_generators/union_node.py
@@ -1,0 +1,74 @@
+from typing import List
+
+
+from trilogy.core.models import Concept, Function, WhereClause
+from trilogy.core.processing.nodes import UnionNode, History, StrategyNode
+from trilogy.core.processing.utility import padding
+from trilogy.core.enums import FunctionType, Purpose
+from trilogy.constants import logger
+
+LOGGER_PREFIX = "[GEN_UNION_NODE]"
+
+
+def is_union(c: Concept):
+    return isinstance(c.lineage, Function) and c.lineage.operator == FunctionType.UNION
+
+
+def gen_union_node(
+    concept: Concept,
+    local_optional: List[Concept],
+    environment,
+    g,
+    depth: int,
+    source_concepts,
+    history: History | None = None,
+    conditions: WhereClause | None = None,
+) -> StrategyNode | None:
+    all_unions = [x for x in local_optional if is_union(x)] + [concept]
+
+    parents = []
+    keys = [x for x in all_unions if x.purpose == Purpose.KEY]
+    base = keys.pop()
+    remaining = [x for x in all_unions if x.address != base.address]
+    arguments = []
+    if isinstance(base.lineage, Function):
+        arguments = base.lineage.concept_arguments
+    for arg in arguments:
+        relevant_parents: list[Concept] = []
+        for other_union in remaining:
+            potential_parents = [z for z in other_union.lineage.arguments if isinstance(z, Concept)]
+            relevant_parents += [
+                x for x in potential_parents if x.keys and arg.address in x.keys
+            ]
+        logger.info(
+            f"For parent arg {arg.address}, including additional union inputs {[c.address for c in relevant_parents]}"
+        )
+        parent: StrategyNode = source_concepts(
+            mandatory_list=[arg] + relevant_parents,
+            environment=environment,
+            g=g,
+            depth=depth + 1,
+            history=history,
+            conditions=conditions,
+        )
+        parent.hide_output_concepts(parent.output_concepts)
+        # parent.remove_output_concepts(parent.output_concepts)
+        parent.add_output_concept(concept)
+        for x in remaining:
+            parent.add_output_concept(x)
+
+        parents.append(parent)
+        if not parent:
+            logger.info(
+                f"{padding(depth)}{LOGGER_PREFIX} could not find union node parents"
+            )
+            return None
+
+    base = UnionNode(
+        input_concepts=[concept] + local_optional,
+        output_concepts=[concept] + local_optional,
+        environment=environment,
+        g=g,
+        parents=parents,
+    )
+    return base

--- a/trilogy/core/processing/node_generators/unnest_node.py
+++ b/trilogy/core/processing/node_generators/unnest_node.py
@@ -1,10 +1,9 @@
 from typing import List
 
-
-from trilogy.core.models import Concept, Function, WhereClause
-from trilogy.core.processing.nodes import UnnestNode, History, StrategyNode
-from trilogy.core.processing.utility import padding
 from trilogy.constants import logger
+from trilogy.core.models import Concept, Function, WhereClause
+from trilogy.core.processing.nodes import History, StrategyNode, UnnestNode
+from trilogy.core.processing.utility import padding
 
 LOGGER_PREFIX = "[GEN_UNNEST_NODE]"
 
@@ -24,9 +23,7 @@ def gen_unnest_node(
         arguments = concept.lineage.concept_arguments
 
     equivalent_optional = [x for x in local_optional if x.lineage == concept.lineage]
-    non_equivalent_optional = [
-        x for x in local_optional if x not in equivalent_optional
-    ]
+    non_equivalent_optional = [x for x in local_optional if x not in equivalent_optional]
     if arguments or local_optional:
         parent = source_concepts(
             mandatory_list=arguments + non_equivalent_optional,
@@ -37,9 +34,7 @@ def gen_unnest_node(
             conditions=conditions,
         )
         if not parent:
-            logger.info(
-                f"{padding(depth)}{LOGGER_PREFIX} could not find unnest node parents"
-            )
+            logger.info(f"{padding(depth)}{LOGGER_PREFIX} could not find unnest node parents")
             return None
 
     base = UnnestNode(

--- a/trilogy/core/processing/node_generators/unnest_node.py
+++ b/trilogy/core/processing/node_generators/unnest_node.py
@@ -23,7 +23,9 @@ def gen_unnest_node(
         arguments = concept.lineage.concept_arguments
 
     equivalent_optional = [x for x in local_optional if x.lineage == concept.lineage]
-    non_equivalent_optional = [x for x in local_optional if x not in equivalent_optional]
+    non_equivalent_optional = [
+        x for x in local_optional if x not in equivalent_optional
+    ]
     if arguments or local_optional:
         parent = source_concepts(
             mandatory_list=arguments + non_equivalent_optional,
@@ -34,7 +36,9 @@ def gen_unnest_node(
             conditions=conditions,
         )
         if not parent:
-            logger.info(f"{padding(depth)}{LOGGER_PREFIX} could not find unnest node parents")
+            logger.info(
+                f"{padding(depth)}{LOGGER_PREFIX} could not find unnest node parents"
+            )
             return None
 
     base = UnnestNode(

--- a/trilogy/core/processing/node_generators/window_node.py
+++ b/trilogy/core/processing/node_generators/window_node.py
@@ -1,11 +1,10 @@
 from typing import List
 
-
-from trilogy.core.models import Concept, WindowItem, Environment, WhereClause
-from trilogy.utility import unique
-from trilogy.core.processing.nodes import WindowNode, StrategyNode, History
 from trilogy.constants import logger
+from trilogy.core.models import Concept, Environment, WhereClause, WindowItem
+from trilogy.core.processing.nodes import History, StrategyNode, WindowNode
 from trilogy.core.processing.utility import padding
+from trilogy.utility import unique
 
 LOGGER_PREFIX = "[GEN_WINDOW_NODE]"
 
@@ -68,20 +67,9 @@ def gen_window_node(
         logger.info(f"{padding(depth)}{LOGGER_PREFIX} window node parents unresolvable")
         return None
     parent_node.resolve()
-    if not all(
-        [
-            x.address in [y.address for y in parent_node.output_concepts]
-            for x in parent_concepts
-        ]
-    ):
-        missing = [
-            x
-            for x in parent_concepts
-            if x.address not in [y.address for y in parent_node.output_concepts]
-        ]
-        logger.info(
-            f"{padding(depth)}{LOGGER_PREFIX} window node parents unresolvable, missing {missing}"
-        )
+    if not all([x.address in [y.address for y in parent_node.output_concepts] for x in parent_concepts]):
+        missing = [x for x in parent_concepts if x.address not in [y.address for y in parent_node.output_concepts]]
+        logger.info(f"{padding(depth)}{LOGGER_PREFIX} window node parents unresolvable, missing {missing}")
         raise SyntaxError
     _window_node = WindowNode(
         input_concepts=parent_concepts + targets + non_equivalent_optional,

--- a/trilogy/core/processing/node_generators/window_node.py
+++ b/trilogy/core/processing/node_generators/window_node.py
@@ -67,9 +67,20 @@ def gen_window_node(
         logger.info(f"{padding(depth)}{LOGGER_PREFIX} window node parents unresolvable")
         return None
     parent_node.resolve()
-    if not all([x.address in [y.address for y in parent_node.output_concepts] for x in parent_concepts]):
-        missing = [x for x in parent_concepts if x.address not in [y.address for y in parent_node.output_concepts]]
-        logger.info(f"{padding(depth)}{LOGGER_PREFIX} window node parents unresolvable, missing {missing}")
+    if not all(
+        [
+            x.address in [y.address for y in parent_node.output_concepts]
+            for x in parent_concepts
+        ]
+    ):
+        missing = [
+            x
+            for x in parent_concepts
+            if x.address not in [y.address for y in parent_node.output_concepts]
+        ]
+        logger.info(
+            f"{padding(depth)}{LOGGER_PREFIX} window node parents unresolvable, missing {missing}"
+        )
         raise SyntaxError
     _window_node = WindowNode(
         input_concepts=parent_concepts + targets + non_equivalent_optional,

--- a/trilogy/core/processing/nodes/README.md
+++ b/trilogy/core/processing/nodes/README.md
@@ -1,0 +1,28 @@
+# Nodes
+
+Nodes are the initial logical planning unit for a query path. 
+
+A query will initially resolve recursively to nodes, which are a lightweight operatoror representation.
+
+(Nodes will then later be instantiated as QueryDatasources/Datasources, a more complete intermediate representation,
+before finally becoming CTEs; a complete simplified object that is ready to be rendered as SQL).
+
+## Union Nodes
+
+Union nodes attempt to logically resolve union bindings.
+
+For a union concept:
+
+``` sql
+select
+    a,
+    b,
+    c,
+    union(a,b),
+    union(b,c),
+    a.prop,
+    b.prop,
+    c.prop
+```
+
+We 

--- a/trilogy/core/processing/nodes/__init__.py
+++ b/trilogy/core/processing/nodes/__init__.py
@@ -161,5 +161,6 @@ __all__ = [
     "NodeJoin",
     "ConstantNode",
     "UnnestNode",
+    "UnionNode",
     "History",
 ]

--- a/trilogy/core/processing/nodes/__init__.py
+++ b/trilogy/core/processing/nodes/__init__.py
@@ -25,7 +25,11 @@ class History(BaseModel):
         conditions: WhereClause | None = None,
     ) -> str:
         if conditions:
-            return "-".join([c.address for c in search]) + str(accept_partial) + str(conditions)
+            return (
+                "-".join([c.address for c in search])
+                + str(accept_partial)
+                + str(conditions)
+            )
         return "-".join([c.address for c in search]) + str(accept_partial)
 
     def search_to_history(
@@ -35,7 +39,9 @@ class History(BaseModel):
         output: StrategyNode | None,
         conditions: WhereClause | None = None,
     ):
-        self.history[self._concepts_to_lookup(search, accept_partial, conditions=conditions)] = output
+        self.history[
+            self._concepts_to_lookup(search, accept_partial, conditions=conditions)
+        ] = output
 
     def get_history(
         self,
@@ -50,7 +56,9 @@ class History(BaseModel):
             conditions,
         )
         if parent_key and parent_key == key:
-            raise ValueError(f"Parent key {parent_key} is the same as the current key {key}")
+            raise ValueError(
+                f"Parent key {parent_key} is the same as the current key {key}"
+            )
         if key in self.history:
             node = self.history[key]
             if node:
@@ -96,7 +104,15 @@ class History(BaseModel):
         accept_partial_optional: bool,
         conditions: WhereClause | None = None,
     ) -> str:
-        return str(main.address) + "|" + "-".join([c.address for c in search]) + str(accept_partial) + str(fail_if_not_found) + str(accept_partial_optional) + str(conditions)
+        return (
+            str(main.address)
+            + "|"
+            + "-".join([c.address for c in search])
+            + str(accept_partial)
+            + str(fail_if_not_found)
+            + str(accept_partial_optional)
+            + str(conditions)
+        )
 
     def gen_select_node(
         self,

--- a/trilogy/core/processing/nodes/__init__.py
+++ b/trilogy/core/processing/nodes/__init__.py
@@ -5,6 +5,7 @@ from .select_node_v2 import SelectNode, ConstantNode
 from .window_node import WindowNode
 from .base_node import StrategyNode, NodeJoin
 from .unnest_node import UnnestNode
+from .union_node import UnionNode
 from pydantic import BaseModel, Field, ConfigDict
 from trilogy.core.models import Concept, Environment, WhereClause
 

--- a/trilogy/core/processing/nodes/__init__.py
+++ b/trilogy/core/processing/nodes/__init__.py
@@ -1,13 +1,15 @@
+from pydantic import BaseModel, ConfigDict, Field
+
+from trilogy.core.models import Concept, Environment, WhereClause
+
+from .base_node import NodeJoin, StrategyNode
 from .filter_node import FilterNode
 from .group_node import GroupNode
 from .merge_node import MergeNode
-from .select_node_v2 import SelectNode, ConstantNode
-from .window_node import WindowNode
-from .base_node import StrategyNode, NodeJoin
-from .unnest_node import UnnestNode
+from .select_node_v2 import ConstantNode, SelectNode
 from .union_node import UnionNode
-from pydantic import BaseModel, Field, ConfigDict
-from trilogy.core.models import Concept, Environment, WhereClause
+from .unnest_node import UnnestNode
+from .window_node import WindowNode
 
 
 class History(BaseModel):
@@ -23,11 +25,7 @@ class History(BaseModel):
         conditions: WhereClause | None = None,
     ) -> str:
         if conditions:
-            return (
-                "-".join([c.address for c in search])
-                + str(accept_partial)
-                + str(conditions)
-            )
+            return "-".join([c.address for c in search]) + str(accept_partial) + str(conditions)
         return "-".join([c.address for c in search]) + str(accept_partial)
 
     def search_to_history(
@@ -37,9 +35,7 @@ class History(BaseModel):
         output: StrategyNode | None,
         conditions: WhereClause | None = None,
     ):
-        self.history[
-            self._concepts_to_lookup(search, accept_partial, conditions=conditions)
-        ] = output
+        self.history[self._concepts_to_lookup(search, accept_partial, conditions=conditions)] = output
 
     def get_history(
         self,
@@ -54,9 +50,7 @@ class History(BaseModel):
             conditions,
         )
         if parent_key and parent_key == key:
-            raise ValueError(
-                f"Parent key {parent_key} is the same as the current key {key}"
-            )
+            raise ValueError(f"Parent key {parent_key} is the same as the current key {key}")
         if key in self.history:
             node = self.history[key]
             if node:
@@ -102,15 +96,7 @@ class History(BaseModel):
         accept_partial_optional: bool,
         conditions: WhereClause | None = None,
     ) -> str:
-        return (
-            str(main.address)
-            + "|"
-            + "-".join([c.address for c in search])
-            + str(accept_partial)
-            + str(fail_if_not_found)
-            + str(accept_partial_optional)
-            + str(conditions)
-        )
+        return str(main.address) + "|" + "-".join([c.address for c in search]) + str(accept_partial) + str(fail_if_not_found) + str(accept_partial_optional) + str(conditions)
 
     def gen_select_node(
         self,

--- a/trilogy/core/processing/nodes/base_node.py
+++ b/trilogy/core/processing/nodes/base_node.py
@@ -1,40 +1,31 @@
-from typing import List, Optional, Sequence
 from collections import defaultdict
+from dataclasses import dataclass
+from typing import List, Optional, Sequence
 
+from trilogy.core.enums import BooleanOperator, Granularity, JoinType, Purpose, PurposeLineage
 from trilogy.core.models import (
+    Comparison,
+    Concept,
+    ConceptPair,
+    Conditional,
+    Datasource,
+    Environment,
     Grain,
+    LooseConceptList,
+    Parenthetical,
     QueryDatasource,
     SourceType,
-    Concept,
-    Environment,
-    Conditional,
     UnnestJoin,
-    Datasource,
-    Comparison,
-    Parenthetical,
-    LooseConceptList,
-    ConceptPair,
 )
-from trilogy.core.enums import Purpose, JoinType, PurposeLineage, Granularity
 from trilogy.utility import unique
-from dataclasses import dataclass
-from trilogy.core.enums import BooleanOperator
 
 
-def concept_list_to_grain(
-    inputs: List[Concept], parent_sources: Sequence[QueryDatasource | Datasource]
-) -> Grain:
-    candidates = [
-        c
-        for c in inputs
-        if c.purpose == Purpose.KEY and c.granularity != Granularity.SINGLE_ROW
-    ]
+def concept_list_to_grain(inputs: List[Concept], parent_sources: Sequence[QueryDatasource | Datasource]) -> Grain:
+    candidates = [c for c in inputs if c.purpose == Purpose.KEY and c.granularity != Granularity.SINGLE_ROW]
     for x in inputs:
         if x.granularity == Granularity.SINGLE_ROW:
             continue
-        if x.purpose == Purpose.PROPERTY and not any(
-            [key in candidates for key in (x.keys or [])]
-        ):
+        if x.purpose == Purpose.PROPERTY and not any([key in candidates for key in (x.keys or [])]):
             candidates.append(x)
         elif x.purpose == Purpose.CONSTANT:
             candidates.append(x)
@@ -53,21 +44,16 @@ def resolve_concept_map(
     full_joins: List[Concept] | None = None,
 ) -> dict[str, set[Datasource | QueryDatasource | UnnestJoin]]:
     targets = targets or []
-    concept_map: dict[str, set[Datasource | QueryDatasource | UnnestJoin]] = (
-        defaultdict(set)
-    )
+    concept_map: dict[str, set[Datasource | QueryDatasource | UnnestJoin]] = defaultdict(set)
     full_addresses = {c.address for c in full_joins} if full_joins else set()
     inherited = set([t.address for t in inherited_inputs])
     for input in inputs:
         for concept in input.output_concepts:
             if concept.address not in input.non_partial_concept_addresses:
                 continue
-            if isinstance(input, QueryDatasource) and concept.address in [
-                x.address for x in input.hidden_concepts
-            ]:
+            if isinstance(input, QueryDatasource) and concept.address in [x.address for x in input.hidden_concepts]:
                 continue
             if concept.address in full_addresses:
-
                 concept_map[concept.address].add(input)
             elif concept.address not in concept_map:
                 # equi_targets = [x for x in targets if concept.address in x.pseudonyms or x.address in concept.pseudonyms]
@@ -81,10 +67,7 @@ def resolve_concept_map(
         for concept in input.output_concepts:
             if concept.address not in [t for t in inherited_inputs]:
                 continue
-            if (
-                isinstance(input, QueryDatasource)
-                and concept.address in input.hidden_concepts
-            ):
+            if isinstance(input, QueryDatasource) and concept.address in input.hidden_concepts:
                 continue
             if len(concept_map.get(concept.address, [])) == 0:
                 concept_map[concept.address].add(input)
@@ -97,49 +80,20 @@ def resolve_concept_map(
     return concept_map
 
 
-def get_all_parent_partial(
-    all_concepts: List[Concept], parents: List["StrategyNode"]
-) -> List[Concept]:
+def get_all_parent_partial(all_concepts: List[Concept], parents: List["StrategyNode"]) -> List[Concept]:
     return unique(
         [
             c
             for c in all_concepts
-            if len(
-                [
-                    p
-                    for p in parents
-                    if c.address in [x.address for x in p.partial_concepts]
-                ]
-            )
-            >= 1
-            and all(
-                [
-                    c.address in p.partial_lcl
-                    for p in parents
-                    if c.address in p.output_lcl
-                ]
-            )
+            if len([p for p in parents if c.address in [x.address for x in p.partial_concepts]]) >= 1 and all([c.address in p.partial_lcl for p in parents if c.address in p.output_lcl])
         ],
         "address",
     )
 
 
-def get_all_parent_nullable(
-    all_concepts: List[Concept], parents: List["StrategyNode"]
-) -> List[Concept]:
+def get_all_parent_nullable(all_concepts: List[Concept], parents: List["StrategyNode"]) -> List[Concept]:
     return unique(
-        [
-            c
-            for c in all_concepts
-            if len(
-                [
-                    p
-                    for p in parents
-                    if c.address in [x.address for x in p.nullable_concepts]
-                ]
-            )
-            >= 1
-        ],
+        [c for c in all_concepts if len([p for p in parents if c.address in [x.address for x in p.nullable_concepts]]) >= 1],
         "address",
     )
 
@@ -166,9 +120,7 @@ class StrategyNode:
         existence_concepts: List[Concept] | None = None,
         virtual_output_concepts: List[Concept] | None = None,
     ):
-        self.input_concepts: List[Concept] = (
-            unique(input_concepts, "address") if input_concepts else []
-        )
+        self.input_concepts: List[Concept] = unique(input_concepts, "address") if input_concepts else []
         self.input_lcl = LooseConceptList(concepts=self.input_concepts)
         self.output_concepts: List[Concept] = unique(output_concepts, "address")
         self.output_lcl = LooseConceptList(concepts=self.output_concepts)
@@ -178,12 +130,8 @@ class StrategyNode:
         self.whole_grain = whole_grain
         self.parents = parents or []
         self.resolution_cache: Optional[QueryDatasource] = None
-        self.partial_concepts = partial_concepts or get_all_parent_partial(
-            self.output_concepts, self.parents
-        )
-        self.nullable_concepts = nullable_concepts or get_all_parent_nullable(
-            self.output_concepts, self.parents
-        )
+        self.partial_concepts = partial_concepts or get_all_parent_partial(self.output_concepts, self.parents)
+        self.nullable_concepts = nullable_concepts or get_all_parent_nullable(self.output_concepts, self.parents)
 
         self.depth = depth
         self.conditions = conditions
@@ -196,11 +144,7 @@ class StrategyNode:
         self.preexisting_conditions = preexisting_conditions
         if self.conditions and not self.preexisting_conditions:
             self.preexisting_conditions = self.conditions
-        elif (
-            self.conditions
-            and self.preexisting_conditions
-            and self.conditions != self.preexisting_conditions
-        ):
+        elif self.conditions and self.preexisting_conditions and self.conditions != self.preexisting_conditions:
             self.preexisting_conditions = Conditional(
                 left=self.conditions,
                 right=self.preexisting_conditions,
@@ -214,17 +158,13 @@ class StrategyNode:
         self.validate_parents()
         return self
 
-    def set_preexisting_conditions(
-        self, conditions: Conditional | Comparison | Parenthetical
-    ):
+    def set_preexisting_conditions(self, conditions: Conditional | Comparison | Parenthetical):
         self.preexisting_conditions = conditions
         return self
 
     def add_condition(self, condition: Conditional | Comparison | Parenthetical):
         if self.conditions:
-            self.conditions = Conditional(
-                left=self.conditions, right=condition, operator=BooleanOperator.AND
-            )
+            self.conditions = Conditional(left=self.conditions, right=condition, operator=BooleanOperator.AND)
         else:
             self.conditions = condition
         self.set_preexisting_conditions(condition)
@@ -240,9 +180,7 @@ class StrategyNode:
 
         # TODO: make this accurate
         if self.parents:
-            self.partial_concepts = get_all_parent_partial(
-                self.output_concepts, self.parents
-            )
+            self.partial_concepts = get_all_parent_partial(self.output_concepts, self.parents)
 
         self.partial_lcl = LooseConceptList(concepts=self.partial_concepts)
 
@@ -288,9 +226,7 @@ class StrategyNode:
         for x in concepts:
             self.hidden_concepts.append(x)
         addresses = [x.address for x in concepts]
-        self.output_concepts = [
-            x for x in self.output_concepts if x.address not in addresses
-        ]
+        self.output_concepts = [x for x in self.output_concepts if x.address not in addresses]
         if rebuild:
             self.rebuild_cache()
         return self
@@ -317,15 +253,9 @@ class StrategyNode:
         return f"{self.__class__.__name__}<{contents}>"
 
     def _resolve(self) -> QueryDatasource:
-        parent_sources: List[QueryDatasource | Datasource] = [
-            p.resolve() for p in self.parents
-        ]
+        parent_sources: List[QueryDatasource | Datasource] = [p.resolve() for p in self.parents]
 
-        grain = (
-            self.grain
-            if self.grain
-            else concept_list_to_grain(self.output_concepts, [])
-        )
+        grain = self.grain if self.grain else concept_list_to_grain(self.output_concepts, [])
         source_map = resolve_concept_map(
             parent_sources,
             targets=self.output_concepts,
@@ -403,19 +333,14 @@ class NodeJoin:
                     if self.filter_to_mutual:
                         include = False
                     else:
-                        raise SyntaxError(
-                            f"Invalid join, missing {concept} on {str(ds)}, have"
-                            f" {[c.address for c in ds.all_concepts]}"
-                        )
+                        raise SyntaxError(f"Invalid join, missing {concept} on {str(ds)}, have" f" {[c.address for c in ds.all_concepts]}")
             if include:
                 final_concepts.append(concept)
         if not final_concepts and self.concepts:
             # if one datasource only has constants
             # we can join on 1=1
             for ds in [self.left_node, self.right_node]:
-                if all(
-                    [c.derivation == PurposeLineage.CONSTANT for c in ds.all_concepts]
-                ):
+                if all([c.derivation == PurposeLineage.CONSTANT for c in ds.all_concepts]):
                     self.concepts = []
                     return
 
@@ -423,11 +348,7 @@ class NodeJoin:
             right_keys = [c.address for c in self.right_node.all_concepts]
             match_concepts = [c.address for c in self.concepts]
             raise SyntaxError(
-                "No mutual join keys found between"
-                f" {self.left_node} and"
-                f" {self.right_node}, left_keys {left_keys},"
-                f" right_keys {right_keys},"
-                f" provided join concepts {match_concepts}"
+                "No mutual join keys found between" f" {self.left_node} and" f" {self.right_node}, left_keys {left_keys}," f" right_keys {right_keys}," f" provided join concepts {match_concepts}"
             )
         self.concepts = final_concepts
 
@@ -437,8 +358,4 @@ class NodeJoin:
         return str(nodes) + self.join_type.value
 
     def __str__(self):
-        return (
-            f"{self.join_type.value} JOIN {self.left_node} and"
-            f" {self.right_node} on"
-            f" {','.join([str(k) for k in self.concepts])}"
-        )
+        return f"{self.join_type.value} JOIN {self.left_node} and" f" {self.right_node} on" f" {','.join([str(k) for k in self.concepts])}"

--- a/trilogy/core/processing/nodes/filter_node.py
+++ b/trilogy/core/processing/nodes/filter_node.py
@@ -1,13 +1,12 @@
 from typing import List
 
-
 from trilogy.core.models import (
-    SourceType,
+    Comparison,
     Concept,
     Conditional,
-    Comparison,
-    Parenthetical,
     Grain,
+    Parenthetical,
+    SourceType,
 )
 from trilogy.core.processing.nodes.base_node import StrategyNode
 

--- a/trilogy/core/processing/nodes/group_node.py
+++ b/trilogy/core/processing/nodes/group_node.py
@@ -62,7 +62,9 @@ class GroupNode(StrategyNode):
         )
 
     def _resolve(self) -> QueryDatasource:
-        parent_sources: List[QueryDatasource | Datasource] = [p.resolve() for p in self.parents]
+        parent_sources: List[QueryDatasource | Datasource] = [
+            p.resolve() for p in self.parents
+        ]
 
         grain = self.grain or concept_list_to_grain(self.output_concepts, [])
         comp_grain = Grain()
@@ -74,9 +76,18 @@ class GroupNode(StrategyNode):
         if comp_grain == grain and self.force_group is not True:
             # if there is no group by, and inputs equal outputs
             # return the parent
-            logger.info(f"{self.logging_prefix}{LOGGER_PREFIX} Grain of group by equals output" f" grains {comp_grain} and {grain}")
-            if (len(parent_sources) == 1 and LooseConceptList(concepts=parent_sources[0].output_concepts) == self.output_lcl) and isinstance(parent_sources[0], QueryDatasource):
-                logger.info(f"{self.logging_prefix}{LOGGER_PREFIX} No group by required as inputs match outputs of parent; returning parent node")
+            logger.info(
+                f"{self.logging_prefix}{LOGGER_PREFIX} Grain of group by equals output"
+                f" grains {comp_grain} and {grain}"
+            )
+            if (
+                len(parent_sources) == 1
+                and LooseConceptList(concepts=parent_sources[0].output_concepts)
+                == self.output_lcl
+            ) and isinstance(parent_sources[0], QueryDatasource):
+                logger.info(
+                    f"{self.logging_prefix}{LOGGER_PREFIX} No group by required as inputs match outputs of parent; returning parent node"
+                )
                 will_return: QueryDatasource = parent_sources[0]
                 if self.conditions:
                     will_return.condition = self.conditions + will_return.condition
@@ -112,8 +123,12 @@ class GroupNode(StrategyNode):
             ),
             inherited_inputs=self.input_concepts + self.existence_concepts,
         )
-        nullable_addresses = find_nullable_concepts(source_map=source_map, joins=[], datasources=parent_sources)
-        nullable_concepts = [x for x in self.output_concepts if x.address in nullable_addresses]
+        nullable_addresses = find_nullable_concepts(
+            source_map=source_map, joins=[], datasources=parent_sources
+        )
+        nullable_concepts = [
+            x for x in self.output_concepts if x.address in nullable_addresses
+        ]
         base = QueryDatasource(
             input_concepts=self.input_concepts,
             output_concepts=self.output_concepts,

--- a/trilogy/core/processing/nodes/merge_node.py
+++ b/trilogy/core/processing/nodes/merge_node.py
@@ -1,28 +1,27 @@
 from typing import List, Optional, Tuple
 
-
 from trilogy.constants import logger
 from trilogy.core.models import (
     BaseJoin,
+    Comparison,
+    Concept,
+    Conditional,
+    Datasource,
+    Environment,
     Grain,
     JoinType,
-    QueryDatasource,
-    Datasource,
-    SourceType,
-    Concept,
-    UnnestJoin,
-    Conditional,
-    Comparison,
     Parenthetical,
-    Environment,
+    QueryDatasource,
+    SourceType,
+    UnnestJoin,
 )
-from trilogy.utility import unique
 from trilogy.core.processing.nodes.base_node import (
+    NodeJoin,
     StrategyNode,
     resolve_concept_map,
-    NodeJoin,
 )
-from trilogy.core.processing.utility import get_node_joins, find_nullable_concepts
+from trilogy.core.processing.utility import find_nullable_concepts, get_node_joins
+from trilogy.utility import unique
 
 LOGGER_PREFIX = "[CONCEPT DETAIL - MERGE NODE]"
 
@@ -36,11 +35,7 @@ def deduplicate_nodes(
     removed: set[str] = set()
     set_map: dict[str, set[str]] = {}
     for k, v in merged.items():
-        unique_outputs = [
-            environment.concepts[x.address].address
-            for x in v.output_concepts
-            if x not in v.partial_concepts
-        ]
+        unique_outputs = [environment.concepts[x.address].address for x in v.output_concepts if x not in v.partial_concepts]
         set_map[k] = set(unique_outputs)
     for k1, v1 in set_map.items():
         found = False
@@ -57,9 +52,7 @@ def deduplicate_nodes(
             ):
                 og = merged[k1]
                 subset_to = merged[k2]
-                logger.info(
-                    f"{logging_prefix}{LOGGER_PREFIX} extraneous parent node that is subset of another parent node {og.grain.issubset(subset_to.grain)} {og.grain.set} {subset_to.grain.set}"
-                )
+                logger.info(f"{logging_prefix}{LOGGER_PREFIX} extraneous parent node that is subset of another parent node {og.grain.issubset(subset_to.grain)} {og.grain.set} {subset_to.grain.set}")
                 merged = {k: v for k, v in merged.items() if k != k1}
                 removed.add(k1)
                 duplicates = True
@@ -81,17 +74,10 @@ def deduplicate_nodes_and_joins(
     duplicates = True
     while duplicates:
         duplicates = False
-        duplicates, merged, removed = deduplicate_nodes(
-            merged, logging_prefix, environment=environment
-        )
+        duplicates, merged, removed = deduplicate_nodes(merged, logging_prefix, environment=environment)
         # filter out any removed joins
         if joins is not None:
-            joins = [
-                j
-                for j in joins
-                if j.left_node.resolve().identifier not in removed
-                and j.right_node.resolve().identifier not in removed
-            ]
+            joins = [j for j in joins if j.left_node.resolve().identifier not in removed and j.right_node.resolve().identifier not in removed]
     return joins, merged
 
 
@@ -198,33 +184,21 @@ class MergeNode(StrategyNode):
         environment: Environment,
     ) -> List[BaseJoin | UnnestJoin]:
         # only finally, join between them for unique values
-        dataset_list: List[QueryDatasource | Datasource] = sorted(
-            final_datasets, key=lambda x: -len(x.grain.components_copy)
-        )
+        dataset_list: List[QueryDatasource | Datasource] = sorted(final_datasets, key=lambda x: -len(x.grain.components_copy))
 
-        logger.info(
-            f"{self.logging_prefix}{LOGGER_PREFIX} Merge node has {len(dataset_list)} parents, starting merge"
-        )
+        logger.info(f"{self.logging_prefix}{LOGGER_PREFIX} Merge node has {len(dataset_list)} parents, starting merge")
         if final_joins is None:
             if not pregrain.components:
-                logger.info(
-                    f"{self.logging_prefix}{LOGGER_PREFIX} no grain components, doing full join"
-                )
+                logger.info(f"{self.logging_prefix}{LOGGER_PREFIX} no grain components, doing full join")
                 joins = self.create_full_joins(dataset_list)
             else:
-                logger.info(
-                    f"{self.logging_prefix}{LOGGER_PREFIX} inferring node joins to target grain {str(grain)}"
-                )
+                logger.info(f"{self.logging_prefix}{LOGGER_PREFIX} inferring node joins to target grain {str(grain)}")
                 joins = get_node_joins(dataset_list, environment=environment)
         elif final_joins:
-            logger.info(
-                f"{self.logging_prefix}{LOGGER_PREFIX} translating provided node joins {len(final_joins)}"
-            )
+            logger.info(f"{self.logging_prefix}{LOGGER_PREFIX} translating provided node joins {len(final_joins)}")
             joins = self.translate_node_joins(final_joins)
         else:
-            logger.info(
-                f"{self.logging_prefix}{LOGGER_PREFIX} Final joins is not null {final_joins} but is empty, skipping join generation"
-            )
+            logger.info(f"{self.logging_prefix}{LOGGER_PREFIX} Final joins is not null {final_joins} but is empty, skipping join generation")
             return []
 
         for join in joins:
@@ -232,60 +206,32 @@ class MergeNode(StrategyNode):
         return joins
 
     def _resolve(self) -> QueryDatasource:
-        parent_sources: List[QueryDatasource | Datasource] = [
-            p.resolve() for p in self.parents
-        ]
+        parent_sources: List[QueryDatasource | Datasource] = [p.resolve() for p in self.parents]
         merged: dict[str, QueryDatasource | Datasource] = {}
         final_joins: List[NodeJoin] | None = self.node_joins
         for source in parent_sources:
             if source.identifier in merged:
-                logger.info(
-                    f"{self.logging_prefix}{LOGGER_PREFIX} merging parent node with {source.identifier} into existing"
-                )
+                logger.info(f"{self.logging_prefix}{LOGGER_PREFIX} merging parent node with {source.identifier} into existing")
                 merged[source.identifier] = merged[source.identifier] + source
             else:
                 merged[source.identifier] = source
 
         # it's possible that we have more sources than we need
-        final_joins, merged = deduplicate_nodes_and_joins(
-            final_joins, merged, self.logging_prefix, self.environment
-        )
+        final_joins, merged = deduplicate_nodes_and_joins(final_joins, merged, self.logging_prefix, self.environment)
         # early exit if we can just return the parent
         final_datasets: List[QueryDatasource | Datasource] = list(merged.values())
 
-        existence_final = [
-            x
-            for x in final_datasets
-            if all([y in self.existence_concepts for y in x.output_concepts])
-        ]
+        existence_final = [x for x in final_datasets if all([y in self.existence_concepts for y in x.output_concepts])]
         if len(merged.keys()) == 1:
             final: QueryDatasource | Datasource = list(merged.values())[0]
-            if (
-                set([c.address for c in final.output_concepts])
-                == set([c.address for c in self.output_concepts])
-                and not self.conditions
-                and isinstance(final, QueryDatasource)
-            ):
-                logger.info(
-                    f"{self.logging_prefix}{LOGGER_PREFIX} Merge node has only one parent with the same"
-                    " outputs as this merge node, dropping merge node "
-                )
+            if set([c.address for c in final.output_concepts]) == set([c.address for c in self.output_concepts]) and not self.conditions and isinstance(final, QueryDatasource):
+                logger.info(f"{self.logging_prefix}{LOGGER_PREFIX} Merge node has only one parent with the same" " outputs as this merge node, dropping merge node ")
                 return final
 
         # if we have multiple candidates, see if one is good enough
         for dataset in final_datasets:
-            output_set = set(
-                [
-                    c.address
-                    for c in dataset.output_concepts
-                    if c.address not in [x.address for x in dataset.partial_concepts]
-                ]
-            )
-            if (
-                all([c.address in output_set for c in self.all_concepts])
-                and not self.conditions
-                and isinstance(dataset, QueryDatasource)
-            ):
+            output_set = set([c.address for c in dataset.output_concepts if c.address not in [x.address for x in dataset.partial_concepts]])
+            if all([c.address in output_set for c in self.all_concepts]) and not self.conditions and isinstance(dataset, QueryDatasource):
                 logger.info(
                     f"{self.logging_prefix}{LOGGER_PREFIX} Merge node not required as parent node {dataset.source_type}"
                     f" has all required output properties with partial {[c.address for c in dataset.partial_concepts]}"
@@ -298,19 +244,13 @@ class MergeNode(StrategyNode):
             pregrain += source.grain
 
         grain = self.grain if self.grain else pregrain
-        logger.info(
-            f"{self.logging_prefix}{LOGGER_PREFIX} has pre grain {pregrain} and final merge node grain {grain}"
-        )
+        logger.info(f"{self.logging_prefix}{LOGGER_PREFIX} has pre grain {pregrain} and final merge node grain {grain}")
         join_candidates = [x for x in final_datasets if x not in existence_final]
         if len(join_candidates) > 1:
-            joins: List[BaseJoin | UnnestJoin] = self.generate_joins(
-                join_candidates, final_joins, pregrain, grain, self.environment
-            )
+            joins: List[BaseJoin | UnnestJoin] = self.generate_joins(join_candidates, final_joins, pregrain, grain, self.environment)
         else:
             joins = []
-        logger.info(
-            f"{self.logging_prefix}{LOGGER_PREFIX} Final join count for CTE parent count {len(join_candidates)} is {len(joins)}"
-        )
+        logger.info(f"{self.logging_prefix}{LOGGER_PREFIX} Final join count for CTE parent count {len(join_candidates)} is {len(joins)}")
         full_join_concepts = []
         for join in joins:
             if isinstance(join, BaseJoin) and join.join_type == JoinType.FULL:
@@ -319,9 +259,7 @@ class MergeNode(StrategyNode):
             force_group = False
         elif self.force_group is False:
             force_group = False
-        elif not any(
-            [d.grain.issubset(grain) for d in final_datasets]
-        ) and not pregrain.issubset(grain):
+        elif not any([d.grain.issubset(grain) for d in final_datasets]) and not pregrain.issubset(grain):
             logger.info(
                 f"{self.logging_prefix}{LOGGER_PREFIX} no parents include full grain {grain} and pregrain {pregrain} does not match, assume must group to grain. Have {[str(d.grain) for d in final_datasets]}"
             )
@@ -336,9 +274,7 @@ class MergeNode(StrategyNode):
             inherited_inputs=self.input_concepts + self.existence_concepts,
             full_joins=full_join_concepts,
         )
-        nullable_concepts = find_nullable_concepts(
-            source_map=source_map, joins=joins, datasources=final_datasets
-        )
+        nullable_concepts = find_nullable_concepts(source_map=source_map, joins=joins, datasources=final_datasets)
         qds = QueryDatasource(
             input_concepts=unique(self.input_concepts, "address"),
             output_concepts=unique(self.output_concepts, "address"),
@@ -347,9 +283,7 @@ class MergeNode(StrategyNode):
             source_map=source_map,
             joins=qd_joins,
             grain=grain,
-            nullable_concepts=[
-                x for x in self.output_concepts if x.address in nullable_concepts
-            ],
+            nullable_concepts=[x for x in self.output_concepts if x.address in nullable_concepts],
             partial_concepts=self.partial_concepts,
             force_group=force_group,
             condition=self.conditions,

--- a/trilogy/core/processing/nodes/select_node_v2.py
+++ b/trilogy/core/processing/nodes/select_node_v2.py
@@ -98,6 +98,7 @@ class SelectNode(StrategyNode):
                 PurposeLineage.BASIC,
                 PurposeLineage.ROWSET,
                 PurposeLineage.BASIC,
+                PurposeLineage.UNION,
             ):
                 source_map[x.address] = set()
 

--- a/trilogy/core/processing/nodes/union_node.py
+++ b/trilogy/core/processing/nodes/union_node.py
@@ -1,10 +1,9 @@
 from typing import List
 
-
 from trilogy.core.models import (
+    Concept,
     QueryDatasource,
     SourceType,
-    Concept,
 )
 from trilogy.core.processing.nodes.base_node import StrategyNode
 

--- a/trilogy/core/processing/nodes/union_node.py
+++ b/trilogy/core/processing/nodes/union_node.py
@@ -1,0 +1,51 @@
+from typing import List
+
+
+from trilogy.core.models import (
+    QueryDatasource,
+    SourceType,
+    Concept,
+)
+from trilogy.core.processing.nodes.base_node import StrategyNode
+
+
+class UnionNode(StrategyNode):
+    """Union nodes represent combining two keyspaces"""
+
+    source_type = SourceType.UNION
+
+    def __init__(
+        self,
+        input_concepts: List[Concept],
+        output_concepts: List[Concept],
+        environment,
+        g,
+        whole_grain: bool = False,
+        parents: List["StrategyNode"] | None = None,
+        depth: int = 0,
+    ):
+        super().__init__(
+            input_concepts=input_concepts,
+            output_concepts=output_concepts,
+            environment=environment,
+            g=g,
+            whole_grain=whole_grain,
+            parents=parents,
+            depth=depth,
+        )
+
+    def _resolve(self) -> QueryDatasource:
+        """We need to ensure that any filtered values are removed from the output to avoid inappropriate references"""
+        base = super()._resolve()
+        return base
+
+    def copy(self) -> "UnionNode":
+        return UnionNode(
+            input_concepts=list(self.input_concepts),
+            output_concepts=list(self.output_concepts),
+            environment=self.environment,
+            g=self.g,
+            whole_grain=self.whole_grain,
+            parents=self.parents,
+            depth=self.depth,
+        )

--- a/trilogy/core/processing/nodes/unnest_node.py
+++ b/trilogy/core/processing/nodes/unnest_node.py
@@ -1,12 +1,11 @@
 from typing import List
 
-
 from trilogy.core.models import (
+    Concept,
+    Function,
     QueryDatasource,
     SourceType,
-    Concept,
     UnnestJoin,
-    Function,
 )
 from trilogy.core.processing.nodes.base_node import StrategyNode
 

--- a/trilogy/core/processing/nodes/window_node.py
+++ b/trilogy/core/processing/nodes/window_node.py
@@ -1,8 +1,7 @@
 from typing import List
 
-
-from trilogy.core.models import SourceType, Concept
-from trilogy.core.processing.nodes.base_node import StrategyNode, QueryDatasource
+from trilogy.core.models import Concept, SourceType
+from trilogy.core.processing.nodes.base_node import QueryDatasource, StrategyNode
 
 
 class WindowNode(StrategyNode):

--- a/trilogy/core/processing/utility.py
+++ b/trilogy/core/processing/utility.py
@@ -33,6 +33,7 @@ from trilogy.core.models import (
     MultiSelectStatement,
     SelectStatement,
     ProcessedQuery,
+    UnionCTE,
 )
 
 from trilogy.core.enums import Purpose, Granularity, BooleanOperator
@@ -552,7 +553,7 @@ def sort_select_output_processed(cte: CTE, query: ProcessedQuery) -> CTE:
 
 
 def sort_select_output(
-    cte: CTE, query: SelectStatement | MultiSelectStatement | ProcessedQuery
+    cte: CTE | UnionCTE, query: SelectStatement | MultiSelectStatement | ProcessedQuery
 ) -> CTE:
     if isinstance(query, ProcessedQuery):
         return sort_select_output_processed(cte, query)

--- a/trilogy/core/processing/utility.py
+++ b/trilogy/core/processing/utility.py
@@ -61,12 +61,17 @@ class JoinOrderOutput:
         return set(self.keys.keys())
 
 
-def resolve_join_order_v2(g: nx.Graph, partials: dict[str, list[str]]) -> list[JoinOrderOutput]:
+def resolve_join_order_v2(
+    g: nx.Graph, partials: dict[str, list[str]]
+) -> list[JoinOrderOutput]:
     datasources = [x for x in g.nodes if x.startswith("ds~")]
     concepts = [x for x in g.nodes if x.startswith("c~")]
 
     output: list[JoinOrderOutput] = []
-    pivot_map = {concept: [x for x in g.neighbors(concept) if x in datasources] for concept in concepts}
+    pivot_map = {
+        concept: [x for x in g.neighbors(concept) if x in datasources]
+        for concept in concepts
+    }
     pivots = list(
         sorted(
             [x for x in pivot_map if len(pivot_map[x]) > 1],
@@ -77,7 +82,9 @@ def resolve_join_order_v2(g: nx.Graph, partials: dict[str, list[str]]) -> list[J
     eligible_left = set()
 
     while pivots:
-        next_pivots = [x for x in pivots if any(y in eligible_left for y in pivot_map[x])]
+        next_pivots = [
+            x for x in pivots if any(y in eligible_left for y in pivot_map[x])
+        ]
         if next_pivots:
             root = next_pivots[0]
             pivots = [x for x in pivots if x != root]
@@ -96,10 +103,14 @@ def resolve_join_order_v2(g: nx.Graph, partials: dict[str, list[str]]) -> list[J
             return (base, len(x), x)
 
         # get remainig un-joined datasets
-        to_join = sorted([x for x in pivot_map[root] if x not in eligible_left], key=score_key)
+        to_join = sorted(
+            [x for x in pivot_map[root] if x not in eligible_left], key=score_key
+        )
         while to_join:
             # need to sort this to ensure we join on the best match
-            base = sorted([x for x in pivot_map[root] if x in eligible_left], key=score_key)
+            base = sorted(
+                [x for x in pivot_map[root] if x in eligible_left], key=score_key
+            )
             if not base:
                 new = to_join.pop()
                 eligible_left.add(new)
@@ -124,11 +135,15 @@ def resolve_join_order_v2(g: nx.Graph, partials: dict[str, list[str]]) -> list[J
                         exists = True
                 if exists:
                     continue
-                left_is_partial = any(key in partials.get(left_candidate, []) for key in common)
+                left_is_partial = any(
+                    key in partials.get(left_candidate, []) for key in common
+                )
                 right_is_partial = any(key in partials.get(right, []) for key in common)
                 # we don't care if left is nullable for join type (just keys), but if we did
                 # ex: left_is_nullable = any(key in partials.get(left_candidate, [])
-                right_is_nullable = any(key in partials.get(right, []) for key in common)
+                right_is_nullable = any(
+                    key in partials.get(right, []) for key in common
+                )
                 if left_is_partial:
                     join_type = JoinType.FULL
                 elif right_is_partial or right_is_nullable:
@@ -181,14 +196,24 @@ def resolve_join_order_v2(g: nx.Graph, partials: dict[str, list[str]]) -> list[J
     for review_join in output:
         if review_join.type in (JoinType.LEFT_OUTER, JoinType.FULL):
             continue
-        if any([join.right in review_join.lefts for join in output if join.type in (JoinType.LEFT_OUTER, JoinType.FULL)]):
+        if any(
+            [
+                join.right in review_join.lefts
+                for join in output
+                if join.type in (JoinType.LEFT_OUTER, JoinType.FULL)
+            ]
+        ):
             review_join.type = JoinType.LEFT_OUTER
     return output
 
 
 def concept_to_relevant_joins(concepts: list[Concept]) -> List[Concept]:
     addresses = LooseConceptList(concepts=concepts)
-    sub_props = LooseConceptList(concepts=[x for x in concepts if x.keys and all([key in addresses for key in x.keys])])
+    sub_props = LooseConceptList(
+        concepts=[
+            x for x in concepts if x.keys and all([key in addresses for key in x.keys])
+        ]
+    )
     final = [c for c in concepts if c not in sub_props]
     return unique(final, "address")
 
@@ -206,7 +231,9 @@ def create_log_lambda(prefix: str, depth: int, logger: Logger):
     return log_lambda
 
 
-def calculate_graph_relevance(g: nx.DiGraph, subset_nodes: set[str], concepts: set[Concept]) -> int:
+def calculate_graph_relevance(
+    g: nx.DiGraph, subset_nodes: set[str], concepts: set[Concept]
+) -> int:
     """Calculate the relevance of each node in a graph
     Relevance is used to prune irrelevant nodes from the graph
     """
@@ -250,7 +277,9 @@ def add_node_join_concept(
     graph.add_edge(ds_node, name)
     concept_map[name] = concept
     for v_address in concept.pseudonyms:
-        v = environment.alias_origin_lookup.get(v_address, environment.concepts[v_address])
+        v = environment.alias_origin_lookup.get(
+            v_address, environment.concepts[v_address]
+        )
         if f"c~{v.address}" in graph.nodes:
             continue
         if v != concept.address:
@@ -263,13 +292,17 @@ def add_node_join_concept(
             )
 
 
-def resolve_instantiated_concept(concept: Concept, datasource: QueryDatasource | Datasource) -> Concept:
+def resolve_instantiated_concept(
+    concept: Concept, datasource: QueryDatasource | Datasource
+) -> Concept:
     if concept.address in datasource.output_concepts:
         return concept
     for k in concept.pseudonyms:
         if k in datasource.output_concepts:
             return [x for x in datasource.output_concepts if x.address == k].pop()
-    raise SyntaxError(f"Could not find {concept.address} in {datasource.identifier} output {[c.address for c in datasource.output_concepts]}")
+    raise SyntaxError(
+        f"Could not find {concept.address} in {datasource.identifier} output {[c.address for c in datasource.output_concepts]}"
+    )
 
 
 def get_node_joins(
@@ -305,8 +338,12 @@ def get_node_joins(
             concepts=[] if not j.keys else None,
             concept_pairs=[
                 ConceptPair(
-                    left=resolve_instantiated_concept(concept_map[concept], ds_node_map[k]),
-                    right=resolve_instantiated_concept(concept_map[concept], ds_node_map[j.right]),
+                    left=resolve_instantiated_concept(
+                        concept_map[concept], ds_node_map[k]
+                    ),
+                    right=resolve_instantiated_concept(
+                        concept_map[concept], ds_node_map[j.right]
+                    ),
                     existing_datasource=ds_node_map[k],
                 )
                 for k, v in j.keys.items()
@@ -317,7 +354,9 @@ def get_node_joins(
     ]
 
 
-def get_disconnected_components(concept_map: Dict[str, Set[Concept]]) -> Tuple[int, List]:
+def get_disconnected_components(
+    concept_map: Dict[str, Set[Concept]]
+) -> Tuple[int, List]:
     """Find if any of the datasources are not linked"""
     import networkx as nx
 
@@ -330,7 +369,9 @@ def get_disconnected_components(concept_map: Dict[str, Set[Concept]]) -> Tuple[i
             graph.add_edge(datasource, concept.address)
             all_concepts.add(concept)
     sub_graphs = list(nx.connected_components(graph))
-    sub_graphs = [x for x in sub_graphs if calculate_graph_relevance(graph, x, all_concepts) > 0]
+    sub_graphs = [
+        x for x in sub_graphs if calculate_graph_relevance(graph, x, all_concepts) > 0
+    ]
     return len(sub_graphs), sub_graphs
 
 
@@ -367,7 +408,9 @@ def is_scalar_condition(
     elif isinstance(element, SubselectComparison):
         return True
     elif isinstance(element, Comparison):
-        return is_scalar_condition(element.left, materialized) and is_scalar_condition(element.right, materialized)
+        return is_scalar_condition(element.left, materialized) and is_scalar_condition(
+            element.right, materialized
+        )
     elif isinstance(element, Function):
         if element.operator in FunctionClass.AGGREGATE_FUNCTIONS.value:
             return False
@@ -383,9 +426,13 @@ def is_scalar_condition(
     elif isinstance(element, AggregateWrapper):
         return is_scalar_condition(element.function, materialized)
     elif isinstance(element, Conditional):
-        return is_scalar_condition(element.left, materialized) and is_scalar_condition(element.right, materialized)
+        return is_scalar_condition(element.left, materialized) and is_scalar_condition(
+            element.right, materialized
+        )
     elif isinstance(element, CaseWhen):
-        return is_scalar_condition(element.comparison, materialized) and is_scalar_condition(element.expr, materialized)
+        return is_scalar_condition(
+            element.comparison, materialized
+        ) and is_scalar_condition(element.expr, materialized)
     elif isinstance(element, CaseElse):
         return is_scalar_condition(element.expr, materialized)
     elif isinstance(element, MagicConstants):
@@ -431,7 +478,11 @@ def find_nullable_concepts(
     that may contain nulls in the output set
     """
     nullable_datasources = set()
-    datasource_map = {x.identifier: x for x in datasources if isinstance(x, (Datasource, QueryDatasource))}
+    datasource_map = {
+        x.identifier: x
+        for x in datasources
+        if isinstance(x, (Datasource, QueryDatasource))
+    }
     for join in joins:
         is_on_nullable_condition = False
         if not isinstance(join, BaseJoin):
@@ -439,11 +490,22 @@ def find_nullable_concepts(
         if not join.concept_pairs:
             continue
         for pair in join.concept_pairs:
-            if pair.right.address in [y.address for y in datasource_map[join.right_datasource.identifier].nullable_concepts]:
+            if pair.right.address in [
+                y.address
+                for y in datasource_map[
+                    join.right_datasource.identifier
+                ].nullable_concepts
+            ]:
                 is_on_nullable_condition = True
                 break
-            left_check = join.left_datasource.identifier if join.left_datasource is not None else pair.existing_datasource.identifier
-            if pair.left.address in [y.address for y in datasource_map[left_check].nullable_concepts]:
+            left_check = (
+                join.left_datasource.identifier
+                if join.left_datasource is not None
+                else pair.existing_datasource.identifier
+            )
+            if pair.left.address in [
+                y.address for y in datasource_map[left_check].nullable_concepts
+            ]:
                 is_on_nullable_condition = True
                 break
         if is_on_nullable_condition:
@@ -451,8 +513,16 @@ def find_nullable_concepts(
     final_nullable = set()
 
     for k, v in source_map.items():
-        local_nullable = [x for x in datasources if k in [v.address for v in x.nullable_concepts]]
-        if all([k in [v.address for v in x.nullable_concepts] for x in datasources if k in [z.address for z in x.output_concepts]]):
+        local_nullable = [
+            x for x in datasources if k in [v.address for v in x.nullable_concepts]
+        ]
+        if all(
+            [
+                k in [v.address for v in x.nullable_concepts]
+                for x in datasources
+                if k in [z.address for z in x.output_concepts]
+            ]
+        ):
             final_nullable.add(k)
         all_ds = set([ds for ds in local_nullable]).union(nullable_datasources)
         if nullable_datasources:
@@ -461,9 +531,13 @@ def find_nullable_concepts(
     return list(sorted(final_nullable))
 
 
-def sort_select_output_processed(cte: CTE | UnionCTE, query: ProcessedQuery) -> CTE | UnionCTE:
+def sort_select_output_processed(
+    cte: CTE | UnionCTE, query: ProcessedQuery
+) -> CTE | UnionCTE:
     hidden_addresses = [c.address for c in query.hidden_columns]
-    output_addresses = [c.address for c in query.output_columns if c.address not in hidden_addresses]
+    output_addresses = [
+        c.address for c in query.output_columns if c.address not in hidden_addresses
+    ]
 
     mapping = {x.address: x for x in cte.output_columns}
 
@@ -474,11 +548,15 @@ def sort_select_output_processed(cte: CTE | UnionCTE, query: ProcessedQuery) -> 
     return cte
 
 
-def sort_select_output(cte: CTE | UnionCTE, query: SelectStatement | MultiSelectStatement | ProcessedQuery) -> CTE | UnionCTE:
+def sort_select_output(
+    cte: CTE | UnionCTE, query: SelectStatement | MultiSelectStatement | ProcessedQuery
+) -> CTE | UnionCTE:
     if isinstance(query, ProcessedQuery):
         return sort_select_output_processed(cte, query)
     hidden_addresses = [c.address for c in query.hidden_components]
-    output_addresses = [c.address for c in query.output_components if c.address not in hidden_addresses]
+    output_addresses = [
+        c.address for c in query.output_components if c.address not in hidden_addresses
+    ]
 
     mapping = {x.address: x for x in cte.output_columns}
 

--- a/trilogy/core/processing/utility.py
+++ b/trilogy/core/processing/utility.py
@@ -537,7 +537,9 @@ def find_nullable_concepts(
     return list(sorted(final_nullable))
 
 
-def sort_select_output_processed(cte: CTE, query: ProcessedQuery) -> CTE:
+def sort_select_output_processed(
+    cte: CTE | UnionCTE, query: ProcessedQuery
+) -> CTE | UnionCTE:
     hidden_addresses = [c.address for c in query.hidden_columns]
     output_addresses = [
         c.address for c in query.output_columns if c.address not in hidden_addresses
@@ -554,7 +556,7 @@ def sort_select_output_processed(cte: CTE, query: ProcessedQuery) -> CTE:
 
 def sort_select_output(
     cte: CTE | UnionCTE, query: SelectStatement | MultiSelectStatement | ProcessedQuery
-) -> CTE:
+) -> CTE | UnionCTE:
     if isinstance(query, ProcessedQuery):
         return sort_select_output_processed(cte, query)
     hidden_addresses = [c.address for c in query.hidden_components]

--- a/trilogy/core/query_processor.py
+++ b/trilogy/core/query_processor.py
@@ -40,7 +40,9 @@ from trilogy.utility import unique
 LOGGER_PREFIX = "[QUERY BUILD]"
 
 
-def base_join_to_join(base_join: BaseJoin | UnnestJoin, ctes: List[CTE]) -> Join | InstantiatedUnnestJoin:
+def base_join_to_join(
+    base_join: BaseJoin | UnnestJoin, ctes: List[CTE]
+) -> Join | InstantiatedUnnestJoin:
     """This function converts joins at the datasource level
     to joins at the CTE level"""
     if isinstance(base_join, UnnestJoin):
@@ -98,14 +100,20 @@ def base_join_to_join(base_join: BaseJoin | UnnestJoin, ctes: List[CTE]) -> Join
     )
 
 
-def generate_source_map(query_datasource: QueryDatasource, all_new_ctes: List[CTE | UnionCTE]) -> Tuple[Dict[str, list[str]], Dict[str, list[str]]]:
+def generate_source_map(
+    query_datasource: QueryDatasource, all_new_ctes: List[CTE | UnionCTE]
+) -> Tuple[Dict[str, list[str]], Dict[str, list[str]]]:
     source_map: Dict[str, list[str]] = defaultdict(list)
     # now populate anything derived in this level
     for qdk, qdv in query_datasource.source_map.items():
         unnest = [x for x in qdv if isinstance(x, UnnestJoin)]
         for _ in unnest:
             source_map[qdk] = []
-        if qdk not in source_map and len(qdv) == 1 and isinstance(list(qdv)[0], UnnestJoin):
+        if (
+            qdk not in source_map
+            and len(qdv) == 1
+            and isinstance(list(qdv)[0], UnnestJoin)
+        ):
             source_map[qdk] = []
         basic = [x for x in qdv if isinstance(x, Datasource)]
         for base in basic:
@@ -114,12 +122,20 @@ def generate_source_map(query_datasource: QueryDatasource, all_new_ctes: List[CT
         ctes = [x for x in qdv if isinstance(x, QueryDatasource)]
         if ctes:
             names = set([x.safe_identifier for x in ctes])
-            matches = [cte for cte in all_new_ctes if cte.source.safe_identifier in names]
+            matches = [
+                cte for cte in all_new_ctes if cte.source.safe_identifier in names
+            ]
 
             if not matches and names:
-                raise SyntaxError(f"Missing parent CTEs for source map; expecting {names}, have {[cte.source.safe_identifier for cte in all_new_ctes]}")
+                raise SyntaxError(
+                    f"Missing parent CTEs for source map; expecting {names}, have {[cte.source.safe_identifier for cte in all_new_ctes]}"
+                )
             for cte in matches:
-                output_address = [x.address for x in cte.output_columns if x.address not in [z.address for z in cte.partial_concepts]]
+                output_address = [
+                    x.address
+                    for x in cte.output_columns
+                    if x.address not in [z.address for z in cte.partial_concepts]
+                ]
                 if qdk in output_address:
                     source_map[qdk].append(cte.safe_identifier)
             # now do a pass that accepts partials
@@ -130,16 +146,22 @@ def generate_source_map(query_datasource: QueryDatasource, all_new_ctes: List[CT
             if not qdv:
                 source_map[qdk] = []
             elif CONFIG.validate_missing:
-                raise ValueError(f"Missing {qdk} in {source_map}, source map {query_datasource.source_map} ")
+                raise ValueError(
+                    f"Missing {qdk} in {source_map}, source map {query_datasource.source_map} "
+                )
 
     # existence lookups use a separate map
     # as they cannot be referenced in row resolution
     existence_source_map: Dict[str, list[str]] = defaultdict(list)
     for ek, ev in query_datasource.existence_source_map.items():
         ids = set([x.safe_identifier for x in ev])
-        ematches = [cte.name for cte in all_new_ctes if cte.source.safe_identifier in ids]
+        ematches = [
+            cte.name for cte in all_new_ctes if cte.source.safe_identifier in ids
+        ]
         existence_source_map[ek] = ematches
-    return {k: [] if not v else list(set(v)) for k, v in source_map.items()}, existence_source_map
+    return {
+        k: [] if not v else list(set(v)) for k, v in source_map.items()
+    }, existence_source_map
 
 
 def datasource_to_query_datasource(datasource: Datasource) -> QueryDatasource:
@@ -184,7 +206,10 @@ def resolve_cte_base_name_and_alias_v2(
     source_map: Dict[str, list[str]],
     raw_joins: List[Join | InstantiatedUnnestJoin],
 ) -> Tuple[str | None, str | None]:
-    if isinstance(source.datasources[0], Datasource) and not source.datasources[0].name == CONSTANT_DATASET:
+    if (
+        isinstance(source.datasources[0], Datasource)
+        and not source.datasources[0].name == CONSTANT_DATASET
+    ):
         ds = source.datasources[0]
         return ds.safe_location, ds.safe_identifier
 
@@ -219,7 +244,9 @@ def resolve_cte_base_name_and_alias_v2(
     return None, None
 
 
-def datasource_to_cte(query_datasource: QueryDatasource, name_map: dict[str, str]) -> CTE | UnionCTE:
+def datasource_to_cte(
+    query_datasource: QueryDatasource, name_map: dict[str, str]
+) -> CTE | UnionCTE:
     parents: list[CTE | UnionCTE] = []
     if query_datasource.source_type == SourceType.UNION:
         direct_parents: list[CTE | UnionCTE] = []
@@ -234,12 +261,17 @@ def datasource_to_cte(query_datasource: QueryDatasource, name_map: dict[str, str
             source=query_datasource,
             parent_ctes=parents,
             internal_ctes=direct_parents,
-            output_columns=[c.with_grain(query_datasource.grain) for c in query_datasource.output_concepts],
+            output_columns=[
+                c.with_grain(query_datasource.grain)
+                for c in query_datasource.output_concepts
+            ],
             grain=direct_parents[0].grain,
         )
         return final
 
-    if len(query_datasource.datasources) > 1 or any([isinstance(x, QueryDatasource) for x in query_datasource.datasources]):
+    if len(query_datasource.datasources) > 1 or any(
+        [isinstance(x, QueryDatasource) for x in query_datasource.datasources]
+    ):
         all_new_ctes: List[CTE | UnionCTE] = []
         for datasource in query_datasource.datasources:
             if isinstance(datasource, QueryDatasource):
@@ -262,19 +294,30 @@ def datasource_to_cte(query_datasource: QueryDatasource, name_map: dict[str, str
             source_map = {k: [] for k in query_datasource.source_map}
             existence_map = source_map
         else:
-            source_map = {k: [] if not v else [source.safe_identifier] for k, v in query_datasource.source_map.items()}
+            source_map = {
+                k: [] if not v else [source.safe_identifier]
+                for k, v in query_datasource.source_map.items()
+            }
             existence_map = source_map
 
     human_id = generate_cte_name(query_datasource.identifier, name_map)
 
-    final_joins = [base_join_to_join(join, [x for x in parents if isinstance(x, CTE)]) for join in query_datasource.joins]
+    final_joins = [
+        base_join_to_join(join, [x for x in parents if isinstance(x, CTE)])
+        for join in query_datasource.joins
+    ]
 
-    base_name, base_alias = resolve_cte_base_name_and_alias_v2(human_id, query_datasource, source_map, final_joins)
+    base_name, base_alias = resolve_cte_base_name_and_alias_v2(
+        human_id, query_datasource, source_map, final_joins
+    )
     cte = CTE(
         name=human_id,
         source=query_datasource,
         # output columns are what are selected/grouped by
-        output_columns=[c.with_grain(query_datasource.grain) for c in query_datasource.output_concepts],
+        output_columns=[
+            c.with_grain(query_datasource.grain)
+            for c in query_datasource.output_concepts
+        ],
         source_map=source_map,
         existence_source_map=existence_map,
         # related columns include all referenced columns, such as filtering
@@ -295,8 +338,14 @@ def datasource_to_cte(query_datasource: QueryDatasource, name_map: dict[str, str
     if cte.grain != query_datasource.grain:
         raise ValueError("Grain was corrupted in CTE generation")
     for x in cte.output_columns:
-        if x.address not in cte.source_map and not any(y in cte.source_map for y in x.pseudonyms) and CONFIG.validate_missing:
-            raise ValueError(f"Missing {x.address} in {cte.source_map}, source map {cte.source.source_map.keys()} ")
+        if (
+            x.address not in cte.source_map
+            and not any(y in cte.source_map for y in x.pseudonyms)
+            and CONFIG.validate_missing
+        ):
+            raise ValueError(
+                f"Missing {x.address} in {cte.source_map}, source map {cte.source.source_map.keys()} "
+            )
 
     return cte
 
@@ -308,7 +357,9 @@ def get_query_node(
     history: History | None = None,
 ) -> StrategyNode:
     graph = graph or generate_graph(environment)
-    logger.info(f"{LOGGER_PREFIX} getting source datasource for query with filtering {statement.where_clause_category} and output {[str(c) for c in statement.output_components]}")
+    logger.info(
+        f"{LOGGER_PREFIX} getting source datasource for query with filtering {statement.where_clause_category} and output {[str(c) for c in statement.output_components]}"
+    )
     if not statement.output_components:
         raise ValueError(f"Statement has no output components {statement}")
 
@@ -322,7 +373,9 @@ def get_query_node(
         history=history,
     )
     if not ods:
-        raise ValueError(f"Could not find source query concepts for {[x.address for x in search_concepts]}")
+        raise ValueError(
+            f"Could not find source query concepts for {[x.address for x in search_concepts]}"
+        )
     ds: StrategyNode = ods
     if statement.having_clause:
         final = statement.having_clause.conditional
@@ -385,7 +438,9 @@ def process_persist(
     statement: PersistStatement,
     hooks: List[BaseHook] | None = None,
 ) -> ProcessedQueryPersist:
-    select = process_query(environment=environment, statement=statement.select, hooks=hooks)
+    select = process_query(
+        environment=environment, statement=statement.select, hooks=hooks
+    )
 
     # build our object to return
     arg_dict = {k: v for k, v in select.__dict__.items()}
@@ -401,7 +456,9 @@ def process_copy(
     statement: CopyStatement,
     hooks: List[BaseHook] | None = None,
 ) -> ProcessedCopyStatement:
-    select = process_query(environment=environment, statement=statement.select, hooks=hooks)
+    select = process_query(
+        environment=environment, statement=statement.select, hooks=hooks
+    )
 
     # build our object to return
     arg_dict = {k: v for k, v in select.__dict__.items()}
@@ -420,7 +477,9 @@ def process_query(
     hooks = hooks or []
     statement.refresh_bindings(environment)
     graph = generate_graph(environment)
-    root_datasource = get_query_datasources(environment=environment, graph=graph, statement=statement, hooks=hooks)
+    root_datasource = get_query_datasources(
+        environment=environment, graph=graph, statement=statement, hooks=hooks
+    )
     for hook in hooks:
         hook.process_root_datasource(root_datasource)
     # this should always return 1 - TODO, refactor

--- a/trilogy/dialect/base.py
+++ b/trilogy/dialect/base.py
@@ -71,7 +71,9 @@ def INVALID_REFERENCE_STRING(x: Any, callsite: str = ""):
 
 
 def window_factory(string: str, include_concept: bool = False) -> Callable:
-    def render_window(concept: str, window: str, sort: str, offset: int | None = None) -> str:
+    def render_window(
+        concept: str, window: str, sort: str, offset: int | None = None
+    ) -> str:
         if not include_concept:
             concept = ""
         if offset is not None:
@@ -278,11 +280,17 @@ class BaseDialect:
         result = None
         if c.pseudonyms:
             candidates = [y for y in [cte.get_concept(x) for x in c.pseudonyms] if y]
-            logger.debug(f"{LOGGER_PREFIX} [{c.address}] pseudonym candidates are {[x.address for x in candidates]}")
+            logger.debug(
+                f"{LOGGER_PREFIX} [{c.address}] pseudonym candidates are {[x.address for x in candidates]}"
+            )
             for candidate in [c] + candidates:
                 try:
-                    logger.debug(f"{LOGGER_PREFIX} [{c.address}] Attempting rendering w/ candidate {candidate.address}")
-                    result = self._render_concept_sql(candidate, cte, raise_invalid=True)
+                    logger.debug(
+                        f"{LOGGER_PREFIX} [{c.address}] Attempting rendering w/ candidate {candidate.address}"
+                    )
+                    result = self._render_concept_sql(
+                        candidate, cte, raise_invalid=True
+                    )
                     if result:
                         break
                 except ValueError:
@@ -293,13 +301,19 @@ class BaseDialect:
             return f"{result} as {self.QUOTE_CHARACTER}{c.safe_address}{self.QUOTE_CHARACTER}"
         return result
 
-    def _render_concept_sql(self, c: Concept, cte: CTE | UnionCTE, raise_invalid: bool = False) -> str:
+    def _render_concept_sql(
+        self, c: Concept, cte: CTE | UnionCTE, raise_invalid: bool = False
+    ) -> str:
         # only recurse while it's in sources of the current cte
-        logger.debug(f"{LOGGER_PREFIX} [{c.address}] Starting rendering loop on cte: {cte.name}")
+        logger.debug(
+            f"{LOGGER_PREFIX} [{c.address}] Starting rendering loop on cte: {cte.name}"
+        )
 
         # check if it's not inherited AND no pseudonyms are inherited
         if c.lineage and cte.source_map.get(c.address, []) == []:
-            logger.debug(f"{LOGGER_PREFIX} [{c.address}] rendering concept with lineage that is not already existing, have {cte.source_map}")
+            logger.debug(
+                f"{LOGGER_PREFIX} [{c.address}] rendering concept with lineage that is not already existing, have {cte.source_map}"
+            )
             if isinstance(c.lineage, WindowItem):
                 rendered_order_components = [
                     f"{self.render_concept_sql(x.expr, cte, alias=False, raise_invalid=raise_invalid)} {x.order.value}"
@@ -341,14 +355,31 @@ class BaseDialect:
                 if cte.group_to_grain:
                     rval = self.FUNCTION_MAP[c.lineage.function.operator](args)
                 else:
-                    logger.debug(f"{LOGGER_PREFIX} [{c.address}] ignoring aggregate, already at" " target grain")
+                    logger.debug(
+                        f"{LOGGER_PREFIX} [{c.address}] ignoring aggregate, already at"
+                        " target grain"
+                    )
                     rval = f"{self.FUNCTION_GRAIN_MATCH_MAP[c.lineage.function.operator](args)}"
-            elif isinstance(c.lineage, Function) and c.lineage.operator == FunctionType.UNION:
-                local_matched = [x for x in c.lineage.arguments if isinstance(x, Concept) and x.address in cte.output_columns]
+            elif (
+                isinstance(c.lineage, Function)
+                and c.lineage.operator == FunctionType.UNION
+            ):
+                local_matched = [
+                    x
+                    for x in c.lineage.arguments
+                    if isinstance(x, Concept) and x.address in cte.output_columns
+                ]
                 if not local_matched:
-                    raise SyntaxError("Could not find appropriate source element for union")
+                    raise SyntaxError(
+                        "Could not find appropriate source element for union"
+                    )
                 rval = self.render_expr(local_matched[0], cte)
-            elif isinstance(c.lineage, Function) and c.lineage.operator == FunctionType.CONSTANT and CONFIG.rendering.parameters is True and c.datatype.data_type != DataType.MAP:
+            elif (
+                isinstance(c.lineage, Function)
+                and c.lineage.operator == FunctionType.CONSTANT
+                and CONFIG.rendering.parameters is True
+                and c.datatype.data_type != DataType.MAP
+            ):
                 rval = f":{c.safe_address}"
             else:
                 args = []
@@ -382,13 +413,17 @@ class BaseDialect:
                 else:
                     rval = f"{self.FUNCTION_GRAIN_MATCH_MAP[c.lineage.operator](args)}"
         else:
-            logger.debug(f"{LOGGER_PREFIX} [{c.address}] Rendering basic lookup from {cte.source_map.get(c.address, INVALID_REFERENCE_STRING('Missing source reference'))}")
+            logger.debug(
+                f"{LOGGER_PREFIX} [{c.address}] Rendering basic lookup from {cte.source_map.get(c.address, INVALID_REFERENCE_STRING('Missing source reference'))}"
+            )
 
             raw_content = cte.get_alias(c)
             if isinstance(raw_content, RawColumnExpr):
                 rval = raw_content.text
             elif isinstance(raw_content, Function):
-                rval = self.render_expr(raw_content, cte=cte, raise_invalid=raise_invalid)
+                rval = self.render_expr(
+                    raw_content, cte=cte, raise_invalid=raise_invalid
+                )
             else:
                 rval = safe_get_cte_value(
                     self.FUNCTION_MAP[FunctionType.COALESCE],
@@ -398,8 +433,12 @@ class BaseDialect:
                 )
                 if not rval:
                     if raise_invalid:
-                        raise ValueError(f"Invalid reference string found in query: {rval}, this should never occur. Please report this issue.")
-                    rval = INVALID_REFERENCE_STRING(f"Missing source reference to {c.address}")
+                        raise ValueError(
+                            f"Invalid reference string found in query: {rval}, this should never occur. Please report this issue."
+                        )
+                    rval = INVALID_REFERENCE_STRING(
+                        f"Missing source reference to {c.address}"
+                    )
         return rval
 
     def render_expr(
@@ -449,14 +488,20 @@ class BaseDialect:
                 if e.right.address not in lookup_cte.existence_source_map:
                     lookup = lookup_cte.source_map.get(
                         e.right.address,
-                        [INVALID_REFERENCE_STRING(f"Missing source reference to {e.right.address}")],
+                        [
+                            INVALID_REFERENCE_STRING(
+                                f"Missing source reference to {e.right.address}"
+                            )
+                        ],
                     )
                 else:
                     lookup = lookup_cte.existence_source_map[e.right.address]
                 if len(lookup) > 0:
                     target = lookup[0]
                 else:
-                    target = INVALID_REFERENCE_STRING(f"Missing source CTE for {e.right.address}")
+                    target = INVALID_REFERENCE_STRING(
+                        f"Missing source CTE for {e.right.address}"
+                    )
                 return f"{self.render_expr(e.left, cte=cte, cte_map=cte_map, raise_invalid=raise_invalid)} {e.operator.value} (select {target}.{self.QUOTE_CHARACTER}{e.right.safe_address}{self.QUOTE_CHARACTER} from {target} where {target}.{self.QUOTE_CHARACTER}{e.right.safe_address}{self.QUOTE_CHARACTER} is not null)"
             elif isinstance(e.right, (ListWrapper, TupleWrapper, Parenthetical, list)):
                 return f"{self.render_expr(e.left, cte=cte, cte_map=cte_map, raise_invalid=raise_invalid)} {e.operator.value} {self.render_expr(e.right, cte=cte, cte_map=cte_map, raise_invalid=raise_invalid)}"
@@ -479,8 +524,14 @@ class BaseDialect:
             # conditions need to be nested in parentheses
             return f"{self.render_expr(e.left, cte=cte, cte_map=cte_map, raise_invalid=raise_invalid)} {e.operator.value} {self.render_expr(e.right, cte=cte, cte_map=cte_map, raise_invalid=raise_invalid)}"
         elif isinstance(e, WindowItem):
-            rendered_order_components = [f"{self.render_expr(x.expr, cte, cte_map=cte_map, raise_invalid=raise_invalid)} {x.order.value}" for x in e.order_by]
-            rendered_over_components = [self.render_expr(x, cte, cte_map=cte_map, raise_invalid=raise_invalid) for x in e.over]
+            rendered_order_components = [
+                f"{self.render_expr(x.expr, cte, cte_map=cte_map, raise_invalid=raise_invalid)} {x.order.value}"
+                for x in e.order_by
+            ]
+            rendered_over_components = [
+                self.render_expr(x, cte, cte_map=cte_map, raise_invalid=raise_invalid)
+                for x in e.over
+            ]
             return f"{self.WINDOW_FUNCTION_MAP[e.type](concept = self.render_expr(e.content, cte=cte, cte_map=cte_map, raise_invalid=raise_invalid), window=','.join(rendered_over_components), sort=','.join(rendered_order_components))}"  # noqa: E501
         elif isinstance(e, Parenthetical):
             # conditions need to be nested in parentheses
@@ -526,12 +577,16 @@ class BaseDialect:
 
             return self.FUNCTION_GRAIN_MATCH_MAP[e.operator](arguments)
         elif isinstance(e, AggregateWrapper):
-            return self.render_expr(e.function, cte, cte_map=cte_map, raise_invalid=raise_invalid)
+            return self.render_expr(
+                e.function, cte, cte_map=cte_map, raise_invalid=raise_invalid
+            )
         elif isinstance(e, FilterItem):
             return f"CASE WHEN {self.render_expr(e.where.conditional,cte=cte, cte_map=cte_map, raise_invalid=raise_invalid)} THEN {self.render_expr(e.content, cte, cte_map=cte_map, raise_invalid=raise_invalid)} ELSE NULL END"
         elif isinstance(e, Concept):
             if cte:
-                return self.render_concept_sql(e, cte, alias=False, raise_invalid=raise_invalid)
+                return self.render_concept_sql(
+                    e, cte, alias=False, raise_invalid=raise_invalid
+                )
             elif cte_map:
                 return f"{cte_map[e.address].name}.{self.QUOTE_CHARACTER}{e.safe_address}{self.QUOTE_CHARACTER}"
             return f"{self.QUOTE_CHARACTER}{e.safe_address}{self.QUOTE_CHARACTER}"
@@ -563,9 +618,14 @@ class BaseDialect:
 
     def render_cte(self, cte: CTE | UnionCTE, auto_sort: bool = True) -> CompiledCTE:
         if isinstance(cte, UnionCTE):
-            base_statement = f"\n{cte.operator}\n".join([self.render_cte(child).statement for child in cte.internal_ctes])
+            base_statement = f"\n{cte.operator}\n".join(
+                [self.render_cte(child).statement for child in cte.internal_ctes]
+            )
             if cte.order_by:
-                ordering = [self.render_order_item(i, cte, final=True, alias=False) for i in cte.order_by.items]
+                ordering = [
+                    self.render_order_item(i, cte, final=True, alias=False)
+                    for i in cte.order_by.items
+                ]
                 base_statement += "\nORDER BY " + ",".join(ordering)
             return CompiledCTE(name=cte.name, statement=base_statement)
         if self.UNNEST_MODE in (
@@ -578,11 +638,19 @@ class BaseDialect:
             select_columns = [
                 self.render_concept_sql(c, cte)
                 for c in cte.output_columns
-                if c.address not in [y.address for y in cte.join_derived_concepts] and c.address not in [y.address for y in cte.hidden_concepts]
-            ] + [f"{self.QUOTE_CHARACTER}{c.safe_address}{self.QUOTE_CHARACTER}" for c in cte.join_derived_concepts]
+                if c.address not in [y.address for y in cte.join_derived_concepts]
+                and c.address not in [y.address for y in cte.hidden_concepts]
+            ] + [
+                f"{self.QUOTE_CHARACTER}{c.safe_address}{self.QUOTE_CHARACTER}"
+                for c in cte.join_derived_concepts
+            ]
         else:
             # otherwse, assume we are unnesting directly in the select
-            select_columns = [self.render_concept_sql(c, cte) for c in cte.output_columns if c.address not in [y.address for y in cte.hidden_concepts]]
+            select_columns = [
+                self.render_concept_sql(c, cte)
+                for c in cte.output_columns
+                if c.address not in [y.address for y in cte.hidden_concepts]
+            ]
         if auto_sort:
             select_columns = sorted(select_columns, key=lambda x: x)
         source: str | None = cte.base_name
@@ -595,7 +663,9 @@ class BaseDialect:
                 ):
                     source = f"{render_unnest(self.UNNEST_MODE, self.QUOTE_CHARACTER, cte.join_derived_concepts[0], self.render_concept_sql, cte)}"
                 # direct - eg DUCK DB - can be directly selected inline
-                elif cte.join_derived_concepts and self.UNNEST_MODE == UnnestMode.DIRECT:
+                elif (
+                    cte.join_derived_concepts and self.UNNEST_MODE == UnnestMode.DIRECT
+                ):
                     source = None
                 else:
                     raise SyntaxError("CTE has joins but no from clause")
@@ -616,7 +686,9 @@ class BaseDialect:
         having: Conditional | Parenthetical | Comparison | None = None
         materialized = {x for x, v in cte.source_map.items() if v}
         if cte.condition:
-            if not cte.group_to_grain or is_scalar_condition(cte.condition, materialized=materialized):
+            if not cte.group_to_grain or is_scalar_condition(
+                cte.condition, materialized=materialized
+            ):
                 where = cte.condition
 
             else:
@@ -654,8 +726,25 @@ class BaseDialect:
                 ],
                 where=(self.render_expr(where, cte) if where else None),
                 having=(self.render_expr(having, cte) if having else None),
-                order_by=([self.render_order_item(i, cte) for i in cte.order_by.items] if cte.order_by else None),
-                group_by=(sorted(list(set([self.render_concept_sql(c, cte, alias=False) for c in cte.group_concepts]))) if cte.group_to_grain else None),
+                order_by=(
+                    [self.render_order_item(i, cte) for i in cte.order_by.items]
+                    if cte.order_by
+                    else None
+                ),
+                group_by=(
+                    sorted(
+                        list(
+                            set(
+                                [
+                                    self.render_concept_sql(c, cte, alias=False)
+                                    for c in cte.group_concepts
+                                ]
+                            )
+                        )
+                    )
+                    if cte.group_to_grain
+                    else None
+                ),
             ),
         )
 
@@ -684,8 +773,19 @@ class BaseDialect:
             | CopyStatement
         ],
         hooks: Optional[List[BaseHook]] = None,
-    ) -> List[ProcessedQuery | ProcessedQueryPersist | ProcessedShowStatement | ProcessedRawSQLStatement]:
-        output: List[ProcessedQuery | ProcessedQueryPersist | ProcessedShowStatement | ProcessedRawSQLStatement | ProcessedCopyStatement] = []
+    ) -> List[
+        ProcessedQuery
+        | ProcessedQueryPersist
+        | ProcessedShowStatement
+        | ProcessedRawSQLStatement
+    ]:
+        output: List[
+            ProcessedQuery
+            | ProcessedQueryPersist
+            | ProcessedShowStatement
+            | ProcessedRawSQLStatement
+            | ProcessedCopyStatement
+        ] = []
         for statement in statements:
             if isinstance(statement, PersistStatement):
                 if hooks:
@@ -718,8 +818,16 @@ class BaseDialect:
                 if isinstance(statement.content, SelectStatement):
                     output.append(
                         ProcessedShowStatement(
-                            output_columns=[environment.concepts[DEFAULT_CONCEPTS["query_text"].address]],
-                            output_values=[process_query(environment, statement.content, hooks=hooks)],
+                            output_columns=[
+                                environment.concepts[
+                                    DEFAULT_CONCEPTS["query_text"].address
+                                ]
+                            ],
+                            output_values=[
+                                process_query(
+                                    environment, statement.content, hooks=hooks
+                                )
+                            ],
                         )
                     )
                 else:
@@ -743,7 +851,12 @@ class BaseDialect:
 
     def compile_statement(
         self,
-        query: (ProcessedQuery | ProcessedQueryPersist | ProcessedShowStatement | ProcessedRawSQLStatement),
+        query: (
+            ProcessedQuery
+            | ProcessedQueryPersist
+            | ProcessedShowStatement
+            | ProcessedRawSQLStatement
+        ),
     ) -> str:
         if isinstance(query, ProcessedShowStatement):
             return ";\n".join([str(x) for x in query.output_values])
@@ -753,27 +866,39 @@ class BaseDialect:
         cte_output_map = {}
         selected = set()
         hidden_addresses = [c.address for c in query.hidden_columns]
-        output_addresses = [c.address for c in query.output_columns if c.address not in hidden_addresses]
+        output_addresses = [
+            c.address for c in query.output_columns if c.address not in hidden_addresses
+        ]
 
         for c in query.base.output_columns:
             if c.address not in selected:
-                select_columns[c.address] = f"{query.base.name}.{safe_quote(c.safe_address, self.QUOTE_CHARACTER)}"
+                select_columns[c.address] = (
+                    f"{query.base.name}.{safe_quote(c.safe_address, self.QUOTE_CHARACTER)}"
+                )
                 cte_output_map[c.address] = query.base
                 if c.address not in hidden_addresses:
                     selected.add(c.address)
         if not all([x in selected for x in output_addresses]):
             missing = [x for x in output_addresses if x not in selected]
-            raise ValueError(f"Did not get all output addresses in select - missing: {missing}, have" f" {selected}")
+            raise ValueError(
+                f"Did not get all output addresses in select - missing: {missing}, have"
+                f" {selected}"
+            )
 
         compiled_ctes = self.generate_ctes(query)
 
         final = self.SQL_TEMPLATE.render(
-            output=(query.output_to if isinstance(query, ProcessedQueryPersist) else None),
+            output=(
+                query.output_to if isinstance(query, ProcessedQueryPersist) else None
+            ),
             full_select=compiled_ctes[-1].statement,
             ctes=compiled_ctes[:-1],
         )
 
         if CONFIG.strict_mode and INVALID_REFERENCE_STRING(1) in final:
-            raise ValueError(f"Invalid reference string found in query: {final}, this should never" " occur. Please report this issue.")
+            raise ValueError(
+                f"Invalid reference string found in query: {final}, this should never"
+                " occur. Please report this issue."
+            )
         logger.info(f"{LOGGER_PREFIX} Compiled query: {final}")
         return final

--- a/trilogy/dialect/bigquery.py
+++ b/trilogy/dialect/bigquery.py
@@ -12,7 +12,9 @@ FUNCTION_MAP = {
     FunctionType.SUM: lambda x: f"sum({x[0]})",
     FunctionType.LENGTH: lambda x: f"length({x[0]})",
     FunctionType.AVG: lambda x: f"avg({x[0]})",
-    FunctionType.LIKE: lambda x: (f" CASE WHEN {x[0]} like {x[1]} THEN True ELSE False END"),
+    FunctionType.LIKE: lambda x: (
+        f" CASE WHEN {x[0]} like {x[1]} THEN True ELSE False END"
+    ),
     FunctionType.MINUTE: lambda x: f"EXTRACT(MINUTE from {x[0]})",
     FunctionType.SECOND: lambda x: f"EXTRACT(SECOND from {x[0]})",
     FunctionType.HOUR: lambda x: f"EXTRACT(HOUR from {x[0]})",

--- a/trilogy/dialect/bigquery.py
+++ b/trilogy/dialect/bigquery.py
@@ -1,10 +1,9 @@
-from typing import Mapping, Callable, Any
+from typing import Any, Callable, Mapping
 
 from jinja2 import Template
 
-from trilogy.core.enums import FunctionType, WindowType, UnnestMode
+from trilogy.core.enums import FunctionType, UnnestMode, WindowType
 from trilogy.dialect.base import BaseDialect
-
 
 WINDOW_FUNCTION_MAP: Mapping[WindowType, Callable[[Any, Any, Any], str]] = {}
 
@@ -13,9 +12,7 @@ FUNCTION_MAP = {
     FunctionType.SUM: lambda x: f"sum({x[0]})",
     FunctionType.LENGTH: lambda x: f"length({x[0]})",
     FunctionType.AVG: lambda x: f"avg({x[0]})",
-    FunctionType.LIKE: lambda x: (
-        f" CASE WHEN {x[0]} like {x[1]} THEN True ELSE False END"
-    ),
+    FunctionType.LIKE: lambda x: (f" CASE WHEN {x[0]} like {x[1]} THEN True ELSE False END"),
     FunctionType.MINUTE: lambda x: f"EXTRACT(MINUTE from {x[0]})",
     FunctionType.SECOND: lambda x: f"EXTRACT(SECOND from {x[0]})",
     FunctionType.HOUR: lambda x: f"EXTRACT(HOUR from {x[0]})",

--- a/trilogy/dialect/common.py
+++ b/trilogy/dialect/common.py
@@ -1,13 +1,14 @@
+from typing import Callable
+
+from trilogy.core.enums import Modifier, UnnestMode
 from trilogy.core.models import (
-    Join,
-    InstantiatedUnnestJoin,
     CTE,
     Concept,
     Function,
+    InstantiatedUnnestJoin,
+    Join,
     RawColumnExpr,
 )
-from trilogy.core.enums import UnnestMode, Modifier
-from typing import Callable
 
 
 def null_wrapper(lval: str, rval: str, modifiers: list[Modifier]) -> str:
@@ -92,9 +93,7 @@ def render_join(
                         render_expr_func,
                         join.inlined_ctes,
                     ),
-                    modifiers=pair.modifiers
-                    + (pair.left.modifiers or [])
-                    + (pair.right.modifiers or []),
+                    modifiers=pair.modifiers + (pair.left.modifiers or []) + (pair.right.modifiers or []),
                 )
                 for pair in join.joinkey_pairs
             ]

--- a/trilogy/dialect/common.py
+++ b/trilogy/dialect/common.py
@@ -93,7 +93,9 @@ def render_join(
                         render_expr_func,
                         join.inlined_ctes,
                     ),
-                    modifiers=pair.modifiers + (pair.left.modifiers or []) + (pair.right.modifiers or []),
+                    modifiers=pair.modifiers
+                    + (pair.left.modifiers or [])
+                    + (pair.right.modifiers or []),
                 )
                 for pair in join.joinkey_pairs
             ]

--- a/trilogy/dialect/config.py
+++ b/trilogy/dialect/config.py
@@ -1,5 +1,4 @@
 class DialectConfig:
-
     def __init__(self):
         pass
 
@@ -35,9 +34,7 @@ class DuckDBConfig(DialectConfig):
 
 
 class PostgresConfig(DialectConfig):
-    def __init__(
-        self, host: str, port: int, username: str, password: str, database: str
-    ):
+    def __init__(self, host: str, port: int, username: str, password: str, database: str):
         self.host = host
         self.port = port
         self.username = username
@@ -49,9 +46,7 @@ class PostgresConfig(DialectConfig):
 
 
 class SQLServerConfig(DialectConfig):
-    def __init__(
-        self, host: str, port: int, username: str, password: str, database: str
-    ):
+    def __init__(self, host: str, port: int, username: str, password: str, database: str):
         self.host = host
         self.port = port
         self.username = username
@@ -101,7 +96,6 @@ class PrestoConfig(DialectConfig):
 
 
 class TrinoConfig(PrestoConfig):
-
     def connection_string(self) -> str:
         if self.schema:
             return f"trino://{self.username}:{self.password}@{self.host}:{self.port}/{self.catalog}/{self.schema}"

--- a/trilogy/dialect/config.py
+++ b/trilogy/dialect/config.py
@@ -34,7 +34,9 @@ class DuckDBConfig(DialectConfig):
 
 
 class PostgresConfig(DialectConfig):
-    def __init__(self, host: str, port: int, username: str, password: str, database: str):
+    def __init__(
+        self, host: str, port: int, username: str, password: str, database: str
+    ):
         self.host = host
         self.port = port
         self.username = username
@@ -46,7 +48,9 @@ class PostgresConfig(DialectConfig):
 
 
 class SQLServerConfig(DialectConfig):
-    def __init__(self, host: str, port: int, username: str, password: str, database: str):
+    def __init__(
+        self, host: str, port: int, username: str, password: str, database: str
+    ):
         self.host = host
         self.port = port
         self.username = username

--- a/trilogy/dialect/duckdb.py
+++ b/trilogy/dialect/duckdb.py
@@ -1,8 +1,8 @@
-from typing import Mapping, Callable, Any
+from typing import Any, Callable, Mapping
 
 from jinja2 import Template
 
-from trilogy.core.enums import FunctionType, WindowType, UnnestMode
+from trilogy.core.enums import FunctionType, UnnestMode, WindowType
 from trilogy.dialect.base import BaseDialect
 
 WINDOW_FUNCTION_MAP: Mapping[WindowType, Callable[[Any, Any, Any], str]] = {}
@@ -12,15 +12,9 @@ FUNCTION_MAP = {
     FunctionType.SUM: lambda args: f"sum({args[0]})",
     FunctionType.AVG: lambda args: f"avg({args[0]})",
     FunctionType.LENGTH: lambda args: f"length({args[0]})",
-    FunctionType.LIKE: lambda args: (
-        f" CASE WHEN {args[0]} like {args[1]} THEN True ELSE False END"
-    ),
-    FunctionType.CONCAT: lambda args: (
-        f"CONCAT({','.join([f''' {str(a)} ''' for a in args])})"
-    ),
-    FunctionType.SPLIT: lambda args: (
-        f"STRING_SPLIT({','.join([f''' {str(a)} ''' for a in args])})"
-    ),
+    FunctionType.LIKE: lambda args: (f" CASE WHEN {args[0]} like {args[1]} THEN True ELSE False END"),
+    FunctionType.CONCAT: lambda args: (f"CONCAT({','.join([f''' {str(a)} ''' for a in args])})"),
+    FunctionType.SPLIT: lambda args: (f"STRING_SPLIT({','.join([f''' {str(a)} ''' for a in args])})"),
     ## Duckdb indexes from 1, not 0
     FunctionType.INDEX_ACCESS: lambda args: (f"{args[0]}[{args[1]}]"),
     # datetime is aliased

--- a/trilogy/dialect/duckdb.py
+++ b/trilogy/dialect/duckdb.py
@@ -12,9 +12,15 @@ FUNCTION_MAP = {
     FunctionType.SUM: lambda args: f"sum({args[0]})",
     FunctionType.AVG: lambda args: f"avg({args[0]})",
     FunctionType.LENGTH: lambda args: f"length({args[0]})",
-    FunctionType.LIKE: lambda args: (f" CASE WHEN {args[0]} like {args[1]} THEN True ELSE False END"),
-    FunctionType.CONCAT: lambda args: (f"CONCAT({','.join([f''' {str(a)} ''' for a in args])})"),
-    FunctionType.SPLIT: lambda args: (f"STRING_SPLIT({','.join([f''' {str(a)} ''' for a in args])})"),
+    FunctionType.LIKE: lambda args: (
+        f" CASE WHEN {args[0]} like {args[1]} THEN True ELSE False END"
+    ),
+    FunctionType.CONCAT: lambda args: (
+        f"CONCAT({','.join([f''' {str(a)} ''' for a in args])})"
+    ),
+    FunctionType.SPLIT: lambda args: (
+        f"STRING_SPLIT({','.join([f''' {str(a)} ''' for a in args])})"
+    ),
     ## Duckdb indexes from 1, not 0
     FunctionType.INDEX_ACCESS: lambda args: (f"{args[0]}[{args[1]}]"),
     # datetime is aliased

--- a/trilogy/dialect/enums.py
+++ b/trilogy/dialect/enums.py
@@ -13,9 +13,13 @@ def default_factory(conf: DialectConfig, config_type):
     from sqlalchemy import create_engine
 
     if not isinstance(conf, config_type):
-        raise TypeError(f"Invalid dialect configuration for type {type(config_type).__name__}")
+        raise TypeError(
+            f"Invalid dialect configuration for type {type(config_type).__name__}"
+        )
     if conf.connect_args:
-        return create_engine(conf.connection_string(), future=True, connect_args=conf.connect_args)
+        return create_engine(
+            conf.connection_string(), future=True, connect_args=conf.connect_args
+        )
     return create_engine(conf.connection_string(), future=True)
 
 
@@ -61,12 +65,16 @@ class Dialects(Enum):
 
             return _engine_factory(conf, SnowflakeConfig)
         elif self == Dialects.POSTGRES:
-            logger.warn("WARN: Using experimental postgres dialect. Most functionality will not work.")
+            logger.warn(
+                "WARN: Using experimental postgres dialect. Most functionality will not work."
+            )
             import importlib
 
             spec = importlib.util.find_spec("psycopg2")
             if spec is None:
-                raise ImportError("postgres driver not installed. python -m pip install pypreql[postgres]")
+                raise ImportError(
+                    "postgres driver not installed. python -m pip install pypreql[postgres]"
+                )
             from trilogy.dialect.config import PostgresConfig
 
             return _engine_factory(conf, PostgresConfig)
@@ -79,7 +87,9 @@ class Dialects(Enum):
 
             return _engine_factory(conf, TrinoConfig)
         else:
-            raise ValueError(f"Unsupported dialect {self} for default engine creation; create one explicitly.")
+            raise ValueError(
+                f"Unsupported dialect {self} for default engine creation; create one explicitly."
+            )
 
     def default_executor(
         self,

--- a/trilogy/dialect/enums.py
+++ b/trilogy/dialect/enums.py
@@ -1,25 +1,21 @@
 from enum import Enum
-from typing import List, TYPE_CHECKING, Optional, Callable
+from typing import TYPE_CHECKING, Callable, List, Optional
 
 if TYPE_CHECKING:
+    from trilogy import Environment, Executor
     from trilogy.hooks.base_hook import BaseHook
-    from trilogy import Executor, Environment
 
-from trilogy.dialect.config import DialectConfig
 from trilogy.constants import logger
+from trilogy.dialect.config import DialectConfig
 
 
 def default_factory(conf: DialectConfig, config_type):
     from sqlalchemy import create_engine
 
     if not isinstance(conf, config_type):
-        raise TypeError(
-            f"Invalid dialect configuration for type {type(config_type).__name__}"
-        )
+        raise TypeError(f"Invalid dialect configuration for type {type(config_type).__name__}")
     if conf.connect_args:
-        return create_engine(
-            conf.connection_string(), future=True, connect_args=conf.connect_args
-        )
+        return create_engine(conf.connection_string(), future=True, connect_args=conf.connect_args)
     return create_engine(conf.connection_string(), future=True)
 
 
@@ -42,6 +38,7 @@ class Dialects(Enum):
         if self == Dialects.BIGQUERY:
             from google.auth import default
             from google.cloud import bigquery
+
             from trilogy.dialect.config import BigQueryConfig
 
             credentials, project = default()
@@ -52,7 +49,6 @@ class Dialects(Enum):
                 BigQueryConfig,
             )
         elif self == Dialects.SQL_SERVER:
-
             raise NotImplementedError()
         elif self == Dialects.DUCK_DB:
             from trilogy.dialect.config import DuckDBConfig
@@ -65,16 +61,12 @@ class Dialects(Enum):
 
             return _engine_factory(conf, SnowflakeConfig)
         elif self == Dialects.POSTGRES:
-            logger.warn(
-                "WARN: Using experimental postgres dialect. Most functionality will not work."
-            )
+            logger.warn("WARN: Using experimental postgres dialect. Most functionality will not work.")
             import importlib
 
             spec = importlib.util.find_spec("psycopg2")
             if spec is None:
-                raise ImportError(
-                    "postgres driver not installed. python -m pip install pypreql[postgres]"
-                )
+                raise ImportError("postgres driver not installed. python -m pip install pypreql[postgres]")
             from trilogy.dialect.config import PostgresConfig
 
             return _engine_factory(conf, PostgresConfig)
@@ -87,9 +79,7 @@ class Dialects(Enum):
 
             return _engine_factory(conf, TrinoConfig)
         else:
-            raise ValueError(
-                f"Unsupported dialect {self} for default engine creation; create one explicitly."
-            )
+            raise ValueError(f"Unsupported dialect {self} for default engine creation; create one explicitly.")
 
     def default_executor(
         self,
@@ -98,7 +88,7 @@ class Dialects(Enum):
         conf: DialectConfig | None = None,
         _engine_factory: Callable | None = None,
     ) -> "Executor":
-        from trilogy import Executor, Environment
+        from trilogy import Environment, Executor
 
         if _engine_factory is not None:
             return Executor(

--- a/trilogy/dialect/postgres.py
+++ b/trilogy/dialect/postgres.py
@@ -1,8 +1,8 @@
-from typing import Mapping, Callable, Any
+from typing import Any, Callable, Mapping
 
 from jinja2 import Template
 
-from trilogy.core.enums import FunctionType, WindowType, DatePart
+from trilogy.core.enums import DatePart, FunctionType, WindowType
 from trilogy.dialect.base import BaseDialect
 
 

--- a/trilogy/dialect/presto.py
+++ b/trilogy/dialect/presto.py
@@ -15,7 +15,9 @@ FUNCTION_MAP = {
     FunctionType.AVG: lambda x: f"avg({x[0]})",
     FunctionType.INDEX_ACCESS: lambda x: f"element_at({x[0]},{x[1]})",
     FunctionType.MAP_ACCESS: lambda x: f"{x[0]}[{x[1]}]",
-    FunctionType.LIKE: lambda x: (f" CASE WHEN {x[0]} like {x[1]} THEN True ELSE False END"),
+    FunctionType.LIKE: lambda x: (
+        f" CASE WHEN {x[0]} like {x[1]} THEN True ELSE False END"
+    ),
     FunctionType.MINUTE: lambda x: f"EXTRACT(MINUTE from {x[0]})",
     FunctionType.SECOND: lambda x: f"EXTRACT(SECOND from {x[0]})",
     FunctionType.HOUR: lambda x: f"EXTRACT(HOUR from {x[0]})",

--- a/trilogy/dialect/presto.py
+++ b/trilogy/dialect/presto.py
@@ -1,11 +1,10 @@
-from typing import Mapping, Callable, Any
+from typing import Any, Callable, Mapping
 
 from jinja2 import Template
 
-from trilogy.core.enums import FunctionType, WindowType
-from trilogy.dialect.base import BaseDialect
+from trilogy.core.enums import FunctionType, UnnestMode, WindowType
 from trilogy.core.models import DataType
-from trilogy.core.enums import UnnestMode
+from trilogy.dialect.base import BaseDialect
 
 WINDOW_FUNCTION_MAP: Mapping[WindowType, Callable[[Any, Any, Any], str]] = {}
 
@@ -16,9 +15,7 @@ FUNCTION_MAP = {
     FunctionType.AVG: lambda x: f"avg({x[0]})",
     FunctionType.INDEX_ACCESS: lambda x: f"element_at({x[0]},{x[1]})",
     FunctionType.MAP_ACCESS: lambda x: f"{x[0]}[{x[1]}]",
-    FunctionType.LIKE: lambda x: (
-        f" CASE WHEN {x[0]} like {x[1]} THEN True ELSE False END"
-    ),
+    FunctionType.LIKE: lambda x: (f" CASE WHEN {x[0]} like {x[1]} THEN True ELSE False END"),
     FunctionType.MINUTE: lambda x: f"EXTRACT(MINUTE from {x[0]})",
     FunctionType.SECOND: lambda x: f"EXTRACT(SECOND from {x[0]})",
     FunctionType.HOUR: lambda x: f"EXTRACT(HOUR from {x[0]})",

--- a/trilogy/dialect/snowflake.py
+++ b/trilogy/dialect/snowflake.py
@@ -16,7 +16,9 @@ FUNCTION_MAP = {
     FunctionType.SUM: lambda x: f"sum({x[0]})",
     FunctionType.LENGTH: lambda x: f"length({x[0]})",
     FunctionType.AVG: lambda x: f"avg({x[0]})",
-    FunctionType.LIKE: lambda x: (f" CASE WHEN {x[0]} like {x[1]} THEN True ELSE False END"),
+    FunctionType.LIKE: lambda x: (
+        f" CASE WHEN {x[0]} like {x[1]} THEN True ELSE False END"
+    ),
     FunctionType.MINUTE: lambda x: f"EXTRACT(MINUTE from {x[0]})",
     FunctionType.SECOND: lambda x: f"EXTRACT(SECOND from {x[0]})",
     FunctionType.HOUR: lambda x: f"EXTRACT(HOUR from {x[0]})",

--- a/trilogy/dialect/snowflake.py
+++ b/trilogy/dialect/snowflake.py
@@ -1,8 +1,8 @@
-from typing import Mapping, Callable, Any
+from typing import Any, Callable, Mapping
 
 from jinja2 import Template
 
-from trilogy.core.enums import FunctionType, WindowType, UnnestMode
+from trilogy.core.enums import FunctionType, UnnestMode, WindowType
 from trilogy.dialect.base import BaseDialect
 
 ENV_SNOWFLAKE_PW = "PREQL_SNOWFLAKE_PW"
@@ -16,9 +16,7 @@ FUNCTION_MAP = {
     FunctionType.SUM: lambda x: f"sum({x[0]})",
     FunctionType.LENGTH: lambda x: f"length({x[0]})",
     FunctionType.AVG: lambda x: f"avg({x[0]})",
-    FunctionType.LIKE: lambda x: (
-        f" CASE WHEN {x[0]} like {x[1]} THEN True ELSE False END"
-    ),
+    FunctionType.LIKE: lambda x: (f" CASE WHEN {x[0]} like {x[1]} THEN True ELSE False END"),
     FunctionType.MINUTE: lambda x: f"EXTRACT(MINUTE from {x[0]})",
     FunctionType.SECOND: lambda x: f"EXTRACT(SECOND from {x[0]})",
     FunctionType.HOUR: lambda x: f"EXTRACT(HOUR from {x[0]})",

--- a/trilogy/dialect/sql_server.py
+++ b/trilogy/dialect/sql_server.py
@@ -1,17 +1,16 @@
-from typing import Mapping, Callable, Any
+from typing import Any, Callable, Mapping
 
 from jinja2 import Template
-from trilogy.utility import string_to_hash
-
 
 from trilogy.core.enums import FunctionType, WindowType
 from trilogy.core.models import (
     ProcessedQuery,
     ProcessedQueryPersist,
-    ProcessedShowStatement,
     ProcessedRawSQLStatement,
+    ProcessedShowStatement,
 )
 from trilogy.dialect.base import BaseDialect
+from trilogy.utility import string_to_hash
 
 WINDOW_FUNCTION_MAP: Mapping[WindowType, Callable[[Any, Any, Any], str]] = {}
 
@@ -20,12 +19,8 @@ FUNCTION_MAP = {
     FunctionType.SUM: lambda args: f"sum({args[0]})",
     FunctionType.AVG: lambda args: f"avg({args[0]})",
     FunctionType.LENGTH: lambda args: f"length({args[0]})",
-    FunctionType.LIKE: lambda args: (
-        f" CASE WHEN {args[0]} like {args[1]} THEN True ELSE False END"
-    ),
-    FunctionType.CONCAT: lambda args: (
-        f"CONCAT({','.join([f''' '{a}' ''' for a in args])})"
-    ),
+    FunctionType.LIKE: lambda args: (f" CASE WHEN {args[0]} like {args[1]} THEN True ELSE False END"),
+    FunctionType.CONCAT: lambda args: (f"CONCAT({','.join([f''' '{a}' ''' for a in args])})"),
 }
 
 # if an aggregate function is called on a source that is at the same grain as the aggregate
@@ -85,12 +80,7 @@ class SqlServerDialect(BaseDialect):
 
     def compile_statement(
         self,
-        query: (
-            ProcessedQuery
-            | ProcessedQueryPersist
-            | ProcessedShowStatement
-            | ProcessedRawSQLStatement
-        ),
+        query: (ProcessedQuery | ProcessedQueryPersist | ProcessedShowStatement | ProcessedRawSQLStatement),
     ) -> str:
         base = super().compile_statement(query)
         if isinstance(base, (ProcessedQuery, ProcessedQueryPersist)):

--- a/trilogy/dialect/sql_server.py
+++ b/trilogy/dialect/sql_server.py
@@ -19,8 +19,12 @@ FUNCTION_MAP = {
     FunctionType.SUM: lambda args: f"sum({args[0]})",
     FunctionType.AVG: lambda args: f"avg({args[0]})",
     FunctionType.LENGTH: lambda args: f"length({args[0]})",
-    FunctionType.LIKE: lambda args: (f" CASE WHEN {args[0]} like {args[1]} THEN True ELSE False END"),
-    FunctionType.CONCAT: lambda args: (f"CONCAT({','.join([f''' '{a}' ''' for a in args])})"),
+    FunctionType.LIKE: lambda args: (
+        f" CASE WHEN {args[0]} like {args[1]} THEN True ELSE False END"
+    ),
+    FunctionType.CONCAT: lambda args: (
+        f"CONCAT({','.join([f''' '{a}' ''' for a in args])})"
+    ),
 }
 
 # if an aggregate function is called on a source that is at the same grain as the aggregate
@@ -80,7 +84,12 @@ class SqlServerDialect(BaseDialect):
 
     def compile_statement(
         self,
-        query: (ProcessedQuery | ProcessedQueryPersist | ProcessedShowStatement | ProcessedRawSQLStatement),
+        query: (
+            ProcessedQuery
+            | ProcessedQueryPersist
+            | ProcessedShowStatement
+            | ProcessedRawSQLStatement
+        ),
     ) -> str:
         base = super().compile_statement(query)
         if isinstance(base, (ProcessedQuery, ProcessedQueryPersist)):

--- a/trilogy/engine.py
+++ b/trilogy/engine.py
@@ -1,5 +1,6 @@
-from sqlalchemy.engine import Engine, Connection, CursorResult
 from typing import Protocol
+
+from sqlalchemy.engine import Connection, CursorResult, Engine
 
 
 class EngineResult(Protocol):

--- a/trilogy/executor.py
+++ b/trilogy/executor.py
@@ -60,7 +60,9 @@ class MockResult:
 
 def generate_result_set(columns: List[Concept], output_data: list[Any]) -> MockResult:
     names = [x.address.replace(".", "_") for x in columns]
-    return MockResult(values=[dict(zip(names, [row])) for row in output_data], columns=names)
+    return MockResult(
+        values=[dict(zip(names, [row])) for row in output_data], columns=names
+    )
 
 
 class Executor(object):
@@ -159,12 +161,16 @@ class Executor(object):
 
     @execute_query.register
     def _(self, query: SelectStatement) -> CursorResult:
-        sql = self.generator.generate_queries(self.environment, [query], hooks=self.hooks)
+        sql = self.generator.generate_queries(
+            self.environment, [query], hooks=self.hooks
+        )
         return self.execute_query(sql[0])
 
     @execute_query.register
     def _(self, query: PersistStatement) -> CursorResult:
-        sql = self.generator.generate_queries(self.environment, [query], hooks=self.hooks)
+        sql = self.generator.generate_queries(
+            self.environment, [query], hooks=self.hooks
+        )
         return self.execute_query(sql[0])
 
     @execute_query.register
@@ -173,14 +179,20 @@ class Executor(object):
 
     @execute_query.register
     def _(self, query: ShowStatement) -> CursorResult:
-        sql = self.generator.generate_queries(self.environment, [query], hooks=self.hooks)
+        sql = self.generator.generate_queries(
+            self.environment, [query], hooks=self.hooks
+        )
         return self.execute_query(sql[0])
 
     @execute_query.register
     def _(self, query: ProcessedShowStatement) -> CursorResult:
         return generate_result_set(
             query.output_columns,
-            [self.generator.compile_statement(x) for x in query.output_values if isinstance(x, ProcessedQuery)],
+            [
+                self.generator.compile_statement(x)
+                for x in query.output_values
+                if isinstance(x, ProcessedQuery)
+            ],
         )
 
     @execute_query.register
@@ -198,7 +210,9 @@ class Executor(object):
     @execute_query.register
     def _(self, query: MergeStatementV2) -> CursorResult:
         for concept in query.sources:
-            self.environment.merge_concept(concept, query.targets[concept.address], modifiers=query.modifiers)
+            self.environment.merge_concept(
+                concept, query.targets[concept.address], modifiers=query.modifiers
+            )
 
         return MockResult(
             [
@@ -250,7 +264,9 @@ class Executor(object):
 
     @singledispatchmethod
     def generate_sql(self, command) -> list[str]:
-        raise NotImplementedError("Cannot generate sql for type {}".format(type(command)))
+        raise NotImplementedError(
+            "Cannot generate sql for type {}".format(type(command))
+        )
 
     @generate_sql.register  # type: ignore
     def _(self, command: ProcessedQuery) -> List[str]:
@@ -262,7 +278,9 @@ class Executor(object):
     @generate_sql.register  # type: ignore
     def _(self, command: MultiSelectStatement) -> List[str]:
         output = []
-        sql = self.generator.generate_queries(self.environment, [command], hooks=self.hooks)
+        sql = self.generator.generate_queries(
+            self.environment, [command], hooks=self.hooks
+        )
         for statement in sql:
             compiled_sql = self.generator.compile_statement(statement)
             output.append(compiled_sql)
@@ -273,7 +291,9 @@ class Executor(object):
     @generate_sql.register  # type: ignore
     def _(self, command: SelectStatement) -> List[str]:
         output = []
-        sql = self.generator.generate_queries(self.environment, [command], hooks=self.hooks)
+        sql = self.generator.generate_queries(
+            self.environment, [command], hooks=self.hooks
+        )
         for statement in sql:
             compiled_sql = self.generator.compile_statement(statement)
             output.append(compiled_sql)
@@ -283,8 +303,12 @@ class Executor(object):
     def _(self, command: str) -> List[str]:
         """generate SQL for execution"""
         _, parsed = parse_text(command, self.environment)
-        generatable = [x for x in parsed if isinstance(x, (SelectStatement, PersistStatement))]
-        sql = self.generator.generate_queries(self.environment, generatable, hooks=self.hooks)
+        generatable = [
+            x for x in parsed if isinstance(x, (SelectStatement, PersistStatement))
+        ]
+        sql = self.generator.generate_queries(
+            self.environment, generatable, hooks=self.hooks
+        )
         output = []
         for statement in sql:
             if isinstance(statement, ProcessedShowStatement):
@@ -293,13 +317,25 @@ class Executor(object):
             output.append(compiled_sql)
         return output
 
-    def parse_file(self, file: str | Path, persist: bool = False) -> list[ProcessedQuery | ProcessedQueryPersist | ProcessedShowStatement | ProcessedRawSQLStatement | ProcessedCopyStatement,]:
+    def parse_file(
+        self, file: str | Path, persist: bool = False
+    ) -> list[
+        ProcessedQuery
+        | ProcessedQueryPersist
+        | ProcessedShowStatement
+        | ProcessedRawSQLStatement
+        | ProcessedCopyStatement,
+    ]:
         return list(self.parse_file_generator(file, persist=persist))
 
     def parse_file_generator(
         self, file: str | Path, persist: bool = False
     ) -> Generator[
-        ProcessedQuery | ProcessedQueryPersist | ProcessedShowStatement | ProcessedRawSQLStatement | ProcessedCopyStatement,
+        ProcessedQuery
+        | ProcessedQueryPersist
+        | ProcessedShowStatement
+        | ProcessedRawSQLStatement
+        | ProcessedCopyStatement,
         None,
         None,
     ]:
@@ -308,13 +344,23 @@ class Executor(object):
             command = f.read()
             return self.parse_text_generator(command, persist=persist)
 
-    def parse_text(self, command: str, persist: bool = False) -> List[ProcessedQuery | ProcessedQueryPersist | ProcessedShowStatement | ProcessedRawSQLStatement | ProcessedCopyStatement]:
+    def parse_text(
+        self, command: str, persist: bool = False
+    ) -> List[
+        ProcessedQuery
+        | ProcessedQueryPersist
+        | ProcessedShowStatement
+        | ProcessedRawSQLStatement
+        | ProcessedCopyStatement
+    ]:
         return list(self.parse_text_generator(command, persist=persist))
 
-    def parse_text_generator(
-        self, command: str, persist: bool = False
-    ) -> Generator[
-        ProcessedQuery | ProcessedQueryPersist | ProcessedShowStatement | ProcessedRawSQLStatement | ProcessedCopyStatement,
+    def parse_text_generator(self, command: str, persist: bool = False) -> Generator[
+        ProcessedQuery
+        | ProcessedQueryPersist
+        | ProcessedShowStatement
+        | ProcessedRawSQLStatement
+        | ProcessedCopyStatement,
         None,
         None,
     ]:
@@ -337,7 +383,9 @@ class Executor(object):
         ]
         while generatable:
             t = generatable.pop(0)
-            x = self.generator.generate_queries(self.environment, [t], hooks=self.hooks)[0]
+            x = self.generator.generate_queries(
+                self.environment, [t], hooks=self.hooks
+            )[0]
 
             yield x
 
@@ -345,14 +393,21 @@ class Executor(object):
                 self.environment.add_datasource(x.datasource)
 
     def _hydrate_param(self, param: str) -> Any:
-        matched = [v for v in self.environment.concepts.values() if v.safe_address == param or v.address == param]
+        matched = [
+            v
+            for v in self.environment.concepts.values()
+            if v.safe_address == param or v.address == param
+        ]
         if not matched:
             raise SyntaxError(f"No concept found for parameter {param}")
 
         concept: Concept = matched.pop()
         if not concept.granularity == Granularity.SINGLE_ROW:
             raise SyntaxError(f"Cannot bind non-singleton concept {concept.address}")
-        if isinstance(concept.lineage, Function) and concept.lineage.operator == FunctionType.CONSTANT:
+        if (
+            isinstance(concept.lineage, Function)
+            and concept.lineage.operator == FunctionType.CONSTANT
+        ):
             rval = concept.lineage.arguments[0]
             if isinstance(rval, ListWrapper):
                 return [x for x in rval]
@@ -365,7 +420,9 @@ class Executor(object):
             return None
         return results[0]
 
-    def execute_raw_sql(self, command: str, variables: dict | None = None) -> CursorResult:
+    def execute_raw_sql(
+        self, command: str, variables: dict | None = None
+    ) -> CursorResult:
         """Run a command against the raw underlying
         execution engine"""
         final_params = None
@@ -383,7 +440,9 @@ class Executor(object):
             text(command),
         )
 
-    def execute_text(self, command: str, non_interactive: bool = False) -> List[CursorResult]:
+    def execute_text(
+        self, command: str, non_interactive: bool = False
+    ) -> List[CursorResult]:
         """Run a preql text command"""
         output = []
         # connection = self.engine.connect()
@@ -392,17 +451,25 @@ class Executor(object):
                 output.append(
                     generate_result_set(
                         statement.output_columns,
-                        [self.generator.compile_statement(x) for x in statement.output_values if isinstance(x, ProcessedQuery)],
+                        [
+                            self.generator.compile_statement(x)
+                            for x in statement.output_values
+                            if isinstance(x, ProcessedQuery)
+                        ],
                     )
                 )
                 continue
             if non_interactive:
-                if not isinstance(statement, (ProcessedCopyStatement, ProcessedQueryPersist)):
+                if not isinstance(
+                    statement, (ProcessedCopyStatement, ProcessedQueryPersist)
+                ):
                     continue
             output.append(self.execute_query(statement))
         return output
 
-    def execute_file(self, file: str | Path, non_interactive: bool = False) -> List[CursorResult]:
+    def execute_file(
+        self, file: str | Path, non_interactive: bool = False
+    ) -> List[CursorResult]:
         file = Path(file)
         with open(file, "r") as f:
             command = f.read()

--- a/trilogy/hooks/base_hook.py
+++ b/trilogy/hooks/base_hook.py
@@ -1,6 +1,7 @@
 from trilogy.core.models import (
     QueryDatasource,
     CTE,
+    UnionCTE,
     SelectStatement,
     PersistStatement,
     MultiSelectStatement,
@@ -30,7 +31,7 @@ class BaseHook:
     def process_root_datasource(self, datasource: QueryDatasource):
         pass
 
-    def process_root_cte(self, cte: CTE):
+    def process_root_cte(self, cte: CTE | UnionCTE):
         pass
 
     def process_root_strategy_node(self, node: StrategyNode):

--- a/trilogy/hooks/base_hook.py
+++ b/trilogy/hooks/base_hook.py
@@ -1,11 +1,11 @@
 from trilogy.core.models import (
-    QueryDatasource,
     CTE,
-    UnionCTE,
-    SelectStatement,
-    PersistStatement,
     MultiSelectStatement,
+    PersistStatement,
+    QueryDatasource,
     RowsetDerivationStatement,
+    SelectStatement,
+    UnionCTE,
 )
 from trilogy.core.processing.nodes import StrategyNode
 

--- a/trilogy/hooks/graph_hook.py
+++ b/trilogy/hooks/graph_hook.py
@@ -50,7 +50,13 @@ class GraphHook(BaseHook):
                 else:
                     edge_colors.append("black")
             kwargs["edge_color"] = edge_colors
-        nx.draw(graph, pos=pos, node_color=color_map, connectionstyle="arc3, rad = 0.1", **kwargs)  # Draw the original graph
+        nx.draw(
+            graph,
+            pos=pos,
+            node_color=color_map,
+            connectionstyle="arc3, rad = 0.1",
+            **kwargs
+        )  # Draw the original graph
         # Please note, the code below uses the original idea of re-calculating a dictionary of adjusted label positions per node.
         pos_labels = {}
         # For each node in the Graph

--- a/trilogy/hooks/graph_hook.py
+++ b/trilogy/hooks/graph_hook.py
@@ -1,5 +1,6 @@
-from trilogy.hooks.base_hook import BaseHook
 import networkx as nx
+
+from trilogy.hooks.base_hook import BaseHook
 
 
 class GraphHook(BaseHook):
@@ -49,13 +50,7 @@ class GraphHook(BaseHook):
                 else:
                     edge_colors.append("black")
             kwargs["edge_color"] = edge_colors
-        nx.draw(
-            graph,
-            pos=pos,
-            node_color=color_map,
-            connectionstyle="arc3, rad = 0.1",
-            **kwargs
-        )  # Draw the original graph
+        nx.draw(graph, pos=pos, node_color=color_map, connectionstyle="arc3, rad = 0.1", **kwargs)  # Draw the original graph
         # Please note, the code below uses the original idea of re-calculating a dictionary of adjusted label positions per node.
         pos_labels = {}
         # For each node in the Graph

--- a/trilogy/hooks/query_debugger.py
+++ b/trilogy/hooks/query_debugger.py
@@ -1,5 +1,5 @@
 from typing import Union
-from trilogy.core.models import QueryDatasource, CTE, Datasource, SelectStatement
+from trilogy.core.models import QueryDatasource, CTE, Datasource, SelectStatement, UnionCTE
 
 from trilogy.hooks.base_hook import BaseHook
 from trilogy.constants import logger
@@ -85,7 +85,7 @@ def print_recursive_nodes(
     return display
 
 
-def print_recursive_ctes(input: CTE, depth: int = 0, max_depth: int | None = None):
+def print_recursive_ctes(input: CTE | UnionCTE, depth: int = 0, max_depth: int | None = None):
     if max_depth and depth > max_depth:
         return
     select_statement = [c.address for c in input.output_columns]
@@ -96,6 +96,10 @@ def print_recursive_ctes(input: CTE, depth: int = 0, max_depth: int | None = Non
     if isinstance(input, CTE):
         for child in input.parent_ctes:
             print_recursive_ctes(child, depth + 1)
+    elif isinstance(input, UnionCTE):
+        for child in input.parent_ctes:
+            for parent in child.parent_ctes:
+                print_recursive_ctes(parent, depth+1)
 
 
 class DebuggingHook(BaseHook):

--- a/trilogy/hooks/query_debugger.py
+++ b/trilogy/hooks/query_debugger.py
@@ -1,20 +1,18 @@
+from enum import Enum
+from logging import DEBUG, StreamHandler
 from typing import Union
+
+from trilogy.constants import logger
 from trilogy.core.models import (
-    QueryDatasource,
     CTE,
     Datasource,
+    QueryDatasource,
     SelectStatement,
     UnionCTE,
 )
-
-from trilogy.hooks.base_hook import BaseHook
-from trilogy.constants import logger
-from logging import StreamHandler, DEBUG
 from trilogy.core.processing.nodes import StrategyNode
-
 from trilogy.dialect.bigquery import BigqueryDialect
-
-from enum import Enum
+from trilogy.hooks.base_hook import BaseHook
 
 
 class PrintMode(Enum):
@@ -26,9 +24,7 @@ class PrintMode(Enum):
 renderer = BigqueryDialect()
 
 
-def print_recursive_resolved(
-    input: Union[QueryDatasource, Datasource], mode: PrintMode, depth: int = 0
-):
+def print_recursive_resolved(input: Union[QueryDatasource, Datasource], mode: PrintMode, depth: int = 0):
     extra = []
     if isinstance(input, QueryDatasource):
         if input.joins:
@@ -58,9 +54,7 @@ def print_recursive_resolved(
     return display
 
 
-def print_recursive_nodes(
-    input: StrategyNode, mode: PrintMode = PrintMode.BASIC, depth: int = 0
-):
+def print_recursive_nodes(input: StrategyNode, mode: PrintMode = PrintMode.BASIC, depth: int = 0):
     resolved = input.resolve()
     if mode == PrintMode.FULL:
         display = [
@@ -91,9 +85,7 @@ def print_recursive_nodes(
     return display
 
 
-def print_recursive_ctes(
-    input: CTE | UnionCTE, depth: int = 0, max_depth: int | None = None
-):
+def print_recursive_ctes(input: CTE | UnionCTE, depth: int = 0, max_depth: int | None = None):
     if max_depth and depth > max_depth:
         return
     select_statement = [c.address for c in input.output_columns]

--- a/trilogy/hooks/query_debugger.py
+++ b/trilogy/hooks/query_debugger.py
@@ -24,7 +24,9 @@ class PrintMode(Enum):
 renderer = BigqueryDialect()
 
 
-def print_recursive_resolved(input: Union[QueryDatasource, Datasource], mode: PrintMode, depth: int = 0):
+def print_recursive_resolved(
+    input: Union[QueryDatasource, Datasource], mode: PrintMode, depth: int = 0
+):
     extra = []
     if isinstance(input, QueryDatasource):
         if input.joins:
@@ -54,7 +56,9 @@ def print_recursive_resolved(input: Union[QueryDatasource, Datasource], mode: Pr
     return display
 
 
-def print_recursive_nodes(input: StrategyNode, mode: PrintMode = PrintMode.BASIC, depth: int = 0):
+def print_recursive_nodes(
+    input: StrategyNode, mode: PrintMode = PrintMode.BASIC, depth: int = 0
+):
     resolved = input.resolve()
     if mode == PrintMode.FULL:
         display = [
@@ -85,7 +89,9 @@ def print_recursive_nodes(input: StrategyNode, mode: PrintMode = PrintMode.BASIC
     return display
 
 
-def print_recursive_ctes(input: CTE | UnionCTE, depth: int = 0, max_depth: int | None = None):
+def print_recursive_ctes(
+    input: CTE | UnionCTE, depth: int = 0, max_depth: int | None = None
+):
     if max_depth and depth > max_depth:
         return
     select_statement = [c.address for c in input.output_columns]

--- a/trilogy/hooks/query_debugger.py
+++ b/trilogy/hooks/query_debugger.py
@@ -1,5 +1,11 @@
 from typing import Union
-from trilogy.core.models import QueryDatasource, CTE, Datasource, SelectStatement, UnionCTE
+from trilogy.core.models import (
+    QueryDatasource,
+    CTE,
+    Datasource,
+    SelectStatement,
+    UnionCTE,
+)
 
 from trilogy.hooks.base_hook import BaseHook
 from trilogy.constants import logger
@@ -85,7 +91,9 @@ def print_recursive_nodes(
     return display
 
 
-def print_recursive_ctes(input: CTE | UnionCTE, depth: int = 0, max_depth: int | None = None):
+def print_recursive_ctes(
+    input: CTE | UnionCTE, depth: int = 0, max_depth: int | None = None
+):
     if max_depth and depth > max_depth:
         return
     select_statement = [c.address for c in input.output_columns]
@@ -99,7 +107,7 @@ def print_recursive_ctes(input: CTE | UnionCTE, depth: int = 0, max_depth: int |
     elif isinstance(input, UnionCTE):
         for child in input.parent_ctes:
             for parent in child.parent_ctes:
-                print_recursive_ctes(parent, depth+1)
+                print_recursive_ctes(parent, depth + 1)
 
 
 class DebuggingHook(BaseHook):
@@ -132,7 +140,7 @@ class DebuggingHook(BaseHook):
             for row in printed:
                 print("".join([str(v) for v in row]))
 
-    def process_root_cte(self, cte: CTE):
+    def process_root_cte(self, cte: CTE | UnionCTE):
         if self.process_ctes != PrintMode.OFF:
             print_recursive_ctes(cte, max_depth=self.max_depth)
 

--- a/trilogy/parser.py
+++ b/trilogy/parser.py
@@ -4,5 +4,7 @@ from trilogy.core.models import Environment
 from trilogy.parsing.parse_engine import parse_text
 
 
-def parse(input: str, environment: Optional[Environment] = None) -> tuple[Environment, list]:
+def parse(
+    input: str, environment: Optional[Environment] = None
+) -> tuple[Environment, list]:
     return parse_text(input, environment=environment)

--- a/trilogy/parser.py
+++ b/trilogy/parser.py
@@ -4,7 +4,5 @@ from trilogy.core.models import Environment
 from trilogy.parsing.parse_engine import parse_text
 
 
-def parse(
-    input: str, environment: Optional[Environment] = None
-) -> tuple[Environment, list]:
+def parse(input: str, environment: Optional[Environment] = None) -> tuple[Environment, list]:
     return parse_text(input, environment=environment)

--- a/trilogy/parsing/common.py
+++ b/trilogy/parsing/common.py
@@ -20,7 +20,9 @@ from typing import List, Tuple
 from trilogy.constants import (
     VIRTUAL_CONCEPT_PREFIX,
 )
-from trilogy.core.enums import Modifier, WindowType
+from trilogy.core.enums import Modifier, WindowType, FunctionType, PurposeLineage
+from trilogy.utility import string_to_hash, unique
+from trilogy.core.functions import function_args_to_output_purpose, arg_to_datatype
 
 
 def get_upstream_modifiers(keys: List[Concept]) -> list[Modifier]:
@@ -45,7 +47,10 @@ def process_function_args(
         if isinstance(arg, Function):
             # if it's not an aggregate function, we can skip the virtual concepts
             # to simplify anonymous function handling
-            if arg.operator not in FunctionClass.AGGREGATE_FUNCTIONS.value and arg.operator != FunctionType.UNNEST:
+            if (
+                arg.operator not in FunctionClass.AGGREGATE_FUNCTIONS.value
+                and arg.operator != FunctionType.UNNEST
+            ):
                 final.append(arg)
                 continue
             id_hash = string_to_hash(str(arg))
@@ -59,7 +64,9 @@ def process_function_args(
                 concept.metadata.line_number = meta.line
             environment.add_concept(concept, meta=meta)
             final.append(concept)
-        elif isinstance(arg, (FilterItem, WindowItem, AggregateWrapper, ListWrapper, MapWrapper)):
+        elif isinstance(
+            arg, (FilterItem, WindowItem, AggregateWrapper, ListWrapper, MapWrapper)
+        ):
             id_hash = string_to_hash(str(arg))
             concept = arbitrary_to_concept(
                 arg,
@@ -76,7 +83,9 @@ def process_function_args(
     return final
 
 
-def get_purpose_and_keys(purpose: Purpose | None, args: Tuple[Concept, ...] | None) -> Tuple[Purpose, Tuple[Concept, ...] | None]:
+def get_purpose_and_keys(
+    purpose: Purpose | None, args: Tuple[Concept, ...] | None
+) -> Tuple[Purpose, Tuple[Concept, ...] | None]:
     local_purpose = purpose or function_args_to_output_purpose(args)
     if local_purpose in (Purpose.PROPERTY, Purpose.METRIC) and args:
         keys = concept_list_to_keys(args)
@@ -121,10 +130,16 @@ def constant_to_concept(
     )
 
 
-def function_to_concept(parent: Function, name: str, namespace: str, metadata: Metadata | None = None) -> Concept:
+def function_to_concept(
+    parent: Function, name: str, namespace: str, metadata: Metadata | None = None
+) -> Concept:
     pkeys: List[Concept] = []
     for x in parent.arguments:
-        pkeys += [x for x in parent.concept_arguments if not x.derivation == PurposeLineage.CONSTANT]
+        pkeys += [
+            x
+            for x in parent.concept_arguments
+            if not x.derivation == PurposeLineage.CONSTANT
+        ]
     grain: Grain | None = Grain()
     for x in pkeys:
         grain += x.grain
@@ -186,8 +201,16 @@ def filter_item_to_concept(
         metadata=fmetadata,
         namespace=namespace,
         # filtered copies cannot inherit keys
-        keys=(parent.content.keys if parent.content.purpose == Purpose.PROPERTY else (parent.content,)),
-        grain=(parent.content.grain if parent.content.purpose == Purpose.PROPERTY else Grain()),
+        keys=(
+            parent.content.keys
+            if parent.content.purpose == Purpose.PROPERTY
+            else (parent.content,)
+        ),
+        grain=(
+            parent.content.grain
+            if parent.content.purpose == Purpose.PROPERTY
+            else Grain()
+        ),
         modifiers=modifiers,
     )
 
@@ -238,7 +261,9 @@ def agg_wrapper_to_concept(
     metadata: Metadata | None = None,
     purpose: Purpose | None = None,
 ) -> Concept:
-    local_purpose, keys = get_purpose_and_keys(Purpose.METRIC, tuple(parent.by) if parent.by else None)
+    local_purpose, keys = get_purpose_and_keys(
+        Purpose.METRIC, tuple(parent.by) if parent.by else None
+    )
     # anything grouped to a grain should be a property
     # at that grain
     fmetadata = metadata or Metadata()
@@ -259,7 +284,17 @@ def agg_wrapper_to_concept(
 
 
 def arbitrary_to_concept(
-    parent: (AggregateWrapper | WindowItem | FilterItem | Function | ListWrapper | MapWrapper | int | float | str),
+    parent: (
+        AggregateWrapper
+        | WindowItem
+        | FilterItem
+        | Function
+        | ListWrapper
+        | MapWrapper
+        | int
+        | float
+        | str
+    ),
     namespace: str,
     name: str | None = None,
     metadata: Metadata | None = None,

--- a/trilogy/parsing/common.py
+++ b/trilogy/parsing/common.py
@@ -1,28 +1,28 @@
-from trilogy.core.models import (
-    AggregateWrapper,
-    Concept,
-    Function,
-    Grain,
-    Purpose,
-    Metadata,
-    FilterItem,
-    ListWrapper,
-    MapWrapper,
-    WindowItem,
-    Meta,
-    Parenthetical,
-    FunctionClass,
-    Environment,
-    DataType,
-)
 from typing import List, Tuple
 
 from trilogy.constants import (
     VIRTUAL_CONCEPT_PREFIX,
 )
-from trilogy.core.enums import Modifier, WindowType, FunctionType, PurposeLineage
+from trilogy.core.enums import FunctionType, Modifier, PurposeLineage, WindowType
+from trilogy.core.functions import arg_to_datatype, function_args_to_output_purpose
+from trilogy.core.models import (
+    AggregateWrapper,
+    Concept,
+    DataType,
+    Environment,
+    FilterItem,
+    Function,
+    FunctionClass,
+    Grain,
+    ListWrapper,
+    MapWrapper,
+    Meta,
+    Metadata,
+    Parenthetical,
+    Purpose,
+    WindowItem,
+)
 from trilogy.utility import string_to_hash, unique
-from trilogy.core.functions import function_args_to_output_purpose, arg_to_datatype
 
 
 def get_upstream_modifiers(keys: List[Concept]) -> list[Modifier]:

--- a/trilogy/parsing/parse_engine.py
+++ b/trilogy/parsing/parse_engine.py
@@ -152,7 +152,9 @@ def gen_cache_lookup(path: str, alias: str, parent: str) -> str:
     return path + alias + parent
 
 
-def parse_concept_reference(name: str, environment: Environment, purpose: Optional[Purpose] = None) -> Tuple[str, str, str, str | None]:
+def parse_concept_reference(
+    name: str, environment: Environment, purpose: Optional[Purpose] = None
+) -> Tuple[str, str, str, str | None]:
     parent = None
     if "." in name:
         if purpose == Purpose.PROPERTY:
@@ -275,7 +277,10 @@ class ParseToObjects(Transformer):
         output = args[0]
         if isinstance(output, ConceptDeclarationStatement):
             if len(args) > 1 and isinstance(args[1], Comment):
-                output.concept.metadata.description = output.concept.metadata.description or args[1].text.split("#")[1].strip()
+                output.concept.metadata.description = (
+                    output.concept.metadata.description
+                    or args[1].text.split("#")[1].strip()
+                )
         if isinstance(output, ImportStatement):
             if len(args) > 1 and isinstance(args[1], Comment):
                 comment = args[1].text.split("#")[1].strip()
@@ -283,7 +288,9 @@ class ParseToObjects(Transformer):
                 for _, v in self.environment.concepts.items():
                     if v.namespace == namespace:
                         if v.metadata.description:
-                            v.metadata.description = f"{comment}: {v.metadata.description}"
+                            v.metadata.description = (
+                                f"{comment}: {v.metadata.description}"
+                            )
                         else:
                             v.metadata.description = comment
 
@@ -326,7 +333,9 @@ class ParseToObjects(Transformer):
 
     @v_args(meta=True)
     def struct_type(self, meta: Meta, args) -> StructType:
-        final: list[DataType | MapType | ListType | NumericType | StructType | Concept] = []
+        final: list[
+            DataType | MapType | ListType | NumericType | StructType | Concept
+        ] = []
         for arg in args:
             new = self.environment.concepts.__getitem__(  # type: ignore
                 key=arg, line_no=meta.line
@@ -347,7 +356,9 @@ class ParseToObjects(Transformer):
     def map_type(self, args) -> MapType:
         return MapType(key_type=args[0], value_type=args[1])
 
-    def data_type(self, args) -> DataType | ListType | StructType | MapType | NumericType:
+    def data_type(
+        self, args
+    ) -> DataType | ListType | StructType | MapType | NumericType:
         resolved = args[0]
         if isinstance(resolved, StructType):
             return resolved
@@ -436,7 +447,9 @@ class ParseToObjects(Transformer):
                 namespace = self.environment.namespace or DEFAULT_NAMESPACE
         else:
             if "." not in declaration:
-                raise ParseError(f"Property declaration {args[1]} must be fully qualified with a parent key")
+                raise ParseError(
+                    f"Property declaration {args[1]} must be fully qualified with a parent key"
+                )
             grain, name = declaration.rsplit(".", 1)
             parent = self.environment.concepts[grain]
             parents = [parent]
@@ -490,7 +503,9 @@ class ParseToObjects(Transformer):
         raw_name = args[1]
         # abc.def.property pattern
         if isinstance(raw_name, str):
-            lookup, namespace, name, parent_concept = parse_concept_reference(raw_name, self.environment, purpose)
+            lookup, namespace, name, parent_concept = parse_concept_reference(
+                raw_name, self.environment, purpose
+            )
         # <abc.def,zef.gf>.property pattern
         else:
             keys, name = raw_name
@@ -504,7 +519,9 @@ class ParseToObjects(Transformer):
         while isinstance(source_value, Parenthetical):
             source_value = source_value.content
 
-        if isinstance(source_value, (FilterItem, WindowItem, AggregateWrapper, Function)):
+        if isinstance(
+            source_value, (FilterItem, WindowItem, AggregateWrapper, Function)
+        ):
             concept = arbitrary_to_concept(
                 source_value,
                 name=name,
@@ -531,10 +548,15 @@ class ParseToObjects(Transformer):
             self.environment.add_concept(concept, meta=meta)
             return ConceptDerivation(concept=concept)
 
-        raise SyntaxError(f"Received invalid type {type(args[2])} {args[2]} as input to select" " transform")
+        raise SyntaxError(
+            f"Received invalid type {type(args[2])} {args[2]} as input to select"
+            " transform"
+        )
 
     @v_args(meta=True)
-    def rowset_derivation_statement(self, meta: Meta, args) -> RowsetDerivationStatement:
+    def rowset_derivation_statement(
+        self, meta: Meta, args
+    ) -> RowsetDerivationStatement:
         name = args[0]
         select: SelectStatement | MultiSelectStatement = args[1]
         output = RowsetDerivationStatement(
@@ -557,7 +579,9 @@ class ParseToObjects(Transformer):
             metadata = None
         name = args[1]
         constant: Union[str, float, int, bool, MapWrapper, ListWrapper] = args[2]
-        lookup, namespace, name, parent = parse_concept_reference(name, self.environment)
+        lookup, namespace, name, parent = parse_concept_reference(
+            name, self.environment
+        )
         concept = Concept(
             name=name,
             datatype=arg_to_datatype(constant),
@@ -625,7 +649,9 @@ class ParseToObjects(Transformer):
             elif isinstance(val, WhereClause):
                 where = val
         if not address:
-            raise ValueError("Malformed datasource, missing address or query declaration")
+            raise ValueError(
+                "Malformed datasource, missing address or query declaration"
+            )
         datasource = Datasource(
             name=name,
             columns=columns,
@@ -654,20 +680,32 @@ class ParseToObjects(Transformer):
     def select_transform(self, meta: Meta, args) -> ConceptTransform:
         output: str = args[1]
         transformation = unwrap_transformation(args[0])
-        lookup, namespace, output, parent = parse_concept_reference(output, self.environment)
+        lookup, namespace, output, parent = parse_concept_reference(
+            output, self.environment
+        )
 
         metadata = Metadata(line_number=meta.line, concept_source=ConceptSource.SELECT)
 
         if isinstance(transformation, AggregateWrapper):
-            concept = agg_wrapper_to_concept(transformation, namespace=namespace, name=output, metadata=metadata)
+            concept = agg_wrapper_to_concept(
+                transformation, namespace=namespace, name=output, metadata=metadata
+            )
         elif isinstance(transformation, WindowItem):
-            concept = window_item_to_concept(transformation, namespace=namespace, name=output, metadata=metadata)
+            concept = window_item_to_concept(
+                transformation, namespace=namespace, name=output, metadata=metadata
+            )
         elif isinstance(transformation, FilterItem):
-            concept = filter_item_to_concept(transformation, namespace=namespace, name=output, metadata=metadata)
+            concept = filter_item_to_concept(
+                transformation, namespace=namespace, name=output, metadata=metadata
+            )
         elif isinstance(transformation, CONSTANT_TYPES):
-            concept = constant_to_concept(transformation, namespace=namespace, name=output, metadata=metadata)
+            concept = constant_to_concept(
+                transformation, namespace=namespace, name=output, metadata=metadata
+            )
         elif isinstance(transformation, Function):
-            concept = function_to_concept(transformation, namespace=namespace, name=output, metadata=metadata)
+            concept = function_to_concept(
+                transformation, namespace=namespace, name=output, metadata=metadata
+            )
         else:
             raise SyntaxError("Invalid transformation")
 
@@ -694,7 +732,10 @@ class ParseToObjects(Transformer):
         if not args:
             return None
         if len(args) != 1:
-            raise ParseError("Malformed select statement" f" {args} {self.text_lookup[self.parse_address][meta.start_pos:meta.end_pos]}")
+            raise ParseError(
+                "Malformed select statement"
+                f" {args} {self.text_lookup[self.parse_address][meta.start_pos:meta.end_pos]}"
+            )
         content = args[0]
         if isinstance(content, ConceptTransform):
             return SelectItem(content=content, modifiers=modifiers)
@@ -760,7 +801,11 @@ class ParseToObjects(Transformer):
                 raise ValueError("Invalid merge, source is wildcard, target is not")
             source_wildcard = source[:-2]
             target_wildcard = target[:-2]
-            sources = [v for k, v in self.environment.concepts.items() if v.namespace == source_wildcard]
+            sources = [
+                v
+                for k, v in self.environment.concepts.items()
+                if v.namespace == source_wildcard
+            ]
             targets = {}
             for x in sources:
                 target = target_wildcard + "." + x.name
@@ -778,7 +823,9 @@ class ParseToObjects(Transformer):
             target_wildcard=target_wildcard,
         )
         for source_c in new.sources:
-            self.environment.merge_concept(source_c, targets[source_c.address], modifiers)
+            self.environment.merge_concept(
+                source_c, targets[source_c.address], modifiers
+            )
 
         return new
 
@@ -817,7 +864,9 @@ class ParseToObjects(Transformer):
         token_lookup = Path(target)
 
         # cache lookups by the target, the alias, and the file we're importing it from
-        cache_lookup = gen_cache_lookup(path=target, alias=alias, parent=str(self.token_address))
+        cache_lookup = gen_cache_lookup(
+            path=target, alias=alias, parent=str(self.token_address)
+        )
         if token_lookup in self.tokens:
             raw_tokens = self.tokens[token_lookup]
             text = self.text_lookup[token_lookup]
@@ -876,7 +925,11 @@ class ParseToObjects(Transformer):
             grain = None
 
         new_datasource = select.to_datasource(
-            namespace=(self.environment.namespace if self.environment.namespace else DEFAULT_NAMESPACE),
+            namespace=(
+                self.environment.namespace
+                if self.environment.namespace
+                else DEFAULT_NAMESPACE
+            ),
             name=identifier,
             address=Address(location=address),
             grain=grain,
@@ -976,7 +1029,9 @@ class ParseToObjects(Transformer):
             elif isinstance(item.content, Concept):
                 # Sometimes cached values here don't have the latest info
                 # but we can't just use environment, as it might not have the right grain.
-                item.content = self.environment.concepts[item.content.address].with_grain(item.content.grain)
+                item.content = self.environment.concepts[
+                    item.content.address
+                ].with_grain(item.content.grain)
         if order_by:
             for orderitem in order_by.items:
                 if isinstance(orderitem.expr, Concept):
@@ -1109,8 +1164,12 @@ class ParseToObjects(Transformer):
         left_bound = args[1]
         right_bound = args[2]
         return Conditional(
-            left=Comparison(left=args[0], right=left_bound, operator=ComparisonOperator.GTE),
-            right=Comparison(left=args[0], right=right_bound, operator=ComparisonOperator.LTE),
+            left=Comparison(
+                left=args[0], right=left_bound, operator=ComparisonOperator.GTE
+            ),
+            right=Comparison(
+                left=args[0], right=right_bound, operator=ComparisonOperator.LTE
+            ),
             operator=BooleanOperator.AND,
         )
 
@@ -1158,7 +1217,9 @@ class ParseToObjects(Transformer):
                 if len(args) == 1:
                     return args[0]
                 else:
-                    return Conditional(left=args[0], operator=args[1], right=munch_args(args[2:]))
+                    return Conditional(
+                        left=args[0], operator=args[1], right=munch_args(args[2:])
+                    )
 
         return munch_args(args)
 
@@ -1208,7 +1269,9 @@ class ParseToObjects(Transformer):
                 )
                 self.environment.add_concept(concept, meta=meta)
         assert concept
-        return WindowItem(type=type, content=concept, over=over, order_by=order_by, index=index)
+        return WindowItem(
+            type=type, content=concept, over=over, order_by=order_by, index=index
+        )
 
     def filter_item(self, args) -> FilterItem:
         where: WhereClause
@@ -1802,7 +1865,9 @@ class ParseToObjects(Transformer):
                 datatypes.add(output_datatype)
             mapz[str(arg.expr)] = output_datatype
         if not len(datatypes) == 1:
-            raise SyntaxError(f"All case expressions must have the same output datatype, got {datatypes} from {mapz}")
+            raise SyntaxError(
+                f"All case expressions must have the same output datatype, got {datatypes} from {mapz}"
+            )
         return Function(
             operator=FunctionType.CASE,
             arguments=args,
@@ -1853,7 +1918,9 @@ def unpack_visit_error(e: VisitError):
         raise e.orig_exc
     elif isinstance(e.orig_exc, (SyntaxError, TypeError)):
         if isinstance(e.obj, Tree):
-            raise InvalidSyntaxException(str(e.orig_exc) + " in " + str(e.rule) + f" Line: {e.obj.meta.line}")
+            raise InvalidSyntaxException(
+                str(e.orig_exc) + " in " + str(e.rule) + f" Line: {e.obj.meta.line}"
+            )
         raise InvalidSyntaxException(str(e.orig_exc))
     raise e
 
@@ -1862,11 +1929,17 @@ def parse_text_raw(text: str, environment: Optional[Environment] = None):
     PARSER.parse(text)
 
 
-def parse_text(
-    text: str, environment: Optional[Environment] = None
-) -> Tuple[
+def parse_text(text: str, environment: Optional[Environment] = None) -> Tuple[
     Environment,
-    List[Datasource | ImportStatement | SelectStatement | PersistStatement | ShowStatement | RawSQLStatement | None],
+    List[
+        Datasource
+        | ImportStatement
+        | SelectStatement
+        | PersistStatement
+        | ShowStatement
+        | RawSQLStatement
+        | None
+    ],
 ]:
     environment = environment or Environment()
     parser = ParseToObjects(environment=environment)

--- a/trilogy/parsing/parse_engine.py
+++ b/trilogy/parsing/parse_engine.py
@@ -1422,8 +1422,21 @@ class ParseToObjects(Transformer):
             output_datatype=DataType.STRING,
             output_purpose=Purpose.PROPERTY,
             valid_inputs={DataType.STRING},
-            arg_count=99,
+            arg_count=-1,
             # output_grain=args[0].grain,
+        )
+
+    @v_args(meta=True)
+    def union(self, meta, args):
+        args = process_function_args(args, meta=meta, environment=self.environment)
+        output_datatype = merge_datatypes([arg_to_datatype(x) for x in args])
+        return Function(
+            operator=FunctionType.UNION,
+            arguments=args,
+            output_datatype=output_datatype,
+            output_purpose=Purpose.KEY,
+            valid_inputs={*DataType},
+            arg_count=-1,
         )
 
     @v_args(meta=True)

--- a/trilogy/parsing/render.py
+++ b/trilogy/parsing/render.py
@@ -1,55 +1,52 @@
+from collections import defaultdict
 from functools import singledispatchmethod
 
 from jinja2 import Template
 
-from trilogy.constants import DEFAULT_NAMESPACE, MagicConstants, VIRTUAL_CONCEPT_PREFIX
-from trilogy.core.enums import Purpose, ConceptSource, DatePart, FunctionType
+from trilogy.constants import DEFAULT_NAMESPACE, VIRTUAL_CONCEPT_PREFIX, MagicConstants
+from trilogy.core.enums import ConceptSource, DatePart, FunctionType, Modifier, Purpose
 from trilogy.core.models import (
-    DataType,
     Address,
-    Query,
-    Concept,
-    ConceptTransform,
-    Function,
-    Grain,
-    OrderItem,
-    SelectStatement,
-    SelectItem,
-    WhereClause,
-    Conditional,
-    SubselectComparison,
-    Comparison,
-    Environment,
-    ConceptDeclarationStatement,
-    ConceptDerivation,
-    Datasource,
-    WindowItem,
-    FilterItem,
-    ColumnAssignment,
-    RawColumnExpr,
-    CaseElse,
-    CaseWhen,
-    ImportStatement,
-    Parenthetical,
     AggregateWrapper,
-    PersistStatement,
-    ListWrapper,
-    ListType,
-    TupleWrapper,
-    RowsetDerivationStatement,
-    MultiSelectStatement,
-    OrderBy,
     AlignClause,
     AlignItem,
-    RawSQLStatement,
-    NumericType,
-    MergeStatementV2,
+    CaseElse,
+    CaseWhen,
+    ColumnAssignment,
+    Comparison,
+    Concept,
+    ConceptDeclarationStatement,
+    ConceptDerivation,
+    ConceptTransform,
+    Conditional,
     CopyStatement,
+    Datasource,
+    DataType,
+    Environment,
+    FilterItem,
+    Function,
+    Grain,
+    ImportStatement,
+    ListType,
+    ListWrapper,
+    MergeStatementV2,
+    MultiSelectStatement,
+    NumericType,
+    OrderBy,
+    OrderItem,
+    Parenthetical,
+    PersistStatement,
+    Query,
+    RawColumnExpr,
+    RawSQLStatement,
+    RowsetDerivationStatement,
+    SelectItem,
+    SelectStatement,
+    SubselectComparison,
+    TupleWrapper,
+    WhereClause,
+    WindowItem,
 )
-from trilogy.core.enums import Modifier
-
-from collections import defaultdict
-
 
 QUERY_TEMPLATE = Template(
     """{% if where %}WHERE
@@ -86,10 +83,7 @@ class Renderer:
             # don't render anything that came from an import
             if concept.namespace in arg.imports:
                 continue
-            if (
-                concept.metadata
-                and concept.metadata.concept_source == ConceptSource.AUTO_DERIVED
-            ):
+            if concept.metadata and concept.metadata.concept_source == ConceptSource.AUTO_DERIVED:
                 continue
             elif not concept.lineage and concept.purpose == Purpose.CONSTANT:
                 constants.append(concept)
@@ -113,10 +107,7 @@ class Renderer:
             output_concepts += properties.get(key.name, [])
         output_concepts += metrics
 
-        rendered_concepts = [
-            self.to_string(ConceptDeclarationStatement(concept=concept))
-            for concept in output_concepts
-        ]
+        rendered_concepts = [self.to_string(ConceptDeclarationStatement(concept=concept)) for concept in output_concepts]
 
         rendered_datasources = [
             # extra padding between datasources
@@ -174,9 +165,7 @@ class Renderer:
 
     @to_string.register
     def _(self, arg: "CaseWhen"):
-        return (
-            f"""WHEN {self.to_string(arg.comparison)} THEN {self.to_string(arg.expr)}"""
-        )
+        return f"""WHEN {self.to_string(arg.comparison)} THEN {self.to_string(arg.expr)}"""
 
     @to_string.register
     def _(self, arg: "CaseElse"):
@@ -225,9 +214,7 @@ class Renderer:
     @to_string.register
     def _(self, arg: "ColumnAssignment"):
         if arg.modifiers:
-            modifiers = "".join(
-                [self.to_string(modifier) for modifier in arg.modifiers]
-            )
+            modifiers = "".join([self.to_string(modifier) for modifier in arg.modifiers])
         else:
             modifiers = ""
         if isinstance(arg.alias, str):
@@ -294,11 +281,7 @@ class Renderer:
             select_columns=[self.to_string(c) for c in arg.selection],
             where=self.to_string(arg.where_clause) if arg.where_clause else None,
             having=self.to_string(arg.having_clause) if arg.having_clause else None,
-            order_by=(
-                [self.to_string(c) for c in arg.order_by.items]
-                if arg.order_by
-                else None
-            ),
+            order_by=([self.to_string(c) for c in arg.order_by.items] if arg.order_by else None),
             limit=arg.limit,
         )
 
@@ -355,9 +338,7 @@ class Renderer:
         over = ",".join(self.to_string(c) for c in arg.over)
         order = ",".join(self.to_string(c) for c in arg.order_by)
         if over and order:
-            return (
-                f"{arg.type.value} {self.to_string(arg.content)} by {order} over {over}"
-            )
+            return f"{arg.type.value} {self.to_string(arg.content)} by {order} over {over}"
         elif over:
             return f"{arg.type.value} {self.to_string(arg.content)} over {over}"
         return f"{arg.type.value} {self.to_string(arg.content)} by {order}"

--- a/trilogy/parsing/render.py
+++ b/trilogy/parsing/render.py
@@ -83,7 +83,10 @@ class Renderer:
             # don't render anything that came from an import
             if concept.namespace in arg.imports:
                 continue
-            if concept.metadata and concept.metadata.concept_source == ConceptSource.AUTO_DERIVED:
+            if (
+                concept.metadata
+                and concept.metadata.concept_source == ConceptSource.AUTO_DERIVED
+            ):
                 continue
             elif not concept.lineage and concept.purpose == Purpose.CONSTANT:
                 constants.append(concept)
@@ -107,7 +110,10 @@ class Renderer:
             output_concepts += properties.get(key.name, [])
         output_concepts += metrics
 
-        rendered_concepts = [self.to_string(ConceptDeclarationStatement(concept=concept)) for concept in output_concepts]
+        rendered_concepts = [
+            self.to_string(ConceptDeclarationStatement(concept=concept))
+            for concept in output_concepts
+        ]
 
         rendered_datasources = [
             # extra padding between datasources
@@ -165,7 +171,9 @@ class Renderer:
 
     @to_string.register
     def _(self, arg: "CaseWhen"):
-        return f"""WHEN {self.to_string(arg.comparison)} THEN {self.to_string(arg.expr)}"""
+        return (
+            f"""WHEN {self.to_string(arg.comparison)} THEN {self.to_string(arg.expr)}"""
+        )
 
     @to_string.register
     def _(self, arg: "CaseElse"):
@@ -214,7 +222,9 @@ class Renderer:
     @to_string.register
     def _(self, arg: "ColumnAssignment"):
         if arg.modifiers:
-            modifiers = "".join([self.to_string(modifier) for modifier in arg.modifiers])
+            modifiers = "".join(
+                [self.to_string(modifier) for modifier in arg.modifiers]
+            )
         else:
             modifiers = ""
         if isinstance(arg.alias, str):
@@ -281,7 +291,11 @@ class Renderer:
             select_columns=[self.to_string(c) for c in arg.selection],
             where=self.to_string(arg.where_clause) if arg.where_clause else None,
             having=self.to_string(arg.having_clause) if arg.having_clause else None,
-            order_by=([self.to_string(c) for c in arg.order_by.items] if arg.order_by else None),
+            order_by=(
+                [self.to_string(c) for c in arg.order_by.items]
+                if arg.order_by
+                else None
+            ),
             limit=arg.limit,
         )
 
@@ -338,7 +352,9 @@ class Renderer:
         over = ",".join(self.to_string(c) for c in arg.over)
         order = ",".join(self.to_string(c) for c in arg.order_by)
         if over and order:
-            return f"{arg.type.value} {self.to_string(arg.content)} by {order} over {over}"
+            return (
+                f"{arg.type.value} {self.to_string(arg.content)} by {order} over {over}"
+            )
         elif over:
             return f"{arg.type.value} {self.to_string(arg.content)} over {over}"
         return f"{arg.type.value} {self.to_string(arg.content)} by {order}"

--- a/trilogy/parsing/trilogy.lark
+++ b/trilogy/parsing/trilogy.lark
@@ -79,6 +79,8 @@
     // raw sql statement
     rawsql_statement: "raw_sql"i "(" MULTILINE_STRING ")"
 
+
+
     // copy statement
 
     COPY_TYPE: "csv"i
@@ -166,12 +168,17 @@
     //unnesting is a function
     _UNNEST.1: "UNNEST("i
     unnest: _UNNEST expr ")"
+
+    // union statement
+    _UNION.1: "UNION("i
+    union: _UNION   (expr ",")* expr ")"
+
     //indexing into an expression is a function
     index_access: expr "[" int_lit "]"
     map_key_access: expr "[" string_lit "]"
     attr_access: expr  "." string_lit 
 
-    expr:  _constant_functions | window_item | filter_item | subselect_comparison | between_comparison |  fgroup |  aggregate_functions | unnest | _static_functions |  literal |  concept_lit  | index_access |  map_key_access | attr_access | parenthetical | expr_tuple | comparison |  alt_like 
+    expr:  _constant_functions | window_item | filter_item | subselect_comparison | between_comparison |  fgroup |  aggregate_functions | unnest | union | _static_functions |  literal |  concept_lit  | index_access |  map_key_access | attr_access | parenthetical | expr_tuple | comparison |  alt_like 
     
     // functions
     

--- a/trilogy/scripts/trilogy.py
+++ b/trilogy/scripts/trilogy.py
@@ -1,11 +1,13 @@
-from click import Path, argument, option, group, pass_context, UNPROCESSED
-from trilogy import Executor, Environment, parse
-from trilogy.dialect.enums import Dialects
 from datetime import datetime
 from pathlib import Path as PathlibPath
+
+from click import UNPROCESSED, Path, argument, group, option, pass_context
+
+from trilogy import Environment, Executor, parse
+from trilogy.constants import DEFAULT_NAMESPACE
+from trilogy.dialect.enums import Dialects
 from trilogy.hooks.query_debugger import DebuggingHook
 from trilogy.parsing.render import Renderer
-from trilogy.constants import DEFAULT_NAMESPACE
 
 
 def print_tabulate(q, tabulate):

--- a/trilogy/utility.py
+++ b/trilogy/utility.py
@@ -7,7 +7,9 @@ INT_HASH_SIZE = 16
 
 
 def string_to_hash(input: str) -> int:
-    return int(hashlib.sha256(input.encode("utf-8")).hexdigest(), 16) % 10**INT_HASH_SIZE
+    return (
+        int(hashlib.sha256(input.encode("utf-8")).hexdigest(), 16) % 10**INT_HASH_SIZE
+    )
 
 
 def unique(inputs: List, property: Union[str, Callable]) -> List[Any]:

--- a/trilogy/utility.py
+++ b/trilogy/utility.py
@@ -1,5 +1,5 @@
 import hashlib
-from typing import List, Any, Union, Callable
+from typing import Any, Callable, List, Union
 
 from trilogy.constants import DEFAULT_NAMESPACE
 
@@ -7,9 +7,7 @@ INT_HASH_SIZE = 16
 
 
 def string_to_hash(input: str) -> int:
-    return (
-        int(hashlib.sha256(input.encode("utf-8")).hexdigest(), 16) % 10**INT_HASH_SIZE
-    )
+    return int(hashlib.sha256(input.encode("utf-8")).hexdigest(), 16) % 10**INT_HASH_SIZE
 
 
 def unique(inputs: List, property: Union[str, Callable]) -> List[Any]:


### PR DESCRIPTION
## Description

Add in a union node type and a parsing hook for it.

Currently, union is implemented as a function. When a union lineage concept is detected, we will will generate a union node, which will in turn be transformed into a new UnionCTE object. The UnionCTE object is rendered as a UNION between parent nodes. 

In theory, a union will work by decomposing the union and sourcing all fields based on the decomposed union input + the rest of the optional fields independently. The "fun" bit of reuse here is making sure that a statement consists either entirely of compatible unions (the same keys, or properties of the same keys, or reachable from both union components)

The v1 implementation wires up a working 'golden path' for a union, but not any of the complex handling. The declaration syntax should also be taken with a significant grain of salt pending validation against some real use cases.

Unfortunately, also ran import formatting with ruff accidentally. Will accept that as this release contains no practical functional changes besides the experimental syntax. 

[Hello, 152 file change]. 

Add isort to CI to force sort order in future. 

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
