### PR TITLE
support date/datetime rendering

### DIFF
--- a/tests/rendering/test_rendering.py
+++ b/tests/rendering/test_rendering.py
@@ -1,3 +1,4 @@
+from datetime import date, datetime
 from pathlib import Path, PurePosixPath, PureWindowsPath
 
 from trilogy import Environment
@@ -447,6 +448,43 @@ def test_render_anon(test_environment: Environment):
     )
 
     assert test == "[1, 2, 3, 4]"
+
+
+def test_render_dates():
+
+    now = datetime.now()
+    test = Renderer().to_string(
+        Concept(
+            name=f"{VIRTUAL_CONCEPT_PREFIX}_materialized",
+            purpose=Purpose.CONSTANT,
+            datatype=DataType.INTEGER,
+            lineage=Function(
+                arguments=[now],
+                operator=FunctionType.CONSTANT,
+                output_purpose=Purpose.CONSTANT,
+                output_datatype=DataType.DATETIME,
+            ),
+        )
+    )
+
+    assert test == f"'{now.isoformat()}'::datetime"
+
+    today = date.today()
+    test = Renderer().to_string(
+        Concept(
+            name=f"{VIRTUAL_CONCEPT_PREFIX}_materialized",
+            purpose=Purpose.CONSTANT,
+            datatype=DataType.INTEGER,
+            lineage=Function(
+                arguments=[today],
+                operator=FunctionType.CONSTANT,
+                output_purpose=Purpose.CONSTANT,
+                output_datatype=DataType.DATE,
+            ),
+        )
+    )
+
+    assert test == f"'{today.isoformat()}'::date"
 
 
 def test_render_merge():

--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -4,6 +4,6 @@ from trilogy.dialect.enums import Dialects
 from trilogy.executor import Executor
 from trilogy.parser import parse
 
-__version__ = "0.0.2.51"
+__version__ = "0.0.2.52"
 
 __all__ = ["parse", "Executor", "Dialects", "Environment", "CONFIG"]

--- a/trilogy/parsing/render.py
+++ b/trilogy/parsing/render.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from datetime import date, datetime
 from functools import singledispatchmethod
 
 from jinja2 import Template
@@ -272,6 +273,14 @@ class Renderer:
     @to_string.register
     def _(self, arg: DataType):
         return arg.value
+
+    @to_string.register
+    def _(self, arg: date):
+        return f"'{arg.isoformat()}'::date"
+
+    @to_string.register
+    def _(self, arg: datetime):
+        return f"'{arg.isoformat()}'::datetime"
 
     @to_string.register
     def _(self, arg: ConceptDerivation):


### PR DESCRIPTION
## Description

Micro-release: ensure we can render date/datetime literals back to Trilogy. Since we don't have a dedicated format for parsing, render them back as cast strings for the moment. 

TODO: deal with timezones at some point...

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
