### PR TITLE
Fix Capitalized IS handlig

### DIFF
--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -4,6 +4,6 @@ from trilogy.dialect.enums import Dialects
 from trilogy.executor import Executor
 from trilogy.parser import parse
 
-__version__ = "0.0.3.30"
+__version__ = "0.0.3.31"
 
 __all__ = ["parse", "Executor", "Dialects", "Environment", "CONFIG"]

--- a/trilogy/core/enums.py
+++ b/trilogy/core/enums.py
@@ -287,6 +287,8 @@ class ComparisonOperator(Enum):
                 return ComparisonOperator.IS_NOT
             if value == ["in"]:
                 return ComparisonOperator.IN
+        if str(value).lower() != str(value):
+            return ComparisonOperator(str(value).lower())
         return super()._missing_(str(value).lower())
 
 

--- a/trilogy/parsing/parse_engine.py
+++ b/trilogy/parsing/parse_engine.py
@@ -961,7 +961,7 @@ class ParseToObjects(Transformer):
             lookup = address
             if lookup not in self.environment.config.import_resolver.content:
                 raise ImportError(
-                    f"Unable to import file {lookup}, not found in imsport resolver"
+                    f"Unable to import file {lookup}, not resolvable from provided source files."
                 )
             text = self.environment.config.import_resolver.content[lookup]
         else:

--- a/trilogy/std/display.preql
+++ b/trilogy/std/display.preql
@@ -1,0 +1,3 @@
+
+
+type percent float; # Percentage value


### PR DESCRIPTION
## Description

`IS NULL` would error out vs `is NULL` because the comparison enum parsing was off.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
