### PR TITLE
force filter window promotion

### DIFF
--- a/tests/modeling/tpc_h/adhoc03.preql
+++ b/tests/modeling/tpc_h/adhoc03.preql
@@ -1,4 +1,4 @@
 import lineitem;
 
 where rank order.customer.id by sum(order.total_price) desc <= 10
-select order.id.count;
+select count(order.id) as order_count, order.id.count as order_count_two;

--- a/tests/modeling/tpc_h/adhoc03.preql
+++ b/tests/modeling/tpc_h/adhoc03.preql
@@ -1,0 +1,4 @@
+import lineitem;
+
+where rank order.customer.id by sum(order.total_price) desc <= 10
+select order.id.count;

--- a/tests/modeling/tpc_h/test_tpch_queries.py
+++ b/tests/modeling/tpc_h/test_tpch_queries.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from pytest import raises
 
-from trilogy import parse
+from trilogy import parse, Executor, Dialects
 from trilogy.core.exceptions import InvalidSyntaxException
 from trilogy.core.models.environment import Environment
 
@@ -15,3 +15,17 @@ def test_adhoc02_error():
         text = f.read()
         with raises(InvalidSyntaxException):
             env, queries = parse(text, env)
+
+
+def test_adhoc03():
+    env = Environment(working_path=working_path)
+    with open(working_path / "adhoc03.preql") as f:
+        text = f.read()
+
+    
+
+    engine: Executor = Dialects.DUCK_DB.default_executor(
+        environment=env, hooks=[]
+    )
+
+    results = engine.execute_query(text)

--- a/tests/modeling/tpc_h/test_tpch_queries.py
+++ b/tests/modeling/tpc_h/test_tpch_queries.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from pytest import raises
 
-from trilogy import parse, Executor, Dialects
+from trilogy import Dialects, Executor, parse
 from trilogy.core.exceptions import InvalidSyntaxException
 from trilogy.core.models.environment import Environment
 from trilogy.hooks import DebuggingHook
@@ -19,7 +19,6 @@ def test_adhoc02_error():
 
 
 def test_adhoc03():
-    x = DebuggingHook()
     env = Environment(working_path=working_path)
     with open(working_path / "adhoc03.preql") as f:
         text = f.read()

--- a/tests/modeling/tpc_h/test_tpch_queries.py
+++ b/tests/modeling/tpc_h/test_tpch_queries.py
@@ -5,6 +5,7 @@ from pytest import raises
 from trilogy import parse, Executor, Dialects
 from trilogy.core.exceptions import InvalidSyntaxException
 from trilogy.core.models.environment import Environment
+from trilogy.hooks import DebuggingHook
 
 working_path = Path(__file__).parent
 
@@ -18,14 +19,13 @@ def test_adhoc02_error():
 
 
 def test_adhoc03():
+    x = DebuggingHook()
     env = Environment(working_path=working_path)
     with open(working_path / "adhoc03.preql") as f:
         text = f.read()
 
-    
+    engine: Executor = Dialects.DUCK_DB.default_executor(environment=env, hooks=[])
 
-    engine: Executor = Dialects.DUCK_DB.default_executor(
-        environment=env, hooks=[]
-    )
-
-    results = engine.execute_query(text)
+    results = engine.execute_query(text).fetchall()
+    assert results[0].order_count == 289
+    assert results[0].order_count_two == 289

--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -4,6 +4,6 @@ from trilogy.dialect.enums import Dialects
 from trilogy.executor import Executor
 from trilogy.parser import parse
 
-__version__ = "0.0.3.40"
+__version__ = "0.0.3.41"
 
 __all__ = ["parse", "Executor", "Dialects", "Environment", "CONFIG"]

--- a/trilogy/core/environment_helpers.py
+++ b/trilogy/core/environment_helpers.py
@@ -1,7 +1,7 @@
 from trilogy.constants import DEFAULT_NAMESPACE
 from trilogy.core.enums import ConceptSource, DatePart, FunctionType, Purpose
 from trilogy.core.functions import AttrAccess
-from trilogy.core.models.author import Concept, Function, Metadata, TraitDataType, Grain
+from trilogy.core.models.author import Concept, Function, Grain, Metadata, TraitDataType
 from trilogy.core.models.core import DataType, StructType, arg_to_datatype
 from trilogy.core.models.environment import Environment
 from trilogy.parsing.common import Meta

--- a/trilogy/core/environment_helpers.py
+++ b/trilogy/core/environment_helpers.py
@@ -1,7 +1,7 @@
 from trilogy.constants import DEFAULT_NAMESPACE
 from trilogy.core.enums import ConceptSource, DatePart, FunctionType, Purpose
 from trilogy.core.functions import AttrAccess
-from trilogy.core.models.author import Concept, Function, Metadata, TraitDataType
+from trilogy.core.models.author import Concept, Function, Metadata, TraitDataType, Grain
 from trilogy.core.models.core import DataType, StructType, arg_to_datatype
 from trilogy.core.models.environment import Environment
 from trilogy.parsing.common import Meta
@@ -182,11 +182,9 @@ def generate_key_concepts(concept: Concept, environment: Environment):
             datatype=DataType.INTEGER,
             purpose=default_type,
             lineage=const_function,
-            grain=concept.grain,
+            grain=Grain(),
             namespace=concept.namespace,
-            keys={
-                concept.address,
-            },
+            keys={},
             metadata=Metadata(
                 description=f"Auto-derived integer. The {ftype.value} of {concept.address}, {base_description}",
                 line_number=base_line_number,

--- a/trilogy/core/environment_helpers.py
+++ b/trilogy/core/environment_helpers.py
@@ -184,7 +184,7 @@ def generate_key_concepts(concept: Concept, environment: Environment):
             lineage=const_function,
             grain=Grain(),
             namespace=concept.namespace,
-            keys={},
+            keys=set(),
             metadata=Metadata(
                 description=f"Auto-derived integer. The {ftype.value} of {concept.address}, {base_description}",
                 line_number=base_line_number,

--- a/trilogy/core/models/build.py
+++ b/trilogy/core/models/build.py
@@ -1697,6 +1697,7 @@ class Factory:
 
     @build.register
     def _(self, base: WhereClause) -> BuildWhereClause:
+
         return BuildWhereClause.model_construct(
             conditional=self.build(base.conditional)
         )
@@ -1756,14 +1757,14 @@ class Factory:
         from trilogy.parsing.common import arbitrary_to_concept
 
         left = base.left
-        if isinstance(left, AggregateWrapper):
+        if isinstance(left, (AggregateWrapper, WindowItem, FilterItem)):
             left_c = arbitrary_to_concept(
                 left,
                 environment=self.environment,
             )
             left = left_c  # type: ignore
         right = base.right
-        if isinstance(right, AggregateWrapper):
+        if isinstance(right, (AggregateWrapper, WindowItem, FilterItem)):
             right_c = arbitrary_to_concept(
                 right,
                 environment=self.environment,


### PR DESCRIPTION
## Description

This is a patch to a larger problem, which is that many complex objects need to be promoted to a concept to do proper placement in SQL generation.

(otherwise we end up with stuff like window in where and duckdb complaining).

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
