### PR TITLE
Regex Functions and More Quotes

### DIFF
--- a/tests/complex/test_complex_source_fetching.py
+++ b/tests/complex/test_complex_source_fetching.py
@@ -62,7 +62,7 @@ def test_aggregate_to_grain(stackoverflow_environment: Environment):
             rendered = generator.render_concept_sql(build_avg_post_length, cte)
 
             assert re.search(
-                r'avg\([0-9A-z\_]+\."post_length"\) as "user_avg_post_length"',
+                r'avg\(["0-9A-z\_]+\."post_length"\) as "user_avg_post_length"',
                 rendered,
             ), generator.compile_statement(query)
             found = True

--- a/tests/engine/demo/test_demo_duckdb.py
+++ b/tests/engine/demo/test_demo_duckdb.py
@@ -441,16 +441,16 @@ ORDER BY
         results.strip()
         == """
 SELECT
-    raw_data."passengerid" as "passenger_id",
-    raw_data."passengerid" + 1 as "id_one",
-    raw_data."name" as "passenger_name"
+    "raw_data"."passengerid" as "passenger_id",
+    "raw_data"."passengerid" + 1 as "id_one",
+    "raw_data"."name" as "passenger_name"
 FROM
-    raw_titanic as raw_data
+    "raw_titanic" as "raw_data"
 WHERE
-     CASE WHEN raw_data."name" like '%a%' THEN True ELSE False END = True
+     CASE WHEN "raw_data"."name" like '%a%' THEN True ELSE False END = True
 
 ORDER BY 
-    raw_data."name" asc""".strip()
+    "raw_data"."name" asc""".strip()
     )
 
 
@@ -551,14 +551,14 @@ def test_demo_brevity(base_test_env, engine: Executor):
     assert (
         sql[-1].strip()
         == """SELECT
-    raw_data."survived" as "passenger_survived",
-    count(raw_data."passengerid") as "passenger_id_count",
-    count(raw_data."passengerid") as "passenger_count_alt",
-    count(raw_data."passengerid") as "passenger_count_alt_2"
+    "raw_data"."survived" as "passenger_survived",
+    count("raw_data"."passengerid") as "passenger_id_count",
+    count("raw_data"."passengerid") as "passenger_count_alt",
+    count("raw_data"."passengerid") as "passenger_count_alt_2"
 FROM
-    raw_titanic as raw_data
+    "raw_titanic" as "raw_data"
 GROUP BY 
-    raw_data."survived"
+    "raw_data"."survived"
 """.strip()
     )
 

--- a/tests/engine/test_duckdb.py
+++ b/tests/engine/test_duckdb.py
@@ -200,7 +200,7 @@ order by item desc;
     assert len(parsed) == 1
     results = duckdb_engine.execute_text(test)[0].fetchall()
     assert len(results) == 1
-    assert 'fact_items."item" as "item"' in results[0]["__preql_internal_query_text"]
+    assert '"fact_items"."item" as "item"' in results[0]["__preql_internal_query_text"]
 
 
 def test_rollback(duckdb_engine: Executor, expected_results):

--- a/tests/engine/test_snowflake.py
+++ b/tests/engine/test_snowflake.py
@@ -66,7 +66,7 @@ select zeta order by zeta asc;"""
     results2 = snowflake_engine.generate_sql(text)[0]
     assert (
         re.search(
-            r'LEFT JOIN LATERAL flatten\(\w+\."array_int"\) as unnest_wrapper \( unnest1, unnest2, unnest3, unnest4, "zeta"\)',
+            r'LEFT JOIN LATERAL flatten\([A-z"]+."array_int"\) as unnest_wrapper \( unnest1, unnest2, unnest3, unnest4, "zeta"\)',
             results2,
         )
         is not None

--- a/tests/generators/test_merge_concept_node.py
+++ b/tests/generators/test_merge_concept_node.py
@@ -105,8 +105,8 @@ address num1;
         compiled = bd.compile_statement(query)
         assert query_to_lines(compiled) == query_to_lines(
             """SELECT
-             	env2_num1.`one` as `env2_one`,
-             	env2_num1.`one` as `env2_one`
+             	`env2_num1`.`one` as `env2_one`,
+             	`env2_num1`.`one` as `env2_one`
              FROM
-             	num1 as env2_num1"""
+             	`num1` as `env2_num1`"""
         ), compiled

--- a/tests/modeling/faa/test_faa.py
+++ b/tests/modeling/faa/test_faa.py
@@ -22,12 +22,12 @@ select
     # if we don't have this group by, we will get the wrong result
     assert (
         '''SELECT
-    cheerful."carrier_code" as "carrier_code",
-    cheerful."carrier_name" as "carrier_name"
+    "cheerful"."carrier_code" as "carrier_code",
+    "cheerful"."carrier_name" as "carrier_name"
 FROM
-    cheerful
+    "cheerful"
 GROUP BY 
-    cheerful."carrier_code",
-    cheerful."carrier_name"'''
+    "cheerful"."carrier_code",
+    "cheerful"."carrier_name"'''
         in sql
     )

--- a/tests/modeling/tpc_ds_duckdb/test_queries.py
+++ b/tests/modeling/tpc_ds_duckdb/test_queries.py
@@ -208,7 +208,7 @@ def test_ninety_five(engine):
 
 def test_ninety_seven(engine):
     query = run_query(engine, 97)
-    assert len(query) < 4200, query
+    assert len(query) < 4350, query
 
 
 def test_ninety_eight(engine):

--- a/tests/modeling/tpc_ds_duckdb/zquery01.log
+++ b/tests/modeling/tpc_ds_duckdb/zquery01.log
@@ -1,49 +1,49 @@
 query_id = 1
-gen_length = 1849
+gen_length = 1935
 generated_sql = """
 
 WITH 
 thoughtful as (
 SELECT
-    returns_customer_customers.\"C_CUSTOMER_ID\" as \"returns_customer_text_id\",
-    returns_store_returns.\"SR_ITEM_SK\" as \"returns_item_id\",
-    returns_store_returns.\"SR_RETURN_AMT\" as \"returns_return_amount\",
-    returns_store_returns.\"SR_TICKET_NUMBER\" as \"returns_store_sales_ticket_number\",
-    returns_store_store.\"S_STORE_SK\" as \"returns_store_id\"
+    \"returns_customer_customers\".\"C_CUSTOMER_ID\" as \"returns_customer_text_id\",
+    \"returns_store_returns\".\"SR_ITEM_SK\" as \"returns_item_id\",
+    \"returns_store_returns\".\"SR_RETURN_AMT\" as \"returns_return_amount\",
+    \"returns_store_returns\".\"SR_TICKET_NUMBER\" as \"returns_store_sales_ticket_number\",
+    \"returns_store_store\".\"S_STORE_SK\" as \"returns_store_id\"
 FROM
-    memory.store_returns as returns_store_returns
-    INNER JOIN memory.store as returns_store_store on returns_store_returns.\"SR_STORE_SK\" = returns_store_store.\"S_STORE_SK\"
-    INNER JOIN memory.customer as returns_customer_customers on returns_store_returns.\"SR_CUSTOMER_SK\" = returns_customer_customers.\"C_CUSTOMER_SK\"
-    INNER JOIN memory.date_dim as returns_return_date_date on returns_store_returns.\"SR_RETURNED_DATE_SK\" = returns_return_date_date.\"D_DATE_SK\"
+    \"memory\".\"store_returns\" as \"returns_store_returns\"
+    INNER JOIN \"memory\".\"store\" as \"returns_store_store\" on \"returns_store_returns\".\"SR_STORE_SK\" = \"returns_store_store\".\"S_STORE_SK\"
+    INNER JOIN \"memory\".\"customer\" as \"returns_customer_customers\" on \"returns_store_returns\".\"SR_CUSTOMER_SK\" = \"returns_customer_customers\".\"C_CUSTOMER_SK\"
+    INNER JOIN \"memory\".\"date_dim\" as \"returns_return_date_date\" on \"returns_store_returns\".\"SR_RETURNED_DATE_SK\" = \"returns_return_date_date\".\"D_DATE_SK\"
 WHERE
-    returns_store_store.\"S_STATE\" = 'TN' and cast(returns_return_date_date.\"D_YEAR\" as int) = 2000
+    \"returns_store_store\".\"S_STATE\" = 'TN' and cast(\"returns_return_date_date\".\"D_YEAR\" as int) = 2000
 ),
 cooperative as (
 SELECT
-    sum(thoughtful.\"returns_return_amount\") as \"total_returns\",
-    thoughtful.\"returns_customer_text_id\" as \"returns_customer_text_id\",
-    thoughtful.\"returns_store_id\" as \"returns_store_id\"
+    \"thoughtful\".\"returns_customer_text_id\" as \"returns_customer_text_id\",
+    \"thoughtful\".\"returns_store_id\" as \"returns_store_id\",
+    sum(\"thoughtful\".\"returns_return_amount\") as \"total_returns\"
 FROM
-    thoughtful
+    \"thoughtful\"
 GROUP BY 
-    thoughtful.\"returns_customer_text_id\",
-    thoughtful.\"returns_store_id\"),
+    \"thoughtful\".\"returns_customer_text_id\",
+    \"thoughtful\".\"returns_store_id\"),
 questionable as (
 SELECT
-    avg(cooperative.\"total_returns\") as \"avg_store_returns\",
-    cooperative.\"returns_store_id\" as \"returns_store_id\"
+    \"cooperative\".\"returns_store_id\" as \"returns_store_id\",
+    avg(\"cooperative\".\"total_returns\") as \"avg_store_returns\"
 FROM
-    cooperative
+    \"cooperative\"
 GROUP BY 
-    cooperative.\"returns_store_id\")
+    \"cooperative\".\"returns_store_id\")
 SELECT
-    cooperative.\"returns_customer_text_id\" as \"returns_customer_text_id\"
+    \"cooperative\".\"returns_customer_text_id\" as \"returns_customer_text_id\"
 FROM
-    questionable
-    INNER JOIN cooperative on questionable.\"returns_store_id\" = cooperative.\"returns_store_id\"
+    \"questionable\"
+    INNER JOIN \"cooperative\" on \"questionable\".\"returns_store_id\" = \"cooperative\".\"returns_store_id\"
 WHERE
-    cooperative.\"total_returns\" > ( 1.2 * questionable.\"avg_store_returns\" )
+    \"cooperative\".\"total_returns\" > ( 1.2 * \"questionable\".\"avg_store_returns\" )
 
 ORDER BY 
-    cooperative.\"returns_customer_text_id\" asc
+    \"cooperative\".\"returns_customer_text_id\" asc
 LIMIT (100)"""

--- a/tests/modeling/tpc_ds_duckdb/zquery02.log
+++ b/tests/modeling/tpc_ds_duckdb/zquery02.log
@@ -1,175 +1,175 @@
 query_id = 2
-gen_length = 8342
+gen_length = 8626
 generated_sql = """
 
 WITH 
 wakeful as (
 SELECT
-    date_date.\"D_WEEK_SEQ\" as \"relevent_week_seq\"
+    \"date_date\".\"D_WEEK_SEQ\" as \"relevent_week_seq\"
 FROM
-    memory.date_dim as date_date
+    \"memory\".\"date_dim\" as \"date_date\"
 WHERE
-    cast(date_date.\"D_YEAR\" as int) in (2001,2002)
+    cast(\"date_date\".\"D_YEAR\" as int) in (2001,2002)
 ),
 cheerful as (
 SELECT
-    wakeful.\"relevent_week_seq\" as \"relevent_week_seq\"
+    \"wakeful\".\"relevent_week_seq\" as \"relevent_week_seq\"
 FROM
-    wakeful
+    \"wakeful\"
 GROUP BY 
-    wakeful.\"relevent_week_seq\"),
+    \"wakeful\".\"relevent_week_seq\"),
 abundant as (
 SELECT
-    date_date.\"D_DATE_SK\" as \"date_id\",
-    date_date.\"D_DOW\" as \"date_day_of_week\",
-    date_date.\"D_WEEK_SEQ\" as \"date_week_seq\",
-    web_sales_web_sales.\"WS_EXT_SALES_PRICE\" as \"web_sales_extra_sales_price\",
-    web_sales_web_sales.\"WS_ITEM_SK\" as \"web_sales_item_id\",
-    web_sales_web_sales.\"WS_ORDER_NUMBER\" as \"web_sales_order_number\"
+    \"date_date\".\"D_DATE_SK\" as \"date_id\",
+    \"date_date\".\"D_DOW\" as \"date_day_of_week\",
+    \"date_date\".\"D_WEEK_SEQ\" as \"date_week_seq\",
+    \"web_sales_web_sales\".\"WS_EXT_SALES_PRICE\" as \"web_sales_extra_sales_price\",
+    \"web_sales_web_sales\".\"WS_ITEM_SK\" as \"web_sales_item_id\",
+    \"web_sales_web_sales\".\"WS_ORDER_NUMBER\" as \"web_sales_order_number\"
 FROM
-    memory.date_dim as date_date
-    LEFT OUTER JOIN memory.web_sales as web_sales_web_sales on date_date.\"D_DATE_SK\" = web_sales_web_sales.\"WS_SOLD_DATE_SK\"
+    \"memory\".\"date_dim\" as \"date_date\"
+    LEFT OUTER JOIN \"memory\".\"web_sales\" as \"web_sales_web_sales\" on \"date_date\".\"D_DATE_SK\" = \"web_sales_web_sales\".\"WS_SOLD_DATE_SK\"
 WHERE
-    date_date.\"D_WEEK_SEQ\" in (select cheerful.\"relevent_week_seq\" from cheerful where cheerful.\"relevent_week_seq\" is not null)
+    \"date_date\".\"D_WEEK_SEQ\" in (select cheerful.\"relevent_week_seq\" from cheerful where cheerful.\"relevent_week_seq\" is not null)
 ),
 thoughtful as (
 SELECT
-    catalog_sales_catalog_sales.\"CS_EXT_SALES_PRICE\" as \"catalog_sales_extra_sales_price\",
-    catalog_sales_catalog_sales.\"CS_ITEM_SK\" as \"catalog_sales_item_id\",
-    catalog_sales_catalog_sales.\"CS_ORDER_NUMBER\" as \"catalog_sales_order_number\",
-    date_date.\"D_DATE_SK\" as \"date_id\",
-    date_date.\"D_DOW\" as \"date_day_of_week\",
-    date_date.\"D_WEEK_SEQ\" as \"date_week_seq\"
+    \"catalog_sales_catalog_sales\".\"CS_EXT_SALES_PRICE\" as \"catalog_sales_extra_sales_price\",
+    \"catalog_sales_catalog_sales\".\"CS_ITEM_SK\" as \"catalog_sales_item_id\",
+    \"catalog_sales_catalog_sales\".\"CS_ORDER_NUMBER\" as \"catalog_sales_order_number\",
+    \"date_date\".\"D_DATE_SK\" as \"date_id\",
+    \"date_date\".\"D_DOW\" as \"date_day_of_week\",
+    \"date_date\".\"D_WEEK_SEQ\" as \"date_week_seq\"
 FROM
-    memory.date_dim as date_date
-    LEFT OUTER JOIN memory.catalog_sales as catalog_sales_catalog_sales on date_date.\"D_DATE_SK\" = catalog_sales_catalog_sales.\"CS_SOLD_DATE_SK\"
+    \"memory\".\"date_dim\" as \"date_date\"
+    LEFT OUTER JOIN \"memory\".\"catalog_sales\" as \"catalog_sales_catalog_sales\" on \"date_date\".\"D_DATE_SK\" = \"catalog_sales_catalog_sales\".\"CS_SOLD_DATE_SK\"
 WHERE
-    date_date.\"D_WEEK_SEQ\" in (select cheerful.\"relevent_week_seq\" from cheerful where cheerful.\"relevent_week_seq\" is not null)
+    \"date_date\".\"D_WEEK_SEQ\" in (select cheerful.\"relevent_week_seq\" from cheerful where cheerful.\"relevent_week_seq\" is not null)
 ),
 uneven as (
 SELECT
-    abundant.\"date_week_seq\" as \"date_week_seq\",
+    \"abundant\".\"date_week_seq\" as \"date_week_seq\",
     sum(CASE
-	WHEN abundant.\"date_day_of_week\" = 0 THEN abundant.\"web_sales_extra_sales_price\"
+	WHEN \"abundant\".\"date_day_of_week\" = 0 THEN \"abundant\".\"web_sales_extra_sales_price\"
 	ELSE 0.0
 	END) as \"_virt_agg_sum_1430965672846720\",
     sum(CASE
-	WHEN abundant.\"date_day_of_week\" = 1 THEN abundant.\"web_sales_extra_sales_price\"
+	WHEN \"abundant\".\"date_day_of_week\" = 1 THEN \"abundant\".\"web_sales_extra_sales_price\"
 	ELSE 0.0
 	END) as \"_virt_agg_sum_9180600749516014\",
     sum(CASE
-	WHEN abundant.\"date_day_of_week\" = 2 THEN abundant.\"web_sales_extra_sales_price\"
+	WHEN \"abundant\".\"date_day_of_week\" = 2 THEN \"abundant\".\"web_sales_extra_sales_price\"
 	ELSE 0.0
 	END) as \"_virt_agg_sum_5843356674090839\",
     sum(CASE
-	WHEN abundant.\"date_day_of_week\" = 3 THEN abundant.\"web_sales_extra_sales_price\"
+	WHEN \"abundant\".\"date_day_of_week\" = 3 THEN \"abundant\".\"web_sales_extra_sales_price\"
 	ELSE 0.0
 	END) as \"_virt_agg_sum_7719154804838251\",
     sum(CASE
-	WHEN abundant.\"date_day_of_week\" = 4 THEN abundant.\"web_sales_extra_sales_price\"
+	WHEN \"abundant\".\"date_day_of_week\" = 4 THEN \"abundant\".\"web_sales_extra_sales_price\"
 	ELSE 0.0
 	END) as \"_virt_agg_sum_2215622277191905\",
     sum(CASE
-	WHEN abundant.\"date_day_of_week\" = 5 THEN abundant.\"web_sales_extra_sales_price\"
+	WHEN \"abundant\".\"date_day_of_week\" = 5 THEN \"abundant\".\"web_sales_extra_sales_price\"
 	ELSE 0.0
 	END) as \"_virt_agg_sum_591087579650056\",
     sum(CASE
-	WHEN abundant.\"date_day_of_week\" = 6 THEN abundant.\"web_sales_extra_sales_price\"
+	WHEN \"abundant\".\"date_day_of_week\" = 6 THEN \"abundant\".\"web_sales_extra_sales_price\"
 	ELSE 0.0
 	END) as \"_virt_agg_sum_864268046946303\"
 FROM
-    abundant
+    \"abundant\"
 GROUP BY 
-    abundant.\"date_week_seq\"),
+    \"abundant\".\"date_week_seq\"),
 cooperative as (
 SELECT
+    \"thoughtful\".\"date_week_seq\" as \"date_week_seq\",
     sum(CASE
-	WHEN thoughtful.\"date_day_of_week\" = 0 THEN thoughtful.\"catalog_sales_extra_sales_price\"
+	WHEN \"thoughtful\".\"date_day_of_week\" = 0 THEN \"thoughtful\".\"catalog_sales_extra_sales_price\"
 	ELSE 0.0
 	END) as \"_virt_agg_sum_9100576239670120\",
     sum(CASE
-	WHEN thoughtful.\"date_day_of_week\" = 1 THEN thoughtful.\"catalog_sales_extra_sales_price\"
+	WHEN \"thoughtful\".\"date_day_of_week\" = 1 THEN \"thoughtful\".\"catalog_sales_extra_sales_price\"
 	ELSE 0.0
 	END) as \"_virt_agg_sum_4284672965134623\",
     sum(CASE
-	WHEN thoughtful.\"date_day_of_week\" = 2 THEN thoughtful.\"catalog_sales_extra_sales_price\"
+	WHEN \"thoughtful\".\"date_day_of_week\" = 2 THEN \"thoughtful\".\"catalog_sales_extra_sales_price\"
 	ELSE 0.0
 	END) as \"_virt_agg_sum_4203843215898205\",
     sum(CASE
-	WHEN thoughtful.\"date_day_of_week\" = 3 THEN thoughtful.\"catalog_sales_extra_sales_price\"
+	WHEN \"thoughtful\".\"date_day_of_week\" = 3 THEN \"thoughtful\".\"catalog_sales_extra_sales_price\"
 	ELSE 0.0
 	END) as \"_virt_agg_sum_3491982279232038\",
     sum(CASE
-	WHEN thoughtful.\"date_day_of_week\" = 4 THEN thoughtful.\"catalog_sales_extra_sales_price\"
+	WHEN \"thoughtful\".\"date_day_of_week\" = 4 THEN \"thoughtful\".\"catalog_sales_extra_sales_price\"
 	ELSE 0.0
 	END) as \"_virt_agg_sum_8193012987854847\",
     sum(CASE
-	WHEN thoughtful.\"date_day_of_week\" = 5 THEN thoughtful.\"catalog_sales_extra_sales_price\"
+	WHEN \"thoughtful\".\"date_day_of_week\" = 5 THEN \"thoughtful\".\"catalog_sales_extra_sales_price\"
 	ELSE 0.0
 	END) as \"_virt_agg_sum_8649824413129684\",
     sum(CASE
-	WHEN thoughtful.\"date_day_of_week\" = 6 THEN thoughtful.\"catalog_sales_extra_sales_price\"
+	WHEN \"thoughtful\".\"date_day_of_week\" = 6 THEN \"thoughtful\".\"catalog_sales_extra_sales_price\"
 	ELSE 0.0
-	END) as \"_virt_agg_sum_2181143902401134\",
-    thoughtful.\"date_week_seq\" as \"date_week_seq\"
+	END) as \"_virt_agg_sum_2181143902401134\"
 FROM
-    thoughtful
+    \"thoughtful\"
 GROUP BY 
-    thoughtful.\"date_week_seq\"),
+    \"thoughtful\".\"date_week_seq\"),
 yummy as (
 SELECT
-    cooperative.\"date_week_seq\" as \"yearly_agg_date_week_seq\",
-    uneven.\"_virt_agg_sum_1430965672846720\" + cooperative.\"_virt_agg_sum_9100576239670120\" as \"yearly_agg_sunday_sales\",
-    uneven.\"_virt_agg_sum_2215622277191905\" + cooperative.\"_virt_agg_sum_8193012987854847\" as \"yearly_agg_thursday_sales\",
-    uneven.\"_virt_agg_sum_5843356674090839\" + cooperative.\"_virt_agg_sum_4203843215898205\" as \"yearly_agg_tuesday_sales\",
-    uneven.\"_virt_agg_sum_591087579650056\" + cooperative.\"_virt_agg_sum_8649824413129684\" as \"yearly_agg_friday_sales\",
-    uneven.\"_virt_agg_sum_7719154804838251\" + cooperative.\"_virt_agg_sum_3491982279232038\" as \"yearly_agg_wednesday_sales\",
-    uneven.\"_virt_agg_sum_864268046946303\" + cooperative.\"_virt_agg_sum_2181143902401134\" as \"yearly_agg_saturday_sales\",
-    uneven.\"_virt_agg_sum_9180600749516014\" + cooperative.\"_virt_agg_sum_4284672965134623\" as \"yearly_agg_monday_sales\"
+    \"cooperative\".\"date_week_seq\" as \"yearly_agg_date_week_seq\",
+    \"uneven\".\"_virt_agg_sum_1430965672846720\" + \"cooperative\".\"_virt_agg_sum_9100576239670120\" as \"yearly_agg_sunday_sales\",
+    \"uneven\".\"_virt_agg_sum_2215622277191905\" + \"cooperative\".\"_virt_agg_sum_8193012987854847\" as \"yearly_agg_thursday_sales\",
+    \"uneven\".\"_virt_agg_sum_5843356674090839\" + \"cooperative\".\"_virt_agg_sum_4203843215898205\" as \"yearly_agg_tuesday_sales\",
+    \"uneven\".\"_virt_agg_sum_591087579650056\" + \"cooperative\".\"_virt_agg_sum_8649824413129684\" as \"yearly_agg_friday_sales\",
+    \"uneven\".\"_virt_agg_sum_7719154804838251\" + \"cooperative\".\"_virt_agg_sum_3491982279232038\" as \"yearly_agg_wednesday_sales\",
+    \"uneven\".\"_virt_agg_sum_864268046946303\" + \"cooperative\".\"_virt_agg_sum_2181143902401134\" as \"yearly_agg_saturday_sales\",
+    \"uneven\".\"_virt_agg_sum_9180600749516014\" + \"cooperative\".\"_virt_agg_sum_4284672965134623\" as \"yearly_agg_monday_sales\"
 FROM
-    cooperative
-    INNER JOIN uneven on cooperative.\"date_week_seq\" = uneven.\"date_week_seq\"),
+    \"cooperative\"
+    INNER JOIN \"uneven\" on \"cooperative\".\"date_week_seq\" = \"uneven\".\"date_week_seq\"),
 juicy as (
 SELECT
-    lead(yummy.\"yearly_agg_friday_sales\", 53) over (order by yummy.\"yearly_agg_date_week_seq\" asc ) as \"_virt_window_lead_840125329441915\",
-    lead(yummy.\"yearly_agg_monday_sales\", 53) over (order by yummy.\"yearly_agg_date_week_seq\" asc ) as \"_virt_window_lead_1831355371097660\",
-    lead(yummy.\"yearly_agg_saturday_sales\", 53) over (order by yummy.\"yearly_agg_date_week_seq\" asc ) as \"_virt_window_lead_2858098921271386\",
-    lead(yummy.\"yearly_agg_sunday_sales\", 53) over (order by yummy.\"yearly_agg_date_week_seq\" asc ) as \"_virt_window_lead_4780721583408487\",
-    lead(yummy.\"yearly_agg_thursday_sales\", 53) over (order by yummy.\"yearly_agg_date_week_seq\" asc ) as \"_virt_window_lead_8474766537336377\",
-    lead(yummy.\"yearly_agg_tuesday_sales\", 53) over (order by yummy.\"yearly_agg_date_week_seq\" asc ) as \"_virt_window_lead_3375245317408835\",
-    lead(yummy.\"yearly_agg_wednesday_sales\", 53) over (order by yummy.\"yearly_agg_date_week_seq\" asc ) as \"_virt_window_lead_6759541963679355\",
-    yummy.\"yearly_agg_date_week_seq\" as \"yearly_agg_date_week_seq\",
-    yummy.\"yearly_agg_monday_sales\" as \"yearly_agg_monday_sales\"
+    \"yummy\".\"yearly_agg_date_week_seq\" as \"yearly_agg_date_week_seq\",
+    \"yummy\".\"yearly_agg_monday_sales\" as \"yearly_agg_monday_sales\",
+    lead(\"yummy\".\"yearly_agg_friday_sales\", 53) over (order by \"yummy\".\"yearly_agg_date_week_seq\" asc ) as \"_virt_window_lead_840125329441915\",
+    lead(\"yummy\".\"yearly_agg_monday_sales\", 53) over (order by \"yummy\".\"yearly_agg_date_week_seq\" asc ) as \"_virt_window_lead_1831355371097660\",
+    lead(\"yummy\".\"yearly_agg_saturday_sales\", 53) over (order by \"yummy\".\"yearly_agg_date_week_seq\" asc ) as \"_virt_window_lead_2858098921271386\",
+    lead(\"yummy\".\"yearly_agg_sunday_sales\", 53) over (order by \"yummy\".\"yearly_agg_date_week_seq\" asc ) as \"_virt_window_lead_4780721583408487\",
+    lead(\"yummy\".\"yearly_agg_thursday_sales\", 53) over (order by \"yummy\".\"yearly_agg_date_week_seq\" asc ) as \"_virt_window_lead_8474766537336377\",
+    lead(\"yummy\".\"yearly_agg_tuesday_sales\", 53) over (order by \"yummy\".\"yearly_agg_date_week_seq\" asc ) as \"_virt_window_lead_3375245317408835\",
+    lead(\"yummy\".\"yearly_agg_wednesday_sales\", 53) over (order by \"yummy\".\"yearly_agg_date_week_seq\" asc ) as \"_virt_window_lead_6759541963679355\"
 FROM
-    yummy),
+    \"yummy\"),
 vacuous as (
 SELECT
-    juicy.\"_virt_window_lead_1831355371097660\" as \"_virt_window_lead_1831355371097660\",
-    juicy.\"_virt_window_lead_2858098921271386\" as \"_virt_window_lead_2858098921271386\",
-    juicy.\"_virt_window_lead_3375245317408835\" as \"_virt_window_lead_3375245317408835\",
-    juicy.\"_virt_window_lead_4780721583408487\" as \"_virt_window_lead_4780721583408487\",
-    juicy.\"_virt_window_lead_6759541963679355\" as \"_virt_window_lead_6759541963679355\",
-    juicy.\"_virt_window_lead_840125329441915\" as \"_virt_window_lead_840125329441915\",
-    juicy.\"_virt_window_lead_8474766537336377\" as \"_virt_window_lead_8474766537336377\",
-    juicy.\"yearly_agg_date_week_seq\" as \"yearly_agg_date_week_seq\",
-    juicy.\"yearly_agg_monday_sales\" as \"yearly_agg_monday_sales\"
+    \"juicy\".\"_virt_window_lead_1831355371097660\" as \"_virt_window_lead_1831355371097660\",
+    \"juicy\".\"_virt_window_lead_2858098921271386\" as \"_virt_window_lead_2858098921271386\",
+    \"juicy\".\"_virt_window_lead_3375245317408835\" as \"_virt_window_lead_3375245317408835\",
+    \"juicy\".\"_virt_window_lead_4780721583408487\" as \"_virt_window_lead_4780721583408487\",
+    \"juicy\".\"_virt_window_lead_6759541963679355\" as \"_virt_window_lead_6759541963679355\",
+    \"juicy\".\"_virt_window_lead_840125329441915\" as \"_virt_window_lead_840125329441915\",
+    \"juicy\".\"_virt_window_lead_8474766537336377\" as \"_virt_window_lead_8474766537336377\",
+    \"juicy\".\"yearly_agg_date_week_seq\" as \"yearly_agg_date_week_seq\",
+    \"juicy\".\"yearly_agg_monday_sales\" as \"yearly_agg_monday_sales\"
 FROM
-    juicy)
+    \"juicy\")
 SELECT
-    yummy.\"yearly_agg_date_week_seq\" as \"yearly_agg_date_week_seq\",
-    round(yummy.\"yearly_agg_sunday_sales\" / (vacuous.\"_virt_window_lead_4780721583408487\"),2) as \"sunday_increase\",
-    round(yummy.\"yearly_agg_monday_sales\" / (vacuous.\"_virt_window_lead_1831355371097660\"),2) as \"monday_increase\",
-    round(yummy.\"yearly_agg_tuesday_sales\" / (vacuous.\"_virt_window_lead_3375245317408835\"),2) as \"tuesday_increase\",
-    round(yummy.\"yearly_agg_wednesday_sales\" / (vacuous.\"_virt_window_lead_6759541963679355\"),2) as \"wednesday_increase\",
-    round(yummy.\"yearly_agg_thursday_sales\" / (vacuous.\"_virt_window_lead_8474766537336377\"),2) as \"thursday_increase\",
-    round(yummy.\"yearly_agg_friday_sales\" / (vacuous.\"_virt_window_lead_840125329441915\"),2) as \"friday_increase\",
-    round(yummy.\"yearly_agg_saturday_sales\" / (vacuous.\"_virt_window_lead_2858098921271386\"),2) as \"saturday_increase\"
+    \"yummy\".\"yearly_agg_date_week_seq\" as \"yearly_agg_date_week_seq\",
+    round(\"yummy\".\"yearly_agg_sunday_sales\" / (\"vacuous\".\"_virt_window_lead_4780721583408487\"),2) as \"sunday_increase\",
+    round(\"yummy\".\"yearly_agg_monday_sales\" / (\"vacuous\".\"_virt_window_lead_1831355371097660\"),2) as \"monday_increase\",
+    round(\"yummy\".\"yearly_agg_tuesday_sales\" / (\"vacuous\".\"_virt_window_lead_3375245317408835\"),2) as \"tuesday_increase\",
+    round(\"yummy\".\"yearly_agg_wednesday_sales\" / (\"vacuous\".\"_virt_window_lead_6759541963679355\"),2) as \"wednesday_increase\",
+    round(\"yummy\".\"yearly_agg_thursday_sales\" / (\"vacuous\".\"_virt_window_lead_8474766537336377\"),2) as \"thursday_increase\",
+    round(\"yummy\".\"yearly_agg_friday_sales\" / (\"vacuous\".\"_virt_window_lead_840125329441915\"),2) as \"friday_increase\",
+    round(\"yummy\".\"yearly_agg_saturday_sales\" / (\"vacuous\".\"_virt_window_lead_2858098921271386\"),2) as \"saturday_increase\"
 FROM
-    vacuous
-    LEFT OUTER JOIN yummy on vacuous.\"yearly_agg_date_week_seq\" = yummy.\"yearly_agg_date_week_seq\" AND vacuous.\"yearly_agg_monday_sales\" = yummy.\"yearly_agg_monday_sales\"
+    \"vacuous\"
+    LEFT OUTER JOIN \"yummy\" on \"vacuous\".\"yearly_agg_date_week_seq\" = \"yummy\".\"yearly_agg_date_week_seq\" AND \"vacuous\".\"yearly_agg_monday_sales\" = \"yummy\".\"yearly_agg_monday_sales\"
 WHERE
-    round(yummy.\"yearly_agg_sunday_sales\" / (vacuous.\"_virt_window_lead_4780721583408487\"),2) is not null
+    round(\"yummy\".\"yearly_agg_sunday_sales\" / (\"vacuous\".\"_virt_window_lead_4780721583408487\"),2) is not null
 
 ORDER BY 
-    yummy.\"yearly_agg_date_week_seq\" asc nulls first
+    \"yummy\".\"yearly_agg_date_week_seq\" asc nulls first
 LIMIT (100)"""

--- a/tests/modeling/tpc_ds_duckdb/zquery03.log
+++ b/tests/modeling/tpc_ds_duckdb/zquery03.log
@@ -1,36 +1,36 @@
 query_id = 3
-gen_length = 1487
+gen_length = 1551
 generated_sql = """
 
 WITH 
 cheerful as (
 SELECT
-    cast(store_sales_date_date.\"D_YEAR\" as int) as \"store_sales_date_year\",
-    store_sales_item_items.\"I_BRAND\" as \"store_sales_item_brand_name\",
-    store_sales_item_items.\"I_BRAND_ID\" as \"store_sales_item_brand_id\",
-    store_sales_item_items.\"I_ITEM_SK\" as \"store_sales_item_id\",
-    store_sales_store_sales.\"SS_EXT_SALES_PRICE\" as \"store_sales_ext_sales_price\",
-    store_sales_store_sales.\"SS_TICKET_NUMBER\" as \"store_sales_ticket_number\"
+    \"store_sales_item_items\".\"I_BRAND\" as \"store_sales_item_brand_name\",
+    \"store_sales_item_items\".\"I_BRAND_ID\" as \"store_sales_item_brand_id\",
+    \"store_sales_item_items\".\"I_ITEM_SK\" as \"store_sales_item_id\",
+    \"store_sales_store_sales\".\"SS_EXT_SALES_PRICE\" as \"store_sales_ext_sales_price\",
+    \"store_sales_store_sales\".\"SS_TICKET_NUMBER\" as \"store_sales_ticket_number\",
+    cast(\"store_sales_date_date\".\"D_YEAR\" as int) as \"store_sales_date_year\"
 FROM
-    memory.store_sales as store_sales_store_sales
-    INNER JOIN memory.date_dim as store_sales_date_date on store_sales_store_sales.\"SS_SOLD_DATE_SK\" = store_sales_date_date.\"D_DATE_SK\"
-    INNER JOIN memory.item as store_sales_item_items on store_sales_store_sales.\"SS_ITEM_SK\" = store_sales_item_items.\"I_ITEM_SK\"
+    \"memory\".\"store_sales\" as \"store_sales_store_sales\"
+    INNER JOIN \"memory\".\"date_dim\" as \"store_sales_date_date\" on \"store_sales_store_sales\".\"SS_SOLD_DATE_SK\" = \"store_sales_date_date\".\"D_DATE_SK\"
+    INNER JOIN \"memory\".\"item\" as \"store_sales_item_items\" on \"store_sales_store_sales\".\"SS_ITEM_SK\" = \"store_sales_item_items\".\"I_ITEM_SK\"
 WHERE
-    store_sales_date_date.\"D_MOY\" = 11 and store_sales_item_items.\"I_MANUFACT_ID\" = 128
+    \"store_sales_date_date\".\"D_MOY\" = 11 and \"store_sales_item_items\".\"I_MANUFACT_ID\" = 128
 )
 SELECT
-    cheerful.\"store_sales_date_year\" as \"store_sales_date_year\",
-    cheerful.\"store_sales_item_brand_id\" as \"store_sales_item_brand_id\",
-    cheerful.\"store_sales_item_brand_name\" as \"store_sales_item_brand_name\",
-    sum(cheerful.\"store_sales_ext_sales_price\") as \"sum_agg\"
+    \"cheerful\".\"store_sales_date_year\" as \"store_sales_date_year\",
+    \"cheerful\".\"store_sales_item_brand_id\" as \"store_sales_item_brand_id\",
+    \"cheerful\".\"store_sales_item_brand_name\" as \"store_sales_item_brand_name\",
+    sum(\"cheerful\".\"store_sales_ext_sales_price\") as \"sum_agg\"
 FROM
-    cheerful
+    \"cheerful\"
 GROUP BY 
-    cheerful.\"store_sales_date_year\",
-    cheerful.\"store_sales_item_brand_id\",
-    cheerful.\"store_sales_item_brand_name\"
+    \"cheerful\".\"store_sales_date_year\",
+    \"cheerful\".\"store_sales_item_brand_id\",
+    \"cheerful\".\"store_sales_item_brand_name\"
 ORDER BY 
-    cheerful.\"store_sales_date_year\" asc,
-    sum(cheerful.\"store_sales_ext_sales_price\") desc,
-    cheerful.\"store_sales_item_brand_id\" asc
+    \"cheerful\".\"store_sales_date_year\" asc,
+    sum(\"cheerful\".\"store_sales_ext_sales_price\") desc,
+    \"cheerful\".\"store_sales_item_brand_id\" asc
 LIMIT (100)"""

--- a/tests/modeling/tpc_ds_duckdb/zquery06.log
+++ b/tests/modeling/tpc_ds_duckdb/zquery06.log
@@ -1,68 +1,68 @@
 query_id = 6
-gen_length = 3031
+gen_length = 3171
 generated_sql = """
 
 WITH 
 questionable as (
 SELECT
-    cast(store_sales_date_date.\"D_YEAR\" as int) as \"store_sales_date_year\",
-    item_items.\"I_CATEGORY\" as \"item_category\",
-    store_sales_customer_customer_address.\"CA_STATE\" as \"store_sales_customer_state\",
-    store_sales_date_date.\"D_MOY\" as \"store_sales_date_month_of_year\",
-    store_sales_item_items.\"I_CATEGORY\" as \"store_sales_item_category\",
-    store_sales_item_items.\"I_CURRENT_PRICE\" as \"store_sales_item_current_price\",
-    store_sales_item_items.\"I_ITEM_SK\" as \"item_id\",
-    store_sales_store_sales.\"SS_TICKET_NUMBER\" as \"store_sales_ticket_number\"
+    \"item_items\".\"I_CATEGORY\" as \"item_category\",
+    \"store_sales_customer_customer_address\".\"CA_STATE\" as \"store_sales_customer_state\",
+    \"store_sales_date_date\".\"D_MOY\" as \"store_sales_date_month_of_year\",
+    \"store_sales_item_items\".\"I_CATEGORY\" as \"store_sales_item_category\",
+    \"store_sales_item_items\".\"I_CURRENT_PRICE\" as \"store_sales_item_current_price\",
+    \"store_sales_item_items\".\"I_ITEM_SK\" as \"item_id\",
+    \"store_sales_store_sales\".\"SS_TICKET_NUMBER\" as \"store_sales_ticket_number\",
+    cast(\"store_sales_date_date\".\"D_YEAR\" as int) as \"store_sales_date_year\"
 FROM
-    memory.store_sales as store_sales_store_sales
-    INNER JOIN memory.date_dim as store_sales_date_date on store_sales_store_sales.\"SS_SOLD_DATE_SK\" = store_sales_date_date.\"D_DATE_SK\"
-    INNER JOIN memory.customer as store_sales_customer_customers on store_sales_store_sales.\"SS_CUSTOMER_SK\" = store_sales_customer_customers.\"C_CUSTOMER_SK\"
-    INNER JOIN memory.customer_address as store_sales_customer_customer_address on store_sales_customer_customers.\"C_CURRENT_ADDR_SK\" = store_sales_customer_customer_address.\"CA_ADDRESS_SK\"
-    INNER JOIN memory.item as store_sales_item_items on store_sales_store_sales.\"SS_ITEM_SK\" = store_sales_item_items.\"I_ITEM_SK\"
-    INNER JOIN memory.item as item_items on store_sales_store_sales.\"SS_ITEM_SK\" = item_items.\"I_ITEM_SK\"
+    \"memory\".\"store_sales\" as \"store_sales_store_sales\"
+    INNER JOIN \"memory\".\"date_dim\" as \"store_sales_date_date\" on \"store_sales_store_sales\".\"SS_SOLD_DATE_SK\" = \"store_sales_date_date\".\"D_DATE_SK\"
+    INNER JOIN \"memory\".\"customer\" as \"store_sales_customer_customers\" on \"store_sales_store_sales\".\"SS_CUSTOMER_SK\" = \"store_sales_customer_customers\".\"C_CUSTOMER_SK\"
+    INNER JOIN \"memory\".\"customer_address\" as \"store_sales_customer_customer_address\" on \"store_sales_customer_customers\".\"C_CURRENT_ADDR_SK\" = \"store_sales_customer_customer_address\".\"CA_ADDRESS_SK\"
+    INNER JOIN \"memory\".\"item\" as \"store_sales_item_items\" on \"store_sales_store_sales\".\"SS_ITEM_SK\" = \"store_sales_item_items\".\"I_ITEM_SK\"
+    INNER JOIN \"memory\".\"item\" as \"item_items\" on \"store_sales_store_sales\".\"SS_ITEM_SK\" = \"item_items\".\"I_ITEM_SK\"
 WHERE
-    cast(store_sales_date_date.\"D_YEAR\" as int) = 2001 and store_sales_date_date.\"D_MOY\" = 1 and store_sales_item_items.\"I_CATEGORY\" is not null
+    cast(\"store_sales_date_date\".\"D_YEAR\" as int) = 2001 and \"store_sales_date_date\".\"D_MOY\" = 1 and \"store_sales_item_items\".\"I_CATEGORY\" is not null
 ),
 abundant as (
 SELECT
-    avg(item_items.\"I_CURRENT_PRICE\") as \"_virt_agg_avg_5942253052406187\",
-    item_items.\"I_CATEGORY\" as \"item_category\"
+    \"item_items\".\"I_CATEGORY\" as \"item_category\",
+    avg(\"item_items\".\"I_CURRENT_PRICE\") as \"_virt_agg_avg_5942253052406187\"
 FROM
-    memory.item as item_items
+    \"memory\".\"item\" as \"item_items\"
 GROUP BY 
-    item_items.\"I_CATEGORY\"),
+    \"item_items\".\"I_CATEGORY\"),
 uneven as (
 SELECT
-    questionable.\"item_id\" as \"item_id\",
-    questionable.\"store_sales_customer_state\" as \"store_sales_customer_state\",
-    questionable.\"store_sales_ticket_number\" as \"store_sales_ticket_number\"
+    \"questionable\".\"item_id\" as \"item_id\",
+    \"questionable\".\"store_sales_customer_state\" as \"store_sales_customer_state\",
+    \"questionable\".\"store_sales_ticket_number\" as \"store_sales_ticket_number\"
 FROM
-    questionable
-    INNER JOIN abundant on (questionable.\"item_category\" = abundant.\"item_category\" or (questionable.\"item_category\" is null and abundant.\"item_category\" is null))
+    \"questionable\"
+    INNER JOIN \"abundant\" on (\"questionable\".\"item_category\" = \"abundant\".\"item_category\" or (\"questionable\".\"item_category\" is null and \"abundant\".\"item_category\" is null))
 WHERE
-    questionable.\"store_sales_date_year\" = 2001 and questionable.\"store_sales_date_month_of_year\" = 1 and questionable.\"store_sales_item_current_price\" > 1.2 * abundant.\"_virt_agg_avg_5942253052406187\" and questionable.\"store_sales_item_category\" is not null
+    \"questionable\".\"store_sales_date_year\" = 2001 and \"questionable\".\"store_sales_date_month_of_year\" = 1 and \"questionable\".\"store_sales_item_current_price\" > 1.2 * \"abundant\".\"_virt_agg_avg_5942253052406187\" and \"questionable\".\"store_sales_item_category\" is not null
 ),
 yummy as (
 SELECT
-    uneven.\"item_id\" as \"item_id\",
-    uneven.\"store_sales_customer_state\" as \"store_sales_customer_state\",
-    uneven.\"store_sales_ticket_number\" as \"store_sales_ticket_number\"
+    \"uneven\".\"item_id\" as \"item_id\",
+    \"uneven\".\"store_sales_customer_state\" as \"store_sales_customer_state\",
+    \"uneven\".\"store_sales_ticket_number\" as \"store_sales_ticket_number\"
 FROM
-    uneven
+    \"uneven\"
 GROUP BY 
-    uneven.\"item_id\",
-    uneven.\"store_sales_customer_state\",
-    uneven.\"store_sales_ticket_number\")
+    \"uneven\".\"item_id\",
+    \"uneven\".\"store_sales_customer_state\",
+    \"uneven\".\"store_sales_ticket_number\")
 SELECT
-    yummy.\"store_sales_customer_state\" as \"store_sales_customer_state\",
+    \"yummy\".\"store_sales_customer_state\" as \"store_sales_customer_state\",
     sum(1) as \"customer_count\"
 FROM
-    yummy
+    \"yummy\"
 GROUP BY 
-    yummy.\"store_sales_customer_state\"
+    \"yummy\".\"store_sales_customer_state\"
 HAVING
     sum(1) >= 10
 
 ORDER BY 
     sum(1) asc nulls first,
-    yummy.\"store_sales_customer_state\" asc nulls first"""
+    \"yummy\".\"store_sales_customer_state\" asc nulls first"""

--- a/tests/modeling/tpc_ds_duckdb/zquery07.log
+++ b/tests/modeling/tpc_ds_duckdb/zquery07.log
@@ -1,36 +1,36 @@
 query_id = 7
-gen_length = 2138
+gen_length = 2226
 generated_sql = """
 
 WITH 
 cooperative as (
 SELECT
-    store_sales_item_items.\"I_ITEM_ID\" as \"store_sales_item_name\",
-    store_sales_item_items.\"I_ITEM_SK\" as \"store_sales_item_id\",
-    store_sales_store_sales.\"SS_COUPON_AMT\" as \"store_sales_coupon_amt\",
-    store_sales_store_sales.\"SS_LIST_PRICE\" as \"store_sales_list_price\",
-    store_sales_store_sales.\"SS_QUANTITY\" as \"store_sales_quantity\",
-    store_sales_store_sales.\"SS_SALES_PRICE\" as \"store_sales_sales_price\",
-    store_sales_store_sales.\"SS_TICKET_NUMBER\" as \"store_sales_ticket_number\"
+    \"store_sales_item_items\".\"I_ITEM_ID\" as \"store_sales_item_name\",
+    \"store_sales_item_items\".\"I_ITEM_SK\" as \"store_sales_item_id\",
+    \"store_sales_store_sales\".\"SS_COUPON_AMT\" as \"store_sales_coupon_amt\",
+    \"store_sales_store_sales\".\"SS_LIST_PRICE\" as \"store_sales_list_price\",
+    \"store_sales_store_sales\".\"SS_QUANTITY\" as \"store_sales_quantity\",
+    \"store_sales_store_sales\".\"SS_SALES_PRICE\" as \"store_sales_sales_price\",
+    \"store_sales_store_sales\".\"SS_TICKET_NUMBER\" as \"store_sales_ticket_number\"
 FROM
-    memory.store_sales as store_sales_store_sales
-    INNER JOIN memory.date_dim as store_sales_date_date on store_sales_store_sales.\"SS_SOLD_DATE_SK\" = store_sales_date_date.\"D_DATE_SK\"
-    INNER JOIN memory.item as store_sales_item_items on store_sales_store_sales.\"SS_ITEM_SK\" = store_sales_item_items.\"I_ITEM_SK\"
-    INNER JOIN memory.promotion as store_sales_promotion_promotion on store_sales_store_sales.\"SS_PROMO_SK\" = store_sales_promotion_promotion.\"P_PROMO_SK\"
-    INNER JOIN memory.customer_demographics as store_sales_customer_demographic_customer_demographics on store_sales_store_sales.\"SS_CDEMO_SK\" = store_sales_customer_demographic_customer_demographics.\"CD_DEMO_SK\"
+    \"memory\".\"store_sales\" as \"store_sales_store_sales\"
+    INNER JOIN \"memory\".\"date_dim\" as \"store_sales_date_date\" on \"store_sales_store_sales\".\"SS_SOLD_DATE_SK\" = \"store_sales_date_date\".\"D_DATE_SK\"
+    INNER JOIN \"memory\".\"item\" as \"store_sales_item_items\" on \"store_sales_store_sales\".\"SS_ITEM_SK\" = \"store_sales_item_items\".\"I_ITEM_SK\"
+    INNER JOIN \"memory\".\"promotion\" as \"store_sales_promotion_promotion\" on \"store_sales_store_sales\".\"SS_PROMO_SK\" = \"store_sales_promotion_promotion\".\"P_PROMO_SK\"
+    INNER JOIN \"memory\".\"customer_demographics\" as \"store_sales_customer_demographic_customer_demographics\" on \"store_sales_store_sales\".\"SS_CDEMO_SK\" = \"store_sales_customer_demographic_customer_demographics\".\"CD_DEMO_SK\"
 WHERE
-    store_sales_customer_demographic_customer_demographics.\"CD_GENDER\" = 'M' and store_sales_customer_demographic_customer_demographics.\"CD_MARITAL_STATUS\" = 'S' and store_sales_customer_demographic_customer_demographics.\"CD_EDUCATION_STATUS\" = 'College' and ( store_sales_promotion_promotion.\"P_CHANNEL_EMAIL\" = 'N' or store_sales_promotion_promotion.\"P_CHANNEL_EVENT\" = 'N' ) and cast(store_sales_date_date.\"D_YEAR\" as int) = 2000
+    \"store_sales_customer_demographic_customer_demographics\".\"CD_GENDER\" = 'M' and \"store_sales_customer_demographic_customer_demographics\".\"CD_MARITAL_STATUS\" = 'S' and \"store_sales_customer_demographic_customer_demographics\".\"CD_EDUCATION_STATUS\" = 'College' and ( \"store_sales_promotion_promotion\".\"P_CHANNEL_EMAIL\" = 'N' or \"store_sales_promotion_promotion\".\"P_CHANNEL_EVENT\" = 'N' ) and cast(\"store_sales_date_date\".\"D_YEAR\" as int) = 2000
 )
 SELECT
-    cooperative.\"store_sales_item_name\" as \"store_sales_item_name\",
-    avg(cooperative.\"store_sales_quantity\") as \"avg_quantity\",
-    avg(cooperative.\"store_sales_list_price\") as \"avg_list_price\",
-    avg(cooperative.\"store_sales_coupon_amt\") as \"avg_coupon_amt\",
-    avg(cooperative.\"store_sales_sales_price\") as \"avg_sales_price\"
+    \"cooperative\".\"store_sales_item_name\" as \"store_sales_item_name\",
+    avg(\"cooperative\".\"store_sales_quantity\") as \"avg_quantity\",
+    avg(\"cooperative\".\"store_sales_list_price\") as \"avg_list_price\",
+    avg(\"cooperative\".\"store_sales_coupon_amt\") as \"avg_coupon_amt\",
+    avg(\"cooperative\".\"store_sales_sales_price\") as \"avg_sales_price\"
 FROM
-    cooperative
+    \"cooperative\"
 GROUP BY 
-    cooperative.\"store_sales_item_name\"
+    \"cooperative\".\"store_sales_item_name\"
 ORDER BY 
-    cooperative.\"store_sales_item_name\" asc
+    \"cooperative\".\"store_sales_item_name\" asc
 LIMIT (100)"""

--- a/tests/modeling/tpc_ds_duckdb/zquery08.log
+++ b/tests/modeling/tpc_ds_duckdb/zquery08.log
@@ -1,83 +1,83 @@
 query_id = 8
-gen_length = 3073
+gen_length = 3199
 generated_sql = """
 
 WITH 
 questionable as (
 SELECT
-    customer_customer_address.\"CA_ZIP\" as \"customer_zip\",
-    customer_customers.\"C_CUSTOMER_SK\" as \"customer_id\",
-    customer_customers.\"C_PREFERRED_CUST_FLAG\" as \"customer_preferred_cust_flag\"
+    \"customer_customer_address\".\"CA_ZIP\" as \"customer_zip\",
+    \"customer_customers\".\"C_CUSTOMER_SK\" as \"customer_id\",
+    \"customer_customers\".\"C_PREFERRED_CUST_FLAG\" as \"customer_preferred_cust_flag\"
 FROM
-    memory.customer_address as customer_customer_address
-    INNER JOIN memory.customer as customer_customers on customer_customer_address.\"CA_ADDRESS_SK\" = customer_customers.\"C_CURRENT_ADDR_SK\"),
+    \"memory\".\"customer_address\" as \"customer_customer_address\"
+    INNER JOIN \"memory\".\"customer\" as \"customer_customers\" on \"customer_customer_address\".\"CA_ADDRESS_SK\" = \"customer_customers\".\"C_CURRENT_ADDR_SK\"),
 cheerful as (
 SELECT
     unnest(:_virt_7180871482901048) as \"zips_pre\"
 ),
 abundant as (
 SELECT
-    CASE WHEN questionable.\"customer_preferred_cust_flag\" = 'Y' THEN questionable.\"customer_id\" ELSE NULL END as \"_virt_filter_id_8603331542397217\",
-    questionable.\"customer_id\" as \"customer_id\",
-    questionable.\"customer_zip\" as \"customer_zip\"
+    \"questionable\".\"customer_id\" as \"customer_id\",
+    \"questionable\".\"customer_zip\" as \"customer_zip\",
+    CASE WHEN \"questionable\".\"customer_preferred_cust_flag\" = 'Y' THEN \"questionable\".\"customer_id\" ELSE NULL END as \"_virt_filter_id_8603331542397217\"
 FROM
-    questionable),
+    \"questionable\"),
 uneven as (
 SELECT
-    abundant.\"customer_zip\" as \"customer_zip\",
-    count(abundant.\"_virt_filter_id_8603331542397217\") as \"zip_p_count\"
+    \"abundant\".\"customer_zip\" as \"customer_zip\",
+    count(\"abundant\".\"_virt_filter_id_8603331542397217\") as \"zip_p_count\"
 FROM
-    abundant
+    \"abundant\"
 GROUP BY 
-    abundant.\"customer_zip\"),
+    \"abundant\".\"customer_zip\"),
 yummy as (
 SELECT
-    customer_customer_address.\"CA_ADDRESS_SK\" as \"customer_address_id\",
-    customer_customer_address.\"CA_ZIP\" as \"customer_zip\",
-    uneven.\"zip_p_count\" as \"zip_p_count\"
+    \"customer_customer_address\".\"CA_ADDRESS_SK\" as \"customer_address_id\",
+    \"customer_customer_address\".\"CA_ZIP\" as \"customer_zip\",
+    \"uneven\".\"zip_p_count\" as \"zip_p_count\"
 FROM
-    uneven
-    INNER JOIN memory.customer_address as customer_customer_address on uneven.\"customer_zip\" = customer_customer_address.\"CA_ZIP\"),
+    \"uneven\"
+    INNER JOIN \"memory\".\"customer_address\" as \"customer_customer_address\" on \"uneven\".\"customer_zip\" = \"customer_customer_address\".\"CA_ZIP\"),
 juicy as (
 SELECT
-    SUBSTRING(CASE WHEN yummy.\"zip_p_count\" > 10 THEN yummy.\"customer_zip\" ELSE NULL END,1,5) as \"_virt_func_substring_4293448550966409\"
+    SUBSTRING(CASE WHEN \"yummy\".\"zip_p_count\" > 10 THEN \"yummy\".\"customer_zip\" ELSE NULL END,1,5) as \"_virt_func_substring_4293448550966409\"
 FROM
-    yummy),
+    \"yummy\"),
 vacuous as (
 SELECT
-    SUBSTRING(SUBSTRING(cast(cheerful.\"zips_pre\" as string),1,5),1,2) as \"final_zips\"
+    SUBSTRING(SUBSTRING(cast(\"cheerful\".\"zips_pre\" as string),1,5),1,2) as \"final_zips\"
 FROM
-    cheerful
+    \"cheerful\"
 WHERE
-    SUBSTRING(cast(cheerful.\"zips_pre\" as string),1,5) in (select juicy.\"_virt_func_substring_4293448550966409\" from juicy where juicy.\"_virt_func_substring_4293448550966409\" is not null)
+    SUBSTRING(cast(\"cheerful\".\"zips_pre\" as string),1,5) in (select juicy.\"_virt_func_substring_4293448550966409\" from juicy where juicy.\"_virt_func_substring_4293448550966409\" is not null)
 ),
 concerned as (
 SELECT
-    vacuous.\"final_zips\" as \"final_zips\"
+    \"vacuous\".\"final_zips\" as \"final_zips\"
 FROM
-    vacuous
+    \"vacuous\"
 GROUP BY 
-    vacuous.\"final_zips\"),
+    \"vacuous\".\"final_zips\"),
 young as (
 SELECT
-    store_sales_store_sales.\"SS_ITEM_SK\" as \"store_sales_item_id\",
-    store_sales_store_sales.\"SS_NET_PROFIT\" as \"store_sales_net_profit\",
-    store_sales_store_sales.\"SS_TICKET_NUMBER\" as \"store_sales_ticket_number\",
-    store_sales_store_store.\"S_STORE_NAME\" as \"store_sales_store_name\"
+    \"store_sales_store_sales\".\"SS_ITEM_SK\" as \"store_sales_item_id\",
+    \"store_sales_store_sales\".\"SS_NET_PROFIT\" as \"store_sales_net_profit\",
+    \"store_sales_store_sales\".\"SS_TICKET_NUMBER\" as \"store_sales_ticket_number\",
+    \"store_sales_store_store\".\"S_STORE_NAME\" as \"store_sales_store_name\"
 FROM
-    memory.store_sales as store_sales_store_sales
-    INNER JOIN memory.date_dim as store_sales_date_date on store_sales_store_sales.\"SS_SOLD_DATE_SK\" = store_sales_date_date.\"D_DATE_SK\"
-    INNER JOIN memory.store as store_sales_store_store on store_sales_store_sales.\"SS_STORE_SK\" = store_sales_store_store.\"S_STORE_SK\"
+    \"memory\".\"store_sales\" as \"store_sales_store_sales\"
+    INNER JOIN \"memory\".\"date_dim\" as \"store_sales_date_date\" on \"store_sales_store_sales\".\"SS_SOLD_DATE_SK\" = \"store_sales_date_date\".\"D_DATE_SK\"
+    INNER JOIN \"memory\".\"store\" as \"store_sales_store_store\" on \"store_sales_store_sales\".\"SS_STORE_SK\" = \"store_sales_store_store\".\"S_STORE_SK\"
 WHERE
-    store_sales_date_date.\"D_QOY\" = 2 and cast(store_sales_date_date.\"D_YEAR\" as int) = 1998 and SUBSTRING(store_sales_store_store.\"S_ZIP\",1,2) in (select concerned.\"final_zips\" from concerned where concerned.\"final_zips\" is not null)
+    \"store_sales_date_date\".\"D_QOY\" = 2 and cast(\"store_sales_date_date\".\"D_YEAR\" as int) = 1998 and SUBSTRING(\"store_sales_store_store\".\"S_ZIP\",1,2) in (select concerned.\"final_zips\" from concerned where concerned.\"final_zips\" is not null)
 )
 SELECT
-    young.\"store_sales_store_name\" as \"store_sales_store_name\",
-    sum(young.\"store_sales_net_profit\") as \"store_net_profit\"
+    \"young\".\"store_sales_store_name\" as \"store_sales_store_name\",
+    sum(\"young\".\"store_sales_net_profit\") as \"store_net_profit\"
 FROM
-    young
+    \"young\"
 GROUP BY 
-    young.\"store_sales_store_name\"
+    \"young\".\"store_sales_store_name\"
 ORDER BY 
-    young.\"store_sales_store_name\" asc
+    \"young\".\"store_sales_store_name\" asc
 LIMIT (100)"""

--- a/tests/modeling/tpc_ds_duckdb/zquery10.log
+++ b/tests/modeling/tpc_ds_duckdb/zquery10.log
@@ -1,106 +1,106 @@
 query_id = 10
-gen_length = 5998
+gen_length = 6226
 generated_sql = """
 
 WITH 
 cooperative as (
 SELECT
-    store_sales_store_sales.\"SS_CUSTOMER_SK\" as \"customer_id\",
-    store_sales_store_sales.\"SS_SOLD_DATE_SK\" as \"store_sales_date_id\"
+    \"store_sales_store_sales\".\"SS_CUSTOMER_SK\" as \"customer_id\",
+    \"store_sales_store_sales\".\"SS_SOLD_DATE_SK\" as \"store_sales_date_id\"
 FROM
-    memory.store_sales as store_sales_store_sales
+    \"memory\".\"store_sales\" as \"store_sales_store_sales\"
 GROUP BY 
-    store_sales_store_sales.\"SS_CUSTOMER_SK\",
-    store_sales_store_sales.\"SS_SOLD_DATE_SK\"),
+    \"store_sales_store_sales\".\"SS_CUSTOMER_SK\",
+    \"store_sales_store_sales\".\"SS_SOLD_DATE_SK\"),
 uneven as (
 SELECT
-    web_sales_web_sales.\"WS_BILL_CUSTOMER_SK\" as \"customer_id\",
-    web_sales_web_sales.\"WS_SOLD_DATE_SK\" as \"web_sales_date_id\"
+    \"web_sales_web_sales\".\"WS_BILL_CUSTOMER_SK\" as \"customer_id\",
+    \"web_sales_web_sales\".\"WS_SOLD_DATE_SK\" as \"web_sales_date_id\"
 FROM
-    memory.web_sales as web_sales_web_sales
+    \"memory\".\"web_sales\" as \"web_sales_web_sales\"
 GROUP BY 
-    web_sales_web_sales.\"WS_BILL_CUSTOMER_SK\",
-    web_sales_web_sales.\"WS_SOLD_DATE_SK\"),
+    \"web_sales_web_sales\".\"WS_BILL_CUSTOMER_SK\",
+    \"web_sales_web_sales\".\"WS_SOLD_DATE_SK\"),
 vacuous as (
 SELECT
-    catalog_sales_catalog_sales.\"CS_SHIP_CUSTOMER_SK\" as \"customer_id\",
-    catalog_sales_catalog_sales.\"CS_SOLD_DATE_SK\" as \"catalog_sales_date_id\"
+    \"catalog_sales_catalog_sales\".\"CS_SHIP_CUSTOMER_SK\" as \"customer_id\",
+    \"catalog_sales_catalog_sales\".\"CS_SOLD_DATE_SK\" as \"catalog_sales_date_id\"
 FROM
-    memory.catalog_sales as catalog_sales_catalog_sales
+    \"memory\".\"catalog_sales\" as \"catalog_sales_catalog_sales\"
 GROUP BY 
-    catalog_sales_catalog_sales.\"CS_SHIP_CUSTOMER_SK\",
-    catalog_sales_catalog_sales.\"CS_SOLD_DATE_SK\"),
+    \"catalog_sales_catalog_sales\".\"CS_SHIP_CUSTOMER_SK\",
+    \"catalog_sales_catalog_sales\".\"CS_SOLD_DATE_SK\"),
 concerned as (
 SELECT
-    customer_customers.\"C_CUSTOMER_SK\" as \"relevant_customers\"
+    \"customer_customers\".\"C_CUSTOMER_SK\" as \"relevant_customers\"
 FROM
-    uneven
-    INNER JOIN memory.date_dim as web_sales_date_date on uneven.\"web_sales_date_id\" = web_sales_date_date.\"D_DATE_SK\"
-    FULL JOIN memory.customer as customer_customers on uneven.\"customer_id\" = customer_customers.\"C_CUSTOMER_SK\"
-    LEFT OUTER JOIN vacuous on customer_customers.\"C_CUSTOMER_SK\" = vacuous.\"customer_id\"
-    LEFT OUTER JOIN cooperative on customer_customers.\"C_CUSTOMER_SK\" = cooperative.\"customer_id\"
-    LEFT OUTER JOIN memory.customer_address as customer_customer_address on customer_customers.\"C_CURRENT_ADDR_SK\" = customer_customer_address.\"CA_ADDRESS_SK\"
-    LEFT OUTER JOIN memory.date_dim as store_sales_date_date on cooperative.\"store_sales_date_id\" = store_sales_date_date.\"D_DATE_SK\"
-    LEFT OUTER JOIN memory.date_dim as catalog_sales_date_date on vacuous.\"catalog_sales_date_id\" = catalog_sales_date_date.\"D_DATE_SK\"
+    \"uneven\"
+    INNER JOIN \"memory\".\"date_dim\" as \"web_sales_date_date\" on \"uneven\".\"web_sales_date_id\" = \"web_sales_date_date\".\"D_DATE_SK\"
+    FULL JOIN \"memory\".\"customer\" as \"customer_customers\" on \"uneven\".\"customer_id\" = \"customer_customers\".\"C_CUSTOMER_SK\"
+    LEFT OUTER JOIN \"vacuous\" on \"customer_customers\".\"C_CUSTOMER_SK\" = \"vacuous\".\"customer_id\"
+    LEFT OUTER JOIN \"cooperative\" on \"customer_customers\".\"C_CUSTOMER_SK\" = \"cooperative\".\"customer_id\"
+    LEFT OUTER JOIN \"memory\".\"customer_address\" as \"customer_customer_address\" on \"customer_customers\".\"C_CURRENT_ADDR_SK\" = \"customer_customer_address\".\"CA_ADDRESS_SK\"
+    LEFT OUTER JOIN \"memory\".\"date_dim\" as \"store_sales_date_date\" on \"cooperative\".\"store_sales_date_id\" = \"store_sales_date_date\".\"D_DATE_SK\"
+    LEFT OUTER JOIN \"memory\".\"date_dim\" as \"catalog_sales_date_date\" on \"vacuous\".\"catalog_sales_date_id\" = \"catalog_sales_date_date\".\"D_DATE_SK\"
 WHERE
-    cast(store_sales_date_date.\"D_YEAR\" as int) = 2002 and store_sales_date_date.\"D_MOY\" in (1,2,3,4) and customer_customer_address.\"CA_COUNTY\" in ('Rush County','Toole County','Jefferson County','Dona Ana County','La Porte County') and ( ( cast(web_sales_date_date.\"D_YEAR\" as int) = 2002 and web_sales_date_date.\"D_MOY\" in (1,2,3,4) ) or ( cast(catalog_sales_date_date.\"D_YEAR\" as int) = 2002 and catalog_sales_date_date.\"D_MOY\" in (1,2,3,4) ) )
+    cast(\"store_sales_date_date\".\"D_YEAR\" as int) = 2002 and \"store_sales_date_date\".\"D_MOY\" in (1,2,3,4) and \"customer_customer_address\".\"CA_COUNTY\" in ('Rush County','Toole County','Jefferson County','Dona Ana County','La Porte County') and ( ( cast(\"web_sales_date_date\".\"D_YEAR\" as int) = 2002 and \"web_sales_date_date\".\"D_MOY\" in (1,2,3,4) ) or ( cast(\"catalog_sales_date_date\".\"D_YEAR\" as int) = 2002 and \"catalog_sales_date_date\".\"D_MOY\" in (1,2,3,4) ) )
 ),
 young as (
 SELECT
-    concerned.\"relevant_customers\" as \"relevant_customers\"
+    \"concerned\".\"relevant_customers\" as \"relevant_customers\"
 FROM
-    concerned
+    \"concerned\"
 GROUP BY 
-    concerned.\"relevant_customers\"),
+    \"concerned\".\"relevant_customers\"),
 sparkling as (
 SELECT
-    customer_customers.\"C_CUSTOMER_SK\" as \"customer_id\",
-    customer_demographics_customer_demographics.\"CD_CREDIT_RATING\" as \"customer_demographics_credit_rating\",
-    customer_demographics_customer_demographics.\"CD_DEP_COLLEGE_COUNT\" as \"customer_demographics_college_dependent_count\",
-    customer_demographics_customer_demographics.\"CD_DEP_COUNT\" as \"customer_demographics_dependent_count\",
-    customer_demographics_customer_demographics.\"CD_DEP_EMPLOYED_COUNT\" as \"customer_demographics_employed_dependent_count\",
-    customer_demographics_customer_demographics.\"CD_EDUCATION_STATUS\" as \"customer_demographics_education_status\",
-    customer_demographics_customer_demographics.\"CD_GENDER\" as \"customer_demographics_gender\",
-    customer_demographics_customer_demographics.\"CD_MARITAL_STATUS\" as \"customer_demographics_marital_status\",
-    customer_demographics_customer_demographics.\"CD_PURCHASE_ESTIMATE\" as \"customer_demographics_purchase_estimate\"
+    \"customer_customers\".\"C_CUSTOMER_SK\" as \"customer_id\",
+    \"customer_demographics_customer_demographics\".\"CD_CREDIT_RATING\" as \"customer_demographics_credit_rating\",
+    \"customer_demographics_customer_demographics\".\"CD_DEP_COLLEGE_COUNT\" as \"customer_demographics_college_dependent_count\",
+    \"customer_demographics_customer_demographics\".\"CD_DEP_COUNT\" as \"customer_demographics_dependent_count\",
+    \"customer_demographics_customer_demographics\".\"CD_DEP_EMPLOYED_COUNT\" as \"customer_demographics_employed_dependent_count\",
+    \"customer_demographics_customer_demographics\".\"CD_EDUCATION_STATUS\" as \"customer_demographics_education_status\",
+    \"customer_demographics_customer_demographics\".\"CD_GENDER\" as \"customer_demographics_gender\",
+    \"customer_demographics_customer_demographics\".\"CD_MARITAL_STATUS\" as \"customer_demographics_marital_status\",
+    \"customer_demographics_customer_demographics\".\"CD_PURCHASE_ESTIMATE\" as \"customer_demographics_purchase_estimate\"
 FROM
-    memory.customer_demographics as customer_demographics_customer_demographics
-    INNER JOIN memory.customer as customer_customers on customer_demographics_customer_demographics.\"CD_DEMO_SK\" = customer_customers.\"C_CURRENT_CDEMO_SK\"
+    \"memory\".\"customer_demographics\" as \"customer_demographics_customer_demographics\"
+    INNER JOIN \"memory\".\"customer\" as \"customer_customers\" on \"customer_demographics_customer_demographics\".\"CD_DEMO_SK\" = \"customer_customers\".\"C_CURRENT_CDEMO_SK\"
 WHERE
-    customer_customers.\"C_CUSTOMER_SK\" in (select young.\"relevant_customers\" from young where young.\"relevant_customers\" is not null) and customer_demographics_customer_demographics.\"CD_GENDER\" is not null
+    \"customer_customers\".\"C_CUSTOMER_SK\" in (select young.\"relevant_customers\" from young where young.\"relevant_customers\" is not null) and \"customer_demographics_customer_demographics\".\"CD_GENDER\" is not null
 )
 SELECT
-    sparkling.\"customer_demographics_gender\" as \"customer_demographics_gender\",
-    sparkling.\"customer_demographics_marital_status\" as \"customer_demographics_marital_status\",
-    sparkling.\"customer_demographics_education_status\" as \"customer_demographics_education_status\",
-    count(sparkling.\"customer_id\") as \"cnt1\",
-    sparkling.\"customer_demographics_purchase_estimate\" as \"customer_demographics_purchase_estimate\",
-    count(sparkling.\"customer_id\") as \"cnt2\",
-    sparkling.\"customer_demographics_credit_rating\" as \"customer_demographics_credit_rating\",
-    count(sparkling.\"customer_id\") as \"cnt3\",
-    sparkling.\"customer_demographics_dependent_count\" as \"customer_demographics_dependent_count\",
-    count(sparkling.\"customer_id\") as \"cnt4\",
-    sparkling.\"customer_demographics_employed_dependent_count\" as \"customer_demographics_employed_dependent_count\",
-    count(sparkling.\"customer_id\") as \"cnt5\",
-    sparkling.\"customer_demographics_college_dependent_count\" as \"customer_demographics_college_dependent_count\",
-    count(sparkling.\"customer_id\") as \"cnt6\"
+    \"sparkling\".\"customer_demographics_gender\" as \"customer_demographics_gender\",
+    \"sparkling\".\"customer_demographics_marital_status\" as \"customer_demographics_marital_status\",
+    \"sparkling\".\"customer_demographics_education_status\" as \"customer_demographics_education_status\",
+    count(\"sparkling\".\"customer_id\") as \"cnt1\",
+    \"sparkling\".\"customer_demographics_purchase_estimate\" as \"customer_demographics_purchase_estimate\",
+    count(\"sparkling\".\"customer_id\") as \"cnt2\",
+    \"sparkling\".\"customer_demographics_credit_rating\" as \"customer_demographics_credit_rating\",
+    count(\"sparkling\".\"customer_id\") as \"cnt3\",
+    \"sparkling\".\"customer_demographics_dependent_count\" as \"customer_demographics_dependent_count\",
+    count(\"sparkling\".\"customer_id\") as \"cnt4\",
+    \"sparkling\".\"customer_demographics_employed_dependent_count\" as \"customer_demographics_employed_dependent_count\",
+    count(\"sparkling\".\"customer_id\") as \"cnt5\",
+    \"sparkling\".\"customer_demographics_college_dependent_count\" as \"customer_demographics_college_dependent_count\",
+    count(\"sparkling\".\"customer_id\") as \"cnt6\"
 FROM
-    sparkling
+    \"sparkling\"
 GROUP BY 
-    sparkling.\"customer_demographics_college_dependent_count\",
-    sparkling.\"customer_demographics_credit_rating\",
-    sparkling.\"customer_demographics_dependent_count\",
-    sparkling.\"customer_demographics_education_status\",
-    sparkling.\"customer_demographics_employed_dependent_count\",
-    sparkling.\"customer_demographics_gender\",
-    sparkling.\"customer_demographics_marital_status\",
-    sparkling.\"customer_demographics_purchase_estimate\"
+    \"sparkling\".\"customer_demographics_college_dependent_count\",
+    \"sparkling\".\"customer_demographics_credit_rating\",
+    \"sparkling\".\"customer_demographics_dependent_count\",
+    \"sparkling\".\"customer_demographics_education_status\",
+    \"sparkling\".\"customer_demographics_employed_dependent_count\",
+    \"sparkling\".\"customer_demographics_gender\",
+    \"sparkling\".\"customer_demographics_marital_status\",
+    \"sparkling\".\"customer_demographics_purchase_estimate\"
 ORDER BY 
-    sparkling.\"customer_demographics_gender\" asc,
-    sparkling.\"customer_demographics_marital_status\" asc,
-    sparkling.\"customer_demographics_education_status\" asc,
-    sparkling.\"customer_demographics_purchase_estimate\" asc,
-    sparkling.\"customer_demographics_credit_rating\" asc,
-    sparkling.\"customer_demographics_dependent_count\" asc,
-    sparkling.\"customer_demographics_employed_dependent_count\" asc,
-    sparkling.\"customer_demographics_college_dependent_count\" asc"""
+    \"sparkling\".\"customer_demographics_gender\" asc,
+    \"sparkling\".\"customer_demographics_marital_status\" asc,
+    \"sparkling\".\"customer_demographics_education_status\" asc,
+    \"sparkling\".\"customer_demographics_purchase_estimate\" asc,
+    \"sparkling\".\"customer_demographics_credit_rating\" asc,
+    \"sparkling\".\"customer_demographics_dependent_count\" asc,
+    \"sparkling\".\"customer_demographics_employed_dependent_count\" asc,
+    \"sparkling\".\"customer_demographics_college_dependent_count\" asc"""

--- a/tests/modeling/tpc_ds_duckdb/zquery12.log
+++ b/tests/modeling/tpc_ds_duckdb/zquery12.log
@@ -1,70 +1,70 @@
 query_id = 12
-gen_length = 3258
+gen_length = 3392
 generated_sql = """
 
 WITH 
 cheerful as (
 SELECT
-    web_sales_item_items.\"I_CATEGORY\" as \"web_sales_item_category\",
-    web_sales_item_items.\"I_CLASS\" as \"web_sales_item_class\",
-    web_sales_item_items.\"I_CURRENT_PRICE\" as \"web_sales_item_current_price\",
-    web_sales_item_items.\"I_ITEM_DESC\" as \"web_sales_item_desc\",
-    web_sales_item_items.\"I_ITEM_ID\" as \"web_sales_item_name\",
-    web_sales_item_items.\"I_ITEM_SK\" as \"web_sales_item_id\",
-    web_sales_web_sales.\"WS_EXT_SALES_PRICE\" as \"web_sales_extra_sales_price\",
-    web_sales_web_sales.\"WS_ORDER_NUMBER\" as \"web_sales_order_number\"
+    \"web_sales_item_items\".\"I_CATEGORY\" as \"web_sales_item_category\",
+    \"web_sales_item_items\".\"I_CLASS\" as \"web_sales_item_class\",
+    \"web_sales_item_items\".\"I_CURRENT_PRICE\" as \"web_sales_item_current_price\",
+    \"web_sales_item_items\".\"I_ITEM_DESC\" as \"web_sales_item_desc\",
+    \"web_sales_item_items\".\"I_ITEM_ID\" as \"web_sales_item_name\",
+    \"web_sales_item_items\".\"I_ITEM_SK\" as \"web_sales_item_id\",
+    \"web_sales_web_sales\".\"WS_EXT_SALES_PRICE\" as \"web_sales_extra_sales_price\",
+    \"web_sales_web_sales\".\"WS_ORDER_NUMBER\" as \"web_sales_order_number\"
 FROM
-    memory.web_sales as web_sales_web_sales
-    INNER JOIN memory.date_dim as web_sales_date_date on web_sales_web_sales.\"WS_SOLD_DATE_SK\" = web_sales_date_date.\"D_DATE_SK\"
-    INNER JOIN memory.item as web_sales_item_items on web_sales_web_sales.\"WS_ITEM_SK\" = web_sales_item_items.\"I_ITEM_SK\"
+    \"memory\".\"web_sales\" as \"web_sales_web_sales\"
+    INNER JOIN \"memory\".\"date_dim\" as \"web_sales_date_date\" on \"web_sales_web_sales\".\"WS_SOLD_DATE_SK\" = \"web_sales_date_date\".\"D_DATE_SK\"
+    INNER JOIN \"memory\".\"item\" as \"web_sales_item_items\" on \"web_sales_web_sales\".\"WS_ITEM_SK\" = \"web_sales_item_items\".\"I_ITEM_SK\"
 WHERE
-    cast(web_sales_date_date.\"D_DATE\" as date) >= date '1999-02-22' and cast(web_sales_date_date.\"D_DATE\" as date) <= date '1999-03-24' and web_sales_item_items.\"I_CATEGORY\" in ('Sports','Books','Home')
+    cast(\"web_sales_date_date\".\"D_DATE\" as date) >= date '1999-02-22' and cast(\"web_sales_date_date\".\"D_DATE\" as date) <= date '1999-03-24' and \"web_sales_item_items\".\"I_CATEGORY\" in ('Sports','Books','Home')
 ),
 thoughtful as (
 SELECT
-    cheerful.\"web_sales_item_category\" as \"web_sales_item_category\",
-    cheerful.\"web_sales_item_class\" as \"web_sales_item_class\",
-    cheerful.\"web_sales_item_current_price\" as \"web_sales_item_current_price\",
-    cheerful.\"web_sales_item_desc\" as \"web_sales_item_desc\",
-    cheerful.\"web_sales_item_name\" as \"web_sales_item_name\",
-    sum(cheerful.\"web_sales_extra_sales_price\") as \"itemrevenue\"
+    \"cheerful\".\"web_sales_item_category\" as \"web_sales_item_category\",
+    \"cheerful\".\"web_sales_item_class\" as \"web_sales_item_class\",
+    \"cheerful\".\"web_sales_item_current_price\" as \"web_sales_item_current_price\",
+    \"cheerful\".\"web_sales_item_desc\" as \"web_sales_item_desc\",
+    \"cheerful\".\"web_sales_item_name\" as \"web_sales_item_name\",
+    sum(\"cheerful\".\"web_sales_extra_sales_price\") as \"itemrevenue\"
 FROM
-    cheerful
+    \"cheerful\"
 GROUP BY 
-    cheerful.\"web_sales_item_category\",
-    cheerful.\"web_sales_item_class\",
-    cheerful.\"web_sales_item_current_price\",
-    cheerful.\"web_sales_item_desc\",
-    cheerful.\"web_sales_item_name\"),
+    \"cheerful\".\"web_sales_item_category\",
+    \"cheerful\".\"web_sales_item_class\",
+    \"cheerful\".\"web_sales_item_current_price\",
+    \"cheerful\".\"web_sales_item_desc\",
+    \"cheerful\".\"web_sales_item_name\"),
 cooperative as (
 SELECT
-    sum(thoughtful.\"itemrevenue\") over (partition by thoughtful.\"web_sales_item_class\") as \"itemclassrevenue\",
-    thoughtful.\"itemrevenue\" as \"itemrevenue\",
-    thoughtful.\"web_sales_item_class\" as \"web_sales_item_class\"
+    \"thoughtful\".\"itemrevenue\" as \"itemrevenue\",
+    \"thoughtful\".\"web_sales_item_class\" as \"web_sales_item_class\",
+    sum(\"thoughtful\".\"itemrevenue\") over (partition by \"thoughtful\".\"web_sales_item_class\") as \"itemclassrevenue\"
 FROM
-    thoughtful),
+    \"thoughtful\"),
 questionable as (
 SELECT
-    cooperative.\"itemclassrevenue\" as \"itemclassrevenue\",
-    cooperative.\"itemrevenue\" as \"itemrevenue\",
-    cooperative.\"web_sales_item_class\" as \"web_sales_item_class\"
+    \"cooperative\".\"itemclassrevenue\" as \"itemclassrevenue\",
+    \"cooperative\".\"itemrevenue\" as \"itemrevenue\",
+    \"cooperative\".\"web_sales_item_class\" as \"web_sales_item_class\"
 FROM
-    cooperative)
+    \"cooperative\")
 SELECT
-    thoughtful.\"web_sales_item_name\" as \"web_sales_item_name\",
-    thoughtful.\"web_sales_item_desc\" as \"web_sales_item_desc\",
-    thoughtful.\"web_sales_item_category\" as \"web_sales_item_category\",
-    thoughtful.\"web_sales_item_class\" as \"web_sales_item_class\",
-    thoughtful.\"web_sales_item_current_price\" as \"web_sales_item_current_price\",
-    thoughtful.\"itemrevenue\" as \"itemrevenue\",
-    (thoughtful.\"itemrevenue\" * 100.0) / questionable.\"itemclassrevenue\" as \"revenueratio\"
+    \"thoughtful\".\"web_sales_item_name\" as \"web_sales_item_name\",
+    \"thoughtful\".\"web_sales_item_desc\" as \"web_sales_item_desc\",
+    \"thoughtful\".\"web_sales_item_category\" as \"web_sales_item_category\",
+    \"thoughtful\".\"web_sales_item_class\" as \"web_sales_item_class\",
+    \"thoughtful\".\"web_sales_item_current_price\" as \"web_sales_item_current_price\",
+    \"thoughtful\".\"itemrevenue\" as \"itemrevenue\",
+    (\"thoughtful\".\"itemrevenue\" * 100.0) / \"questionable\".\"itemclassrevenue\" as \"revenueratio\"
 FROM
-    questionable
-    LEFT OUTER JOIN thoughtful on (questionable.\"web_sales_item_class\" = thoughtful.\"web_sales_item_class\" or (questionable.\"web_sales_item_class\" is null and thoughtful.\"web_sales_item_class\" is null)) AND questionable.\"itemrevenue\" = thoughtful.\"itemrevenue\"
+    \"questionable\"
+    LEFT OUTER JOIN \"thoughtful\" on \"questionable\".\"itemrevenue\" = \"thoughtful\".\"itemrevenue\" AND (\"questionable\".\"web_sales_item_class\" = \"thoughtful\".\"web_sales_item_class\" or (\"questionable\".\"web_sales_item_class\" is null and \"thoughtful\".\"web_sales_item_class\" is null))
 ORDER BY 
-    thoughtful.\"web_sales_item_category\" asc,
-    thoughtful.\"web_sales_item_class\" asc,
-    thoughtful.\"web_sales_item_name\" asc,
-    thoughtful.\"web_sales_item_desc\" asc,
-    (thoughtful.\"itemrevenue\" * 100.0) / questionable.\"itemclassrevenue\" asc
+    \"thoughtful\".\"web_sales_item_category\" asc,
+    \"thoughtful\".\"web_sales_item_class\" asc,
+    \"thoughtful\".\"web_sales_item_name\" asc,
+    \"thoughtful\".\"web_sales_item_desc\" asc,
+    (\"thoughtful\".\"itemrevenue\" * 100.0) / \"questionable\".\"itemclassrevenue\" asc
 LIMIT (100)"""

--- a/tests/modeling/tpc_ds_duckdb/zquery15.log
+++ b/tests/modeling/tpc_ds_duckdb/zquery15.log
@@ -1,29 +1,29 @@
 query_id = 15
-gen_length = 1670
+gen_length = 1734
 generated_sql = """
 
 WITH 
 thoughtful as (
 SELECT
-    catalog_sales_bill_customer_customer_address.\"CA_ZIP\" as \"catalog_sales_bill_customer_zip\",
-    catalog_sales_catalog_sales.\"CS_ITEM_SK\" as \"catalog_sales_item_id\",
-    catalog_sales_catalog_sales.\"CS_ORDER_NUMBER\" as \"catalog_sales_order_number\",
-    catalog_sales_catalog_sales.\"CS_SALES_PRICE\" as \"catalog_sales_sales_price\"
+    \"catalog_sales_bill_customer_customer_address\".\"CA_ZIP\" as \"catalog_sales_bill_customer_zip\",
+    \"catalog_sales_catalog_sales\".\"CS_ITEM_SK\" as \"catalog_sales_item_id\",
+    \"catalog_sales_catalog_sales\".\"CS_ORDER_NUMBER\" as \"catalog_sales_order_number\",
+    \"catalog_sales_catalog_sales\".\"CS_SALES_PRICE\" as \"catalog_sales_sales_price\"
 FROM
-    memory.catalog_sales as catalog_sales_catalog_sales
-    INNER JOIN memory.date_dim as catalog_sales_date_date on catalog_sales_catalog_sales.\"CS_SOLD_DATE_SK\" = catalog_sales_date_date.\"D_DATE_SK\"
-    INNER JOIN memory.customer as catalog_sales_bill_customer_customers on catalog_sales_catalog_sales.\"CS_BILL_CUSTOMER_SK\" = catalog_sales_bill_customer_customers.\"C_CUSTOMER_SK\"
-    INNER JOIN memory.customer_address as catalog_sales_bill_customer_customer_address on catalog_sales_bill_customer_customers.\"C_CURRENT_ADDR_SK\" = catalog_sales_bill_customer_customer_address.\"CA_ADDRESS_SK\"
+    \"memory\".\"catalog_sales\" as \"catalog_sales_catalog_sales\"
+    INNER JOIN \"memory\".\"date_dim\" as \"catalog_sales_date_date\" on \"catalog_sales_catalog_sales\".\"CS_SOLD_DATE_SK\" = \"catalog_sales_date_date\".\"D_DATE_SK\"
+    INNER JOIN \"memory\".\"customer\" as \"catalog_sales_bill_customer_customers\" on \"catalog_sales_catalog_sales\".\"CS_BILL_CUSTOMER_SK\" = \"catalog_sales_bill_customer_customers\".\"C_CUSTOMER_SK\"
+    INNER JOIN \"memory\".\"customer_address\" as \"catalog_sales_bill_customer_customer_address\" on \"catalog_sales_bill_customer_customers\".\"C_CURRENT_ADDR_SK\" = \"catalog_sales_bill_customer_customer_address\".\"CA_ADDRESS_SK\"
 WHERE
-    catalog_sales_date_date.\"D_QOY\" = 2 and cast(catalog_sales_date_date.\"D_YEAR\" as int) = 2001 and ( catalog_sales_bill_customer_customer_address.\"CA_STATE\" in ('CA','WA','GA') or catalog_sales_catalog_sales.\"CS_SALES_PRICE\" > 500 or SUBSTRING(catalog_sales_bill_customer_customer_address.\"CA_ZIP\",1,5) in ('85669','86197','88274','83405','86475','85392','85460','80348','81792') )
+    \"catalog_sales_date_date\".\"D_QOY\" = 2 and cast(\"catalog_sales_date_date\".\"D_YEAR\" as int) = 2001 and ( \"catalog_sales_bill_customer_customer_address\".\"CA_STATE\" in ('CA','WA','GA') or \"catalog_sales_catalog_sales\".\"CS_SALES_PRICE\" > 500 or SUBSTRING(\"catalog_sales_bill_customer_customer_address\".\"CA_ZIP\",1,5) in ('85669','86197','88274','83405','86475','85392','85460','80348','81792') )
 )
 SELECT
-    thoughtful.\"catalog_sales_bill_customer_zip\" as \"catalog_sales_bill_customer_zip\",
-    sum(thoughtful.\"catalog_sales_sales_price\") as \"sales\"
+    \"thoughtful\".\"catalog_sales_bill_customer_zip\" as \"catalog_sales_bill_customer_zip\",
+    sum(\"thoughtful\".\"catalog_sales_sales_price\") as \"sales\"
 FROM
-    thoughtful
+    \"thoughtful\"
 GROUP BY 
-    thoughtful.\"catalog_sales_bill_customer_zip\"
+    \"thoughtful\".\"catalog_sales_bill_customer_zip\"
 ORDER BY 
-    thoughtful.\"catalog_sales_bill_customer_zip\" asc nulls first
+    \"thoughtful\".\"catalog_sales_bill_customer_zip\" asc nulls first
 LIMIT (100)"""

--- a/tests/modeling/tpc_ds_duckdb/zquery16.log
+++ b/tests/modeling/tpc_ds_duckdb/zquery16.log
@@ -1,110 +1,110 @@
 query_id = 16
-gen_length = 4849
+gen_length = 5049
 generated_sql = """
 
 WITH 
 abundant as (
 SELECT
-    cs_catalog_sales.\"CS_ORDER_NUMBER\" as \"cs_order_number\",
-    cs_catalog_sales.\"CS_WAREHOUSE_SK\" as \"cs_warehouse_id\"
+    \"cs_catalog_sales\".\"CS_ORDER_NUMBER\" as \"cs_order_number\",
+    \"cs_catalog_sales\".\"CS_WAREHOUSE_SK\" as \"cs_warehouse_id\"
 FROM
-    memory.catalog_sales as cs_catalog_sales
+    \"memory\".\"catalog_sales\" as \"cs_catalog_sales\"
 GROUP BY 
-    cs_catalog_sales.\"CS_ORDER_NUMBER\",
-    cs_catalog_sales.\"CS_WAREHOUSE_SK\"),
+    \"cs_catalog_sales\".\"CS_ORDER_NUMBER\",
+    \"cs_catalog_sales\".\"CS_WAREHOUSE_SK\"),
 questionable as (
 SELECT
-    cr_catalog_returns.\"CR_ORDER_NUMBER\" as \"cr_order_number\"
+    \"cr_catalog_returns\".\"CR_ORDER_NUMBER\" as \"cr_order_number\"
 FROM
-    memory.catalog_returns as cr_catalog_returns
+    \"memory\".\"catalog_returns\" as \"cr_catalog_returns\"
 GROUP BY 
-    cr_catalog_returns.\"CR_ORDER_NUMBER\"),
+    \"cr_catalog_returns\".\"CR_ORDER_NUMBER\"),
 uneven as (
 SELECT
-    abundant.\"cs_order_number\" as \"cs_order_number\",
-    count(abundant.\"cs_warehouse_id\") as \"_virt_agg_count_7777088585630721\"
+    \"abundant\".\"cs_order_number\" as \"cs_order_number\",
+    count(\"abundant\".\"cs_warehouse_id\") as \"_virt_agg_count_7777088585630721\"
 FROM
-    abundant
+    \"abundant\"
 GROUP BY 
-    abundant.\"cs_order_number\"),
+    \"abundant\".\"cs_order_number\"),
 yummy as (
 SELECT
-    CASE WHEN uneven.\"_virt_agg_count_7777088585630721\" > 1 THEN uneven.\"cs_order_number\" ELSE NULL END as \"multi_warehouse_sales\"
+    CASE WHEN \"uneven\".\"_virt_agg_count_7777088585630721\" > 1 THEN \"uneven\".\"cs_order_number\" ELSE NULL END as \"multi_warehouse_sales\"
 FROM
-    uneven),
+    \"uneven\"),
 juicy as (
 SELECT
-    yummy.\"multi_warehouse_sales\" as \"multi_warehouse_sales\"
+    \"yummy\".\"multi_warehouse_sales\" as \"multi_warehouse_sales\"
 FROM
-    yummy
+    \"yummy\"
 GROUP BY 
-    yummy.\"multi_warehouse_sales\"),
+    \"yummy\".\"multi_warehouse_sales\"),
 thoughtful as (
 SELECT
-    cs_catalog_sales.\"CS_CALL_CENTER_SK\" as \"cs_call_center_id\",
-    cs_catalog_sales.\"CS_ORDER_NUMBER\" as \"cs_order_number\",
-    cs_catalog_sales.\"CS_SHIP_ADDR_SK\" as \"cs_customer_address_id\",
-    cs_catalog_sales.\"CS_SHIP_DATE_SK\" as \"cs_ship_date_id\"
+    \"cs_catalog_sales\".\"CS_CALL_CENTER_SK\" as \"cs_call_center_id\",
+    \"cs_catalog_sales\".\"CS_ORDER_NUMBER\" as \"cs_order_number\",
+    \"cs_catalog_sales\".\"CS_SHIP_ADDR_SK\" as \"cs_customer_address_id\",
+    \"cs_catalog_sales\".\"CS_SHIP_DATE_SK\" as \"cs_ship_date_id\"
 FROM
-    memory.catalog_sales as cs_catalog_sales
+    \"memory\".\"catalog_sales\" as \"cs_catalog_sales\"
 WHERE
-    cs_catalog_sales.\"CS_ORDER_NUMBER\" not in (select questionable.\"cr_order_number\" from questionable where questionable.\"cr_order_number\" is not null) and cs_catalog_sales.\"CS_ORDER_NUMBER\" in (select juicy.\"multi_warehouse_sales\" from juicy where juicy.\"multi_warehouse_sales\" is not null)
+    \"cs_catalog_sales\".\"CS_ORDER_NUMBER\" not in (select questionable.\"cr_order_number\" from questionable where questionable.\"cr_order_number\" is not null) and \"cs_catalog_sales\".\"CS_ORDER_NUMBER\" in (select juicy.\"multi_warehouse_sales\" from juicy where juicy.\"multi_warehouse_sales\" is not null)
 
 GROUP BY 
-    cs_catalog_sales.\"CS_CALL_CENTER_SK\",
-    cs_catalog_sales.\"CS_ORDER_NUMBER\",
-    cs_catalog_sales.\"CS_SHIP_ADDR_SK\",
-    cs_catalog_sales.\"CS_SHIP_DATE_SK\"),
+    \"cs_catalog_sales\".\"CS_CALL_CENTER_SK\",
+    \"cs_catalog_sales\".\"CS_ORDER_NUMBER\",
+    \"cs_catalog_sales\".\"CS_SHIP_ADDR_SK\",
+    \"cs_catalog_sales\".\"CS_SHIP_DATE_SK\"),
 sparkling as (
 SELECT
-    cs_catalog_sales.\"CS_EXT_SHIP_COST\" as \"cs_extra_ship_cost\",
-    cs_catalog_sales.\"CS_ITEM_SK\" as \"cs_item_id\",
-    cs_catalog_sales.\"CS_NET_PROFIT\" as \"cs_net_profit\",
-    cs_catalog_sales.\"CS_ORDER_NUMBER\" as \"cs_order_number\"
+    \"cs_catalog_sales\".\"CS_EXT_SHIP_COST\" as \"cs_extra_ship_cost\",
+    \"cs_catalog_sales\".\"CS_ITEM_SK\" as \"cs_item_id\",
+    \"cs_catalog_sales\".\"CS_NET_PROFIT\" as \"cs_net_profit\",
+    \"cs_catalog_sales\".\"CS_ORDER_NUMBER\" as \"cs_order_number\"
 FROM
-    memory.catalog_sales as cs_catalog_sales
-    INNER JOIN memory.date_dim as cs_ship_date_date on cs_catalog_sales.\"CS_SHIP_DATE_SK\" = cs_ship_date_date.\"D_DATE_SK\"
-    INNER JOIN memory.call_center as cs_call_center_call_center on cs_catalog_sales.\"CS_CALL_CENTER_SK\" = cs_call_center_call_center.\"CC_CALL_CENTER_SK\"
-    INNER JOIN memory.customer_address as cs_customer_address_customer_address on cs_catalog_sales.\"CS_SHIP_ADDR_SK\" = cs_customer_address_customer_address.\"CA_ADDRESS_SK\"
+    \"memory\".\"catalog_sales\" as \"cs_catalog_sales\"
+    INNER JOIN \"memory\".\"date_dim\" as \"cs_ship_date_date\" on \"cs_catalog_sales\".\"CS_SHIP_DATE_SK\" = \"cs_ship_date_date\".\"D_DATE_SK\"
+    INNER JOIN \"memory\".\"call_center\" as \"cs_call_center_call_center\" on \"cs_catalog_sales\".\"CS_CALL_CENTER_SK\" = \"cs_call_center_call_center\".\"CC_CALL_CENTER_SK\"
+    INNER JOIN \"memory\".\"customer_address\" as \"cs_customer_address_customer_address\" on \"cs_catalog_sales\".\"CS_SHIP_ADDR_SK\" = \"cs_customer_address_customer_address\".\"CA_ADDRESS_SK\"
 WHERE
-    cast(cs_ship_date_date.\"D_DATE\" as date) >= date '2002-02-01' and cast(cs_ship_date_date.\"D_DATE\" as date) <= date '2002-04-02' and cs_customer_address_customer_address.\"CA_STATE\" = 'GA' and cs_call_center_call_center.\"CC_COUNTY\" = 'Williamson County' and cs_catalog_sales.\"CS_ORDER_NUMBER\" not in (select questionable.\"cr_order_number\" from questionable where questionable.\"cr_order_number\" is not null) and cs_catalog_sales.\"CS_ORDER_NUMBER\" in (select juicy.\"multi_warehouse_sales\" from juicy where juicy.\"multi_warehouse_sales\" is not null)
+    cast(\"cs_ship_date_date\".\"D_DATE\" as date) >= date '2002-02-01' and cast(\"cs_ship_date_date\".\"D_DATE\" as date) <= date '2002-04-02' and \"cs_customer_address_customer_address\".\"CA_STATE\" = 'GA' and \"cs_call_center_call_center\".\"CC_COUNTY\" = 'Williamson County' and \"cs_catalog_sales\".\"CS_ORDER_NUMBER\" not in (select questionable.\"cr_order_number\" from questionable where questionable.\"cr_order_number\" is not null) and \"cs_catalog_sales\".\"CS_ORDER_NUMBER\" in (select juicy.\"multi_warehouse_sales\" from juicy where juicy.\"multi_warehouse_sales\" is not null)
 ),
 vacuous as (
 SELECT
-    thoughtful.\"cs_order_number\" as \"cs_order_number\"
+    \"thoughtful\".\"cs_order_number\" as \"cs_order_number\"
 FROM
-    thoughtful
-    INNER JOIN memory.date_dim as cs_ship_date_date on thoughtful.\"cs_ship_date_id\" = cs_ship_date_date.\"D_DATE_SK\"
-    INNER JOIN memory.call_center as cs_call_center_call_center on thoughtful.\"cs_call_center_id\" = cs_call_center_call_center.\"CC_CALL_CENTER_SK\"
-    INNER JOIN memory.customer_address as cs_customer_address_customer_address on thoughtful.\"cs_customer_address_id\" = cs_customer_address_customer_address.\"CA_ADDRESS_SK\"
+    \"thoughtful\"
+    INNER JOIN \"memory\".\"date_dim\" as \"cs_ship_date_date\" on \"thoughtful\".\"cs_ship_date_id\" = \"cs_ship_date_date\".\"D_DATE_SK\"
+    INNER JOIN \"memory\".\"call_center\" as \"cs_call_center_call_center\" on \"thoughtful\".\"cs_call_center_id\" = \"cs_call_center_call_center\".\"CC_CALL_CENTER_SK\"
+    INNER JOIN \"memory\".\"customer_address\" as \"cs_customer_address_customer_address\" on \"thoughtful\".\"cs_customer_address_id\" = \"cs_customer_address_customer_address\".\"CA_ADDRESS_SK\"
 WHERE
-    cast(cs_ship_date_date.\"D_DATE\" as date) >= date '2002-02-01' and cast(cs_ship_date_date.\"D_DATE\" as date) <= date '2002-04-02' and cs_customer_address_customer_address.\"CA_STATE\" = 'GA' and cs_call_center_call_center.\"CC_COUNTY\" = 'Williamson County' and thoughtful.\"cs_order_number\" not in (select questionable.\"cr_order_number\" from questionable where questionable.\"cr_order_number\" is not null) and thoughtful.\"cs_order_number\" in (select juicy.\"multi_warehouse_sales\" from juicy where juicy.\"multi_warehouse_sales\" is not null)
+    cast(\"cs_ship_date_date\".\"D_DATE\" as date) >= date '2002-02-01' and cast(\"cs_ship_date_date\".\"D_DATE\" as date) <= date '2002-04-02' and \"cs_customer_address_customer_address\".\"CA_STATE\" = 'GA' and \"cs_call_center_call_center\".\"CC_COUNTY\" = 'Williamson County' and \"thoughtful\".\"cs_order_number\" not in (select questionable.\"cr_order_number\" from questionable where questionable.\"cr_order_number\" is not null) and \"thoughtful\".\"cs_order_number\" in (select juicy.\"multi_warehouse_sales\" from juicy where juicy.\"multi_warehouse_sales\" is not null)
 ),
 abhorrent as (
 SELECT
-    sum(sparkling.\"cs_extra_ship_cost\") as \"total_shipping_cost\",
-    sum(sparkling.\"cs_net_profit\") as \"total_net_profit\"
+    sum(\"sparkling\".\"cs_extra_ship_cost\") as \"total_shipping_cost\",
+    sum(\"sparkling\".\"cs_net_profit\") as \"total_net_profit\"
 FROM
-    sparkling),
+    \"sparkling\"),
 concerned as (
 SELECT
-    vacuous.\"cs_order_number\" as \"cs_order_number\"
+    \"vacuous\".\"cs_order_number\" as \"cs_order_number\"
 FROM
-    vacuous
+    \"vacuous\"
 GROUP BY 
-    vacuous.\"cs_order_number\"),
+    \"vacuous\".\"cs_order_number\"),
 young as (
 SELECT
-    count(distinct concerned.\"cs_order_number\") as \"order_count\"
+    count(distinct \"concerned\".\"cs_order_number\") as \"order_count\"
 FROM
-    concerned)
+    \"concerned\")
 SELECT
-    young.\"order_count\" as \"order_count\",
-    abhorrent.\"total_shipping_cost\" as \"total_shipping_cost\",
-    abhorrent.\"total_net_profit\" as \"total_net_profit\"
+    \"young\".\"order_count\" as \"order_count\",
+    \"abhorrent\".\"total_shipping_cost\" as \"total_shipping_cost\",
+    \"abhorrent\".\"total_net_profit\" as \"total_net_profit\"
 FROM
-    young
-    FULL JOIN abhorrent on 1=1
+    \"young\"
+    FULL JOIN \"abhorrent\" on 1=1
 ORDER BY 
-    young.\"order_count\" desc
+    \"young\".\"order_count\" desc
 LIMIT (100)"""

--- a/tests/modeling/tpc_ds_duckdb/zquery20.log
+++ b/tests/modeling/tpc_ds_duckdb/zquery20.log
@@ -1,73 +1,73 @@
 query_id = 20
-gen_length = 2984
+gen_length = 3120
 generated_sql = """
 
 WITH 
 cheerful as (
 SELECT
-    cs_catalog_sales.\"CS_EXT_SALES_PRICE\" as \"cs_extra_sales_price\",
-    cs_catalog_sales.\"CS_ORDER_NUMBER\" as \"cs_order_number\",
-    cs_item_items.\"I_CATEGORY\" as \"cs_item_category\",
-    cs_item_items.\"I_CLASS\" as \"cs_item_class\",
-    cs_item_items.\"I_CURRENT_PRICE\" as \"cs_item_current_price\",
-    cs_item_items.\"I_ITEM_DESC\" as \"cs_item_desc\",
-    cs_item_items.\"I_ITEM_ID\" as \"cs_item_name\",
-    cs_item_items.\"I_ITEM_SK\" as \"cs_item_id\"
+    \"cs_catalog_sales\".\"CS_EXT_SALES_PRICE\" as \"cs_extra_sales_price\",
+    \"cs_catalog_sales\".\"CS_ORDER_NUMBER\" as \"cs_order_number\",
+    \"cs_item_items\".\"I_CATEGORY\" as \"cs_item_category\",
+    \"cs_item_items\".\"I_CLASS\" as \"cs_item_class\",
+    \"cs_item_items\".\"I_CURRENT_PRICE\" as \"cs_item_current_price\",
+    \"cs_item_items\".\"I_ITEM_DESC\" as \"cs_item_desc\",
+    \"cs_item_items\".\"I_ITEM_ID\" as \"cs_item_name\",
+    \"cs_item_items\".\"I_ITEM_SK\" as \"cs_item_id\"
 FROM
-    memory.catalog_sales as cs_catalog_sales
-    INNER JOIN memory.item as cs_item_items on cs_catalog_sales.\"CS_ITEM_SK\" = cs_item_items.\"I_ITEM_SK\"
-    INNER JOIN memory.date_dim as cs_sold_date_date on cs_catalog_sales.\"CS_SOLD_DATE_SK\" = cs_sold_date_date.\"D_DATE_SK\"
+    \"memory\".\"catalog_sales\" as \"cs_catalog_sales\"
+    INNER JOIN \"memory\".\"item\" as \"cs_item_items\" on \"cs_catalog_sales\".\"CS_ITEM_SK\" = \"cs_item_items\".\"I_ITEM_SK\"
+    INNER JOIN \"memory\".\"date_dim\" as \"cs_sold_date_date\" on \"cs_catalog_sales\".\"CS_SOLD_DATE_SK\" = \"cs_sold_date_date\".\"D_DATE_SK\"
 WHERE
-    cs_item_items.\"I_CATEGORY\" in ('Sports','Books','Home') and cast(cs_sold_date_date.\"D_DATE\" as date) >= date '1999-02-22' and cast(cs_sold_date_date.\"D_DATE\" as date) <= date '1999-03-24'
+    \"cs_item_items\".\"I_CATEGORY\" in ('Sports','Books','Home') and cast(\"cs_sold_date_date\".\"D_DATE\" as date) >= date '1999-02-22' and cast(\"cs_sold_date_date\".\"D_DATE\" as date) <= date '1999-03-24'
 ),
 thoughtful as (
 SELECT
-    cheerful.\"cs_item_category\" as \"cs_item_category\",
-    cheerful.\"cs_item_class\" as \"cs_item_class\",
-    cheerful.\"cs_item_current_price\" as \"cs_item_current_price\",
-    cheerful.\"cs_item_desc\" as \"cs_item_desc\",
-    cheerful.\"cs_item_name\" as \"cs_item_name\",
-    sum(cheerful.\"cs_extra_sales_price\") as \"revenue\"
+    \"cheerful\".\"cs_item_category\" as \"cs_item_category\",
+    \"cheerful\".\"cs_item_class\" as \"cs_item_class\",
+    \"cheerful\".\"cs_item_current_price\" as \"cs_item_current_price\",
+    \"cheerful\".\"cs_item_desc\" as \"cs_item_desc\",
+    \"cheerful\".\"cs_item_name\" as \"cs_item_name\",
+    sum(\"cheerful\".\"cs_extra_sales_price\") as \"revenue\"
 FROM
-    cheerful
+    \"cheerful\"
 GROUP BY 
-    cheerful.\"cs_item_category\",
-    cheerful.\"cs_item_class\",
-    cheerful.\"cs_item_current_price\",
-    cheerful.\"cs_item_desc\",
-    cheerful.\"cs_item_name\"),
+    \"cheerful\".\"cs_item_category\",
+    \"cheerful\".\"cs_item_class\",
+    \"cheerful\".\"cs_item_current_price\",
+    \"cheerful\".\"cs_item_desc\",
+    \"cheerful\".\"cs_item_name\"),
 cooperative as (
 SELECT
-    sum(thoughtful.\"revenue\") over (partition by thoughtful.\"cs_item_class\") as \"_virt_window_sum_69632973582362\",
-    thoughtful.\"cs_item_class\" as \"cs_item_class\",
-    thoughtful.\"revenue\" as \"revenue\"
+    \"thoughtful\".\"cs_item_class\" as \"cs_item_class\",
+    \"thoughtful\".\"revenue\" as \"revenue\",
+    sum(\"thoughtful\".\"revenue\") over (partition by \"thoughtful\".\"cs_item_class\") as \"_virt_window_sum_69632973582362\"
 FROM
-    thoughtful),
+    \"thoughtful\"),
 questionable as (
 SELECT
-    cooperative.\"_virt_window_sum_69632973582362\" as \"_virt_window_sum_69632973582362\",
-    cooperative.\"cs_item_class\" as \"cs_item_class\",
-    cooperative.\"revenue\" as \"revenue\"
+    \"cooperative\".\"_virt_window_sum_69632973582362\" as \"_virt_window_sum_69632973582362\",
+    \"cooperative\".\"cs_item_class\" as \"cs_item_class\",
+    \"cooperative\".\"revenue\" as \"revenue\"
 FROM
-    cooperative)
+    \"cooperative\")
 SELECT
-    thoughtful.\"cs_item_name\" as \"cs_item_name\",
-    thoughtful.\"cs_item_desc\" as \"cs_item_desc\",
-    thoughtful.\"cs_item_category\" as \"cs_item_category\",
-    thoughtful.\"cs_item_class\" as \"cs_item_class\",
-    thoughtful.\"cs_item_current_price\" as \"cs_item_current_price\",
-    thoughtful.\"revenue\" as \"revenue\",
-    thoughtful.\"revenue\" * 100.0 / (questionable.\"_virt_window_sum_69632973582362\") as \"revenue_ratio\"
+    \"thoughtful\".\"cs_item_name\" as \"cs_item_name\",
+    \"thoughtful\".\"cs_item_desc\" as \"cs_item_desc\",
+    \"thoughtful\".\"cs_item_category\" as \"cs_item_category\",
+    \"thoughtful\".\"cs_item_class\" as \"cs_item_class\",
+    \"thoughtful\".\"cs_item_current_price\" as \"cs_item_current_price\",
+    \"thoughtful\".\"revenue\" as \"revenue\",
+    \"thoughtful\".\"revenue\" * 100.0 / (\"questionable\".\"_virt_window_sum_69632973582362\") as \"revenue_ratio\"
 FROM
-    questionable
-    LEFT OUTER JOIN thoughtful on (questionable.\"cs_item_class\" = thoughtful.\"cs_item_class\" or (questionable.\"cs_item_class\" is null and thoughtful.\"cs_item_class\" is null)) AND questionable.\"revenue\" = thoughtful.\"revenue\"
+    \"questionable\"
+    LEFT OUTER JOIN \"thoughtful\" on \"questionable\".\"revenue\" = \"thoughtful\".\"revenue\" AND (\"questionable\".\"cs_item_class\" = \"thoughtful\".\"cs_item_class\" or (\"questionable\".\"cs_item_class\" is null and \"thoughtful\".\"cs_item_class\" is null))
 WHERE
-    thoughtful.\"cs_item_name\" is not null
+    \"thoughtful\".\"cs_item_name\" is not null
 
 ORDER BY 
-    thoughtful.\"cs_item_category\" asc nulls first,
-    thoughtful.\"cs_item_class\" asc nulls first,
-    thoughtful.\"cs_item_name\" asc nulls first,
-    thoughtful.\"cs_item_desc\" asc nulls first,
-    thoughtful.\"revenue\" * 100.0 / (questionable.\"_virt_window_sum_69632973582362\") asc nulls first
+    \"thoughtful\".\"cs_item_category\" asc nulls first,
+    \"thoughtful\".\"cs_item_class\" asc nulls first,
+    \"thoughtful\".\"cs_item_name\" asc nulls first,
+    \"thoughtful\".\"cs_item_desc\" asc nulls first,
+    \"thoughtful\".\"revenue\" * 100.0 / (\"questionable\".\"_virt_window_sum_69632973582362\") asc nulls first
 LIMIT (100)"""

--- a/tests/modeling/tpc_ds_duckdb/zquery21.log
+++ b/tests/modeling/tpc_ds_duckdb/zquery21.log
@@ -1,69 +1,69 @@
 query_id = 21
-gen_length = 2858
+gen_length = 2962
 generated_sql = """
 
 WITH 
 thoughtful as (
 SELECT
-    cast(inventory_date_date.\"D_DATE\" as date) as \"inventory_date_date\",
-    inventory_date_date.\"D_DATE_SK\" as \"inventory_date_id\",
-    inventory_item_items.\"I_ITEM_ID\" as \"inventory_item_name\",
-    inventory_item_items.\"I_ITEM_SK\" as \"inventory_item_id\",
-    inventory_warehouse_inventory.\"inv_quantity_on_hand\" as \"inventory_quantity_on_hand\",
-    inventory_warehouse_warehouse.\"w_warehouse_name\" as \"inventory_warehouse_name\",
-    inventory_warehouse_warehouse.\"w_warehouse_sk\" as \"inventory_warehouse_id\"
+    \"inventory_date_date\".\"D_DATE_SK\" as \"inventory_date_id\",
+    \"inventory_item_items\".\"I_ITEM_ID\" as \"inventory_item_name\",
+    \"inventory_item_items\".\"I_ITEM_SK\" as \"inventory_item_id\",
+    \"inventory_warehouse_inventory\".\"inv_quantity_on_hand\" as \"inventory_quantity_on_hand\",
+    \"inventory_warehouse_warehouse\".\"w_warehouse_name\" as \"inventory_warehouse_name\",
+    \"inventory_warehouse_warehouse\".\"w_warehouse_sk\" as \"inventory_warehouse_id\",
+    cast(\"inventory_date_date\".\"D_DATE\" as date) as \"inventory_date_date\"
 FROM
-    memory.inventory as inventory_warehouse_inventory
-    INNER JOIN memory.date_dim as inventory_date_date on inventory_warehouse_inventory.\"inv_date_sk\" = inventory_date_date.\"D_DATE_SK\"
-    INNER JOIN memory.item as inventory_item_items on inventory_warehouse_inventory.\"inv_item_sk\" = inventory_item_items.\"I_ITEM_SK\"
-    INNER JOIN memory.warehouse as inventory_warehouse_warehouse on inventory_warehouse_inventory.\"inv_warehouse_sk\" = inventory_warehouse_warehouse.\"w_warehouse_sk\"
+    \"memory\".\"inventory\" as \"inventory_warehouse_inventory\"
+    INNER JOIN \"memory\".\"date_dim\" as \"inventory_date_date\" on \"inventory_warehouse_inventory\".\"inv_date_sk\" = \"inventory_date_date\".\"D_DATE_SK\"
+    INNER JOIN \"memory\".\"item\" as \"inventory_item_items\" on \"inventory_warehouse_inventory\".\"inv_item_sk\" = \"inventory_item_items\".\"I_ITEM_SK\"
+    INNER JOIN \"memory\".\"warehouse\" as \"inventory_warehouse_warehouse\" on \"inventory_warehouse_inventory\".\"inv_warehouse_sk\" = \"inventory_warehouse_warehouse\".\"w_warehouse_sk\"
 WHERE
-    cast(inventory_date_date.\"D_DATE\" as date) >= date '2000-02-10' and cast(inventory_date_date.\"D_DATE\" as date) <= date '2000-04-10' and inventory_item_items.\"I_CURRENT_PRICE\" >= 0.99 and inventory_item_items.\"I_CURRENT_PRICE\" <= 1.49
+    cast(\"inventory_date_date\".\"D_DATE\" as date) >= date '2000-02-10' and cast(\"inventory_date_date\".\"D_DATE\" as date) <= date '2000-04-10' and \"inventory_item_items\".\"I_CURRENT_PRICE\" >= 0.99 and \"inventory_item_items\".\"I_CURRENT_PRICE\" <= 1.49
 )
 SELECT
-    thoughtful.\"inventory_warehouse_name\" as \"inventory_warehouse_name\",
-    thoughtful.\"inventory_item_name\" as \"inventory_item_name\",
+    \"thoughtful\".\"inventory_warehouse_name\" as \"inventory_warehouse_name\",
+    \"thoughtful\".\"inventory_item_name\" as \"inventory_item_name\",
     sum(CASE
-	WHEN thoughtful.\"inventory_date_date\" < date '2000-03-11' THEN thoughtful.\"inventory_quantity_on_hand\"
+	WHEN \"thoughtful\".\"inventory_date_date\" < date '2000-03-11' THEN \"thoughtful\".\"inventory_quantity_on_hand\"
 	ELSE 0
 	END) as \"inv_before\",
     sum(CASE
-	WHEN thoughtful.\"inventory_date_date\" >= date '2000-03-11' THEN thoughtful.\"inventory_quantity_on_hand\"
+	WHEN \"thoughtful\".\"inventory_date_date\" >= date '2000-03-11' THEN \"thoughtful\".\"inventory_quantity_on_hand\"
 	ELSE 0
 	END) as \"inv_after\"
 FROM
-    thoughtful
+    \"thoughtful\"
 GROUP BY 
-    thoughtful.\"inventory_item_name\",
-    thoughtful.\"inventory_warehouse_name\"
+    \"thoughtful\".\"inventory_item_name\",
+    \"thoughtful\".\"inventory_warehouse_name\"
 HAVING
     CASE
 	WHEN sum(CASE
-	WHEN thoughtful.\"inventory_date_date\" < date '2000-03-11' THEN thoughtful.\"inventory_quantity_on_hand\"
+	WHEN \"thoughtful\".\"inventory_date_date\" < date '2000-03-11' THEN \"thoughtful\".\"inventory_quantity_on_hand\"
 	ELSE 0
 	END) > 0 THEN (sum(CASE
-	WHEN thoughtful.\"inventory_date_date\" >= date '2000-03-11' THEN thoughtful.\"inventory_quantity_on_hand\"
+	WHEN \"thoughtful\".\"inventory_date_date\" >= date '2000-03-11' THEN \"thoughtful\".\"inventory_quantity_on_hand\"
 	ELSE 0
 	END) * 1.0) / sum(CASE
-	WHEN thoughtful.\"inventory_date_date\" < date '2000-03-11' THEN thoughtful.\"inventory_quantity_on_hand\"
+	WHEN \"thoughtful\".\"inventory_date_date\" < date '2000-03-11' THEN \"thoughtful\".\"inventory_quantity_on_hand\"
 	ELSE 0
 	END)
 	ELSE null
 	END >= 2.0 / 3.0 and CASE
 	WHEN sum(CASE
-	WHEN thoughtful.\"inventory_date_date\" < date '2000-03-11' THEN thoughtful.\"inventory_quantity_on_hand\"
+	WHEN \"thoughtful\".\"inventory_date_date\" < date '2000-03-11' THEN \"thoughtful\".\"inventory_quantity_on_hand\"
 	ELSE 0
 	END) > 0 THEN (sum(CASE
-	WHEN thoughtful.\"inventory_date_date\" >= date '2000-03-11' THEN thoughtful.\"inventory_quantity_on_hand\"
+	WHEN \"thoughtful\".\"inventory_date_date\" >= date '2000-03-11' THEN \"thoughtful\".\"inventory_quantity_on_hand\"
 	ELSE 0
 	END) * 1.0) / sum(CASE
-	WHEN thoughtful.\"inventory_date_date\" < date '2000-03-11' THEN thoughtful.\"inventory_quantity_on_hand\"
+	WHEN \"thoughtful\".\"inventory_date_date\" < date '2000-03-11' THEN \"thoughtful\".\"inventory_quantity_on_hand\"
 	ELSE 0
 	END)
 	ELSE null
 	END <= 3.0 / 2.0
 
 ORDER BY 
-    thoughtful.\"inventory_warehouse_name\" asc nulls first,
-    thoughtful.\"inventory_item_name\" asc nulls first
+    \"thoughtful\".\"inventory_warehouse_name\" asc nulls first,
+    \"thoughtful\".\"inventory_item_name\" asc nulls first
 LIMIT (100)"""

--- a/tests/modeling/tpc_ds_duckdb/zquery24.log
+++ b/tests/modeling/tpc_ds_duckdb/zquery24.log
@@ -1,137 +1,137 @@
 query_id = 24
-gen_length = 7145
+gen_length = 7445
 generated_sql = """
 
 WITH 
 cooperative as (
 SELECT
-    store_sales_customer_customers.\"C_CUSTOMER_SK\" as \"store_sales_customer_id\",
-    store_sales_customer_customers.\"C_FIRST_NAME\" as \"store_sales_customer_first_name\",
-    store_sales_customer_customers.\"C_LAST_NAME\" as \"store_sales_customer_last_name\",
-    store_sales_store_sales.\"SS_ITEM_SK\" as \"store_sales_item_id\",
-    store_sales_store_sales.\"SS_NET_PAID\" as \"store_sales_net_paid\",
-    store_sales_store_sales.\"SS_TICKET_NUMBER\" as \"store_sales_ticket_number\",
-    store_sales_store_store.\"S_STORE_NAME\" as \"store_sales_store_name\",
-    store_sales_store_store.\"S_STORE_SK\" as \"store_sales_store_id\"
+    \"store_sales_customer_customers\".\"C_CUSTOMER_SK\" as \"store_sales_customer_id\",
+    \"store_sales_customer_customers\".\"C_FIRST_NAME\" as \"store_sales_customer_first_name\",
+    \"store_sales_customer_customers\".\"C_LAST_NAME\" as \"store_sales_customer_last_name\",
+    \"store_sales_store_sales\".\"SS_ITEM_SK\" as \"store_sales_item_id\",
+    \"store_sales_store_sales\".\"SS_NET_PAID\" as \"store_sales_net_paid\",
+    \"store_sales_store_sales\".\"SS_TICKET_NUMBER\" as \"store_sales_ticket_number\",
+    \"store_sales_store_store\".\"S_STORE_NAME\" as \"store_sales_store_name\",
+    \"store_sales_store_store\".\"S_STORE_SK\" as \"store_sales_store_id\"
 FROM
-    memory.store_sales as store_sales_store_sales
-    LEFT OUTER JOIN memory.store_returns as store_sales_store_returns on store_sales_store_sales.\"SS_ITEM_SK\" = store_sales_store_returns.\"SR_ITEM_SK\" AND store_sales_store_sales.\"SS_TICKET_NUMBER\" = store_sales_store_returns.\"SR_TICKET_NUMBER\"
-    INNER JOIN memory.store as store_sales_store_store on store_sales_store_sales.\"SS_STORE_SK\" = store_sales_store_store.\"S_STORE_SK\"
-    INNER JOIN memory.customer as store_sales_customer_customers on store_sales_store_sales.\"SS_CUSTOMER_SK\" = store_sales_customer_customers.\"C_CUSTOMER_SK\"
-    INNER JOIN memory.customer_address as store_sales_customer_customer_address on store_sales_customer_customers.\"C_CURRENT_ADDR_SK\" = store_sales_customer_customer_address.\"CA_ADDRESS_SK\"
+    \"memory\".\"store_sales\" as \"store_sales_store_sales\"
+    LEFT OUTER JOIN \"memory\".\"store_returns\" as \"store_sales_store_returns\" on \"store_sales_store_sales\".\"SS_ITEM_SK\" = \"store_sales_store_returns\".\"SR_ITEM_SK\" AND \"store_sales_store_sales\".\"SS_TICKET_NUMBER\" = \"store_sales_store_returns\".\"SR_TICKET_NUMBER\"
+    INNER JOIN \"memory\".\"store\" as \"store_sales_store_store\" on \"store_sales_store_sales\".\"SS_STORE_SK\" = \"store_sales_store_store\".\"S_STORE_SK\"
+    INNER JOIN \"memory\".\"customer\" as \"store_sales_customer_customers\" on \"store_sales_store_sales\".\"SS_CUSTOMER_SK\" = \"store_sales_customer_customers\".\"C_CUSTOMER_SK\"
+    INNER JOIN \"memory\".\"customer_address\" as \"store_sales_customer_customer_address\" on \"store_sales_customer_customers\".\"C_CURRENT_ADDR_SK\" = \"store_sales_customer_customer_address\".\"CA_ADDRESS_SK\"
 WHERE
-    store_sales_store_store.\"S_MARKET_ID\" = 8 and store_sales_customer_customers.\"C_BIRTH_COUNTRY\" != UPPER(store_sales_customer_customer_address.\"CA_COUNTRY\")  and CASE WHEN store_sales_store_returns.\"SR_RETURN_TIME_SK\" THEN TRUE ELSE FALSE END is True and store_sales_store_store.\"S_ZIP\" = store_sales_customer_customer_address.\"CA_ZIP\"
+    \"store_sales_store_store\".\"S_MARKET_ID\" = 8 and \"store_sales_customer_customers\".\"C_BIRTH_COUNTRY\" != UPPER(\"store_sales_customer_customer_address\".\"CA_COUNTRY\")  and CASE WHEN \"store_sales_store_returns\".\"SR_RETURN_TIME_SK\" THEN TRUE ELSE FALSE END is True and \"store_sales_store_store\".\"S_ZIP\" = \"store_sales_customer_customer_address\".\"CA_ZIP\"
 ),
 juicy as (
 SELECT
-    store_sales_item_items.\"I_COLOR\" as \"store_sales_item_color\",
-    store_sales_item_items.\"I_ITEM_SK\" as \"store_sales_item_id\"
+    \"store_sales_item_items\".\"I_COLOR\" as \"store_sales_item_color\",
+    \"store_sales_item_items\".\"I_ITEM_SK\" as \"store_sales_item_id\"
 FROM
-    memory.store_sales as store_sales_store_sales
-    INNER JOIN memory.store as store_sales_store_store on store_sales_store_sales.\"SS_STORE_SK\" = store_sales_store_store.\"S_STORE_SK\"
-    INNER JOIN memory.customer as store_sales_customer_customers on store_sales_store_sales.\"SS_CUSTOMER_SK\" = store_sales_customer_customers.\"C_CUSTOMER_SK\"
-    LEFT OUTER JOIN memory.store_returns as store_sales_store_returns on store_sales_store_sales.\"SS_ITEM_SK\" = store_sales_store_returns.\"SR_ITEM_SK\" AND store_sales_store_sales.\"SS_TICKET_NUMBER\" = store_sales_store_returns.\"SR_TICKET_NUMBER\"
-    INNER JOIN memory.customer_address as store_sales_customer_customer_address on store_sales_customer_customers.\"C_CURRENT_ADDR_SK\" = store_sales_customer_customer_address.\"CA_ADDRESS_SK\"
-    INNER JOIN memory.item as store_sales_item_items on store_sales_store_sales.\"SS_ITEM_SK\" = store_sales_item_items.\"I_ITEM_SK\"
+    \"memory\".\"store_sales\" as \"store_sales_store_sales\"
+    INNER JOIN \"memory\".\"store\" as \"store_sales_store_store\" on \"store_sales_store_sales\".\"SS_STORE_SK\" = \"store_sales_store_store\".\"S_STORE_SK\"
+    INNER JOIN \"memory\".\"customer\" as \"store_sales_customer_customers\" on \"store_sales_store_sales\".\"SS_CUSTOMER_SK\" = \"store_sales_customer_customers\".\"C_CUSTOMER_SK\"
+    LEFT OUTER JOIN \"memory\".\"store_returns\" as \"store_sales_store_returns\" on \"store_sales_store_sales\".\"SS_ITEM_SK\" = \"store_sales_store_returns\".\"SR_ITEM_SK\" AND \"store_sales_store_sales\".\"SS_TICKET_NUMBER\" = \"store_sales_store_returns\".\"SR_TICKET_NUMBER\"
+    INNER JOIN \"memory\".\"customer_address\" as \"store_sales_customer_customer_address\" on \"store_sales_customer_customers\".\"C_CURRENT_ADDR_SK\" = \"store_sales_customer_customer_address\".\"CA_ADDRESS_SK\"
+    INNER JOIN \"memory\".\"item\" as \"store_sales_item_items\" on \"store_sales_store_sales\".\"SS_ITEM_SK\" = \"store_sales_item_items\".\"I_ITEM_SK\"
 WHERE
-    store_sales_store_store.\"S_MARKET_ID\" = 8 and store_sales_customer_customers.\"C_BIRTH_COUNTRY\" != UPPER(store_sales_customer_customer_address.\"CA_COUNTRY\")  and CASE WHEN store_sales_store_returns.\"SR_RETURN_TIME_SK\" THEN TRUE ELSE FALSE END is True and store_sales_store_store.\"S_ZIP\" = store_sales_customer_customer_address.\"CA_ZIP\"
+    \"store_sales_store_store\".\"S_MARKET_ID\" = 8 and \"store_sales_customer_customers\".\"C_BIRTH_COUNTRY\" != UPPER(\"store_sales_customer_customer_address\".\"CA_COUNTRY\")  and CASE WHEN \"store_sales_store_returns\".\"SR_RETURN_TIME_SK\" THEN TRUE ELSE FALSE END is True and \"store_sales_store_store\".\"S_ZIP\" = \"store_sales_customer_customer_address\".\"CA_ZIP\"
 ),
 uneven as (
 SELECT
-    cooperative.\"store_sales_store_id\" as \"store_sales_store_id\",
-    cooperative.\"store_sales_store_name\" as \"store_sales_store_name\"
+    \"cooperative\".\"store_sales_store_id\" as \"store_sales_store_id\",
+    \"cooperative\".\"store_sales_store_name\" as \"store_sales_store_name\"
 FROM
-    cooperative
+    \"cooperative\"
 GROUP BY 
-    cooperative.\"store_sales_store_id\",
-    cooperative.\"store_sales_store_name\"),
+    \"cooperative\".\"store_sales_store_id\",
+    \"cooperative\".\"store_sales_store_name\"),
 abundant as (
 SELECT
-    cooperative.\"store_sales_customer_first_name\" as \"store_sales_customer_first_name\",
-    cooperative.\"store_sales_customer_id\" as \"store_sales_customer_id\",
-    cooperative.\"store_sales_customer_last_name\" as \"store_sales_customer_last_name\"
+    \"cooperative\".\"store_sales_customer_first_name\" as \"store_sales_customer_first_name\",
+    \"cooperative\".\"store_sales_customer_id\" as \"store_sales_customer_id\",
+    \"cooperative\".\"store_sales_customer_last_name\" as \"store_sales_customer_last_name\"
 FROM
-    cooperative
+    \"cooperative\"
 GROUP BY 
-    cooperative.\"store_sales_customer_first_name\",
-    cooperative.\"store_sales_customer_id\",
-    cooperative.\"store_sales_customer_last_name\"),
+    \"cooperative\".\"store_sales_customer_first_name\",
+    \"cooperative\".\"store_sales_customer_id\",
+    \"cooperative\".\"store_sales_customer_last_name\"),
 questionable as (
 SELECT
-    cooperative.\"store_sales_customer_id\" as \"store_sales_customer_id\",
-    cooperative.\"store_sales_item_id\" as \"store_sales_item_id\",
-    cooperative.\"store_sales_store_id\" as \"store_sales_store_id\",
-    sum(cooperative.\"store_sales_net_paid\") as \"net_paid\"
+    \"cooperative\".\"store_sales_customer_id\" as \"store_sales_customer_id\",
+    \"cooperative\".\"store_sales_item_id\" as \"store_sales_item_id\",
+    \"cooperative\".\"store_sales_store_id\" as \"store_sales_store_id\",
+    sum(\"cooperative\".\"store_sales_net_paid\") as \"net_paid\"
 FROM
-    cooperative
+    \"cooperative\"
 GROUP BY 
-    cooperative.\"store_sales_customer_id\",
-    cooperative.\"store_sales_item_id\",
-    cooperative.\"store_sales_store_id\"),
+    \"cooperative\".\"store_sales_customer_id\",
+    \"cooperative\".\"store_sales_item_id\",
+    \"cooperative\".\"store_sales_store_id\"),
 vacuous as (
 SELECT
-    juicy.\"store_sales_item_color\" as \"store_sales_item_color\",
-    juicy.\"store_sales_item_id\" as \"store_sales_item_id\"
+    \"juicy\".\"store_sales_item_color\" as \"store_sales_item_color\",
+    \"juicy\".\"store_sales_item_id\" as \"store_sales_item_id\"
 FROM
-    juicy
+    \"juicy\"
 GROUP BY 
-    juicy.\"store_sales_item_color\",
-    juicy.\"store_sales_item_id\"),
+    \"juicy\".\"store_sales_item_color\",
+    \"juicy\".\"store_sales_item_id\"),
 concerned as (
 SELECT
-    abundant.\"store_sales_customer_first_name\" as \"su_store_sales_customer_first_name\",
-    abundant.\"store_sales_customer_last_name\" as \"su_store_sales_customer_last_name\",
-    questionable.\"net_paid\" as \"su_net_paid\",
-    uneven.\"store_sales_store_name\" as \"su_store_sales_store_name\",
-    vacuous.\"store_sales_item_color\" as \"su_store_sales_item_color\"
+    \"abundant\".\"store_sales_customer_first_name\" as \"su_store_sales_customer_first_name\",
+    \"abundant\".\"store_sales_customer_last_name\" as \"su_store_sales_customer_last_name\",
+    \"questionable\".\"net_paid\" as \"su_net_paid\",
+    \"uneven\".\"store_sales_store_name\" as \"su_store_sales_store_name\",
+    \"vacuous\".\"store_sales_item_color\" as \"su_store_sales_item_color\"
 FROM
-    questionable
-    INNER JOIN vacuous on questionable.\"store_sales_item_id\" = vacuous.\"store_sales_item_id\"
-    INNER JOIN uneven on questionable.\"store_sales_store_id\" = uneven.\"store_sales_store_id\"
-    INNER JOIN abundant on questionable.\"store_sales_customer_id\" = abundant.\"store_sales_customer_id\"
+    \"questionable\"
+    INNER JOIN \"vacuous\" on \"questionable\".\"store_sales_item_id\" = \"vacuous\".\"store_sales_item_id\"
+    INNER JOIN \"uneven\" on \"questionable\".\"store_sales_store_id\" = \"uneven\".\"store_sales_store_id\"
+    INNER JOIN \"abundant\" on \"questionable\".\"store_sales_customer_id\" = \"abundant\".\"store_sales_customer_id\"
 GROUP BY 
-    abundant.\"store_sales_customer_first_name\",
-    abundant.\"store_sales_customer_last_name\",
-    questionable.\"net_paid\",
-    questionable.\"store_sales_customer_id\",
-    questionable.\"store_sales_item_id\",
-    questionable.\"store_sales_store_id\",
-    uneven.\"store_sales_store_name\",
-    vacuous.\"store_sales_item_color\"),
+    \"abundant\".\"store_sales_customer_first_name\",
+    \"abundant\".\"store_sales_customer_last_name\",
+    \"questionable\".\"net_paid\",
+    \"questionable\".\"store_sales_customer_id\",
+    \"questionable\".\"store_sales_item_id\",
+    \"questionable\".\"store_sales_store_id\",
+    \"uneven\".\"store_sales_store_name\",
+    \"vacuous\".\"store_sales_item_color\"),
 sparkling as (
 SELECT
-    CASE WHEN concerned.\"su_store_sales_item_color\" = 'peach' THEN concerned.\"su_net_paid\" ELSE NULL END as \"_virt_filter_net_paid_3139932349044856\",
-    concerned.\"su_net_paid\" as \"su_net_paid\",
-    concerned.\"su_store_sales_customer_first_name\" as \"su_store_sales_customer_first_name\",
-    concerned.\"su_store_sales_customer_last_name\" as \"su_store_sales_customer_last_name\",
-    concerned.\"su_store_sales_store_name\" as \"su_store_sales_store_name\"
+    \"concerned\".\"su_net_paid\" as \"su_net_paid\",
+    \"concerned\".\"su_store_sales_customer_first_name\" as \"su_store_sales_customer_first_name\",
+    \"concerned\".\"su_store_sales_customer_last_name\" as \"su_store_sales_customer_last_name\",
+    \"concerned\".\"su_store_sales_store_name\" as \"su_store_sales_store_name\",
+    CASE WHEN \"concerned\".\"su_store_sales_item_color\" = 'peach' THEN \"concerned\".\"su_net_paid\" ELSE NULL END as \"_virt_filter_net_paid_3139932349044856\"
 FROM
-    concerned),
+    \"concerned\"),
 young as (
 SELECT
-    avg(concerned.\"su_net_paid\") as \"avg_store_customer_sales\"
+    avg(\"concerned\".\"su_net_paid\") as \"avg_store_customer_sales\"
 FROM
-    concerned),
+    \"concerned\"),
 abhorrent as (
 SELECT
-    sparkling.\"su_store_sales_customer_first_name\" as \"su_store_sales_customer_first_name\",
-    sparkling.\"su_store_sales_customer_last_name\" as \"su_store_sales_customer_last_name\",
-    sparkling.\"su_store_sales_store_name\" as \"su_store_sales_store_name\",
-    sum(sparkling.\"_virt_filter_net_paid_3139932349044856\") as \"peach_sales\"
+    \"sparkling\".\"su_store_sales_customer_first_name\" as \"su_store_sales_customer_first_name\",
+    \"sparkling\".\"su_store_sales_customer_last_name\" as \"su_store_sales_customer_last_name\",
+    \"sparkling\".\"su_store_sales_store_name\" as \"su_store_sales_store_name\",
+    sum(\"sparkling\".\"_virt_filter_net_paid_3139932349044856\") as \"peach_sales\"
 FROM
-    sparkling
+    \"sparkling\"
 GROUP BY 
-    sparkling.\"su_store_sales_customer_first_name\",
-    sparkling.\"su_store_sales_customer_last_name\",
-    sparkling.\"su_store_sales_store_name\")
+    \"sparkling\".\"su_store_sales_customer_first_name\",
+    \"sparkling\".\"su_store_sales_customer_last_name\",
+    \"sparkling\".\"su_store_sales_store_name\")
 SELECT
-    abhorrent.\"su_store_sales_customer_last_name\" as \"su_store_sales_customer_last_name\",
-    abhorrent.\"su_store_sales_customer_first_name\" as \"su_store_sales_customer_first_name\",
-    abhorrent.\"su_store_sales_store_name\" as \"su_store_sales_store_name\",
-    abhorrent.\"peach_sales\" as \"peach_sales\"
+    \"abhorrent\".\"su_store_sales_customer_last_name\" as \"su_store_sales_customer_last_name\",
+    \"abhorrent\".\"su_store_sales_customer_first_name\" as \"su_store_sales_customer_first_name\",
+    \"abhorrent\".\"su_store_sales_store_name\" as \"su_store_sales_store_name\",
+    \"abhorrent\".\"peach_sales\" as \"peach_sales\"
 FROM
-    abhorrent
-    FULL JOIN young on 1=1
+    \"abhorrent\"
+    FULL JOIN \"young\" on 1=1
 WHERE
-    abhorrent.\"peach_sales\" > 0.05 * young.\"avg_store_customer_sales\"
+    \"abhorrent\".\"peach_sales\" > 0.05 * \"young\".\"avg_store_customer_sales\"
 """

--- a/tests/modeling/tpc_ds_duckdb/zquery25.log
+++ b/tests/modeling/tpc_ds_duckdb/zquery25.log
@@ -1,145 +1,145 @@
 query_id = 25
-gen_length = 9017
+gen_length = 9425
 generated_sql = """
 
 WITH 
 uneven as (
 SELECT
-    catalog_sales_catalog_sales.\"CS_BILL_CUSTOMER_SK\" as \"store_sales_customer_id\",
-    catalog_sales_catalog_sales.\"CS_ITEM_SK\" as \"store_sales_item_id\",
-    catalog_sales_catalog_sales.\"CS_SOLD_DATE_SK\" as \"catalog_sales_date_id\"
+    \"catalog_sales_catalog_sales\".\"CS_BILL_CUSTOMER_SK\" as \"store_sales_customer_id\",
+    \"catalog_sales_catalog_sales\".\"CS_ITEM_SK\" as \"store_sales_item_id\",
+    \"catalog_sales_catalog_sales\".\"CS_SOLD_DATE_SK\" as \"catalog_sales_date_id\"
 FROM
-    memory.catalog_sales as catalog_sales_catalog_sales
+    \"memory\".\"catalog_sales\" as \"catalog_sales_catalog_sales\"
 GROUP BY 
-    catalog_sales_catalog_sales.\"CS_BILL_CUSTOMER_SK\",
-    catalog_sales_catalog_sales.\"CS_ITEM_SK\",
-    catalog_sales_catalog_sales.\"CS_SOLD_DATE_SK\"),
+    \"catalog_sales_catalog_sales\".\"CS_BILL_CUSTOMER_SK\",
+    \"catalog_sales_catalog_sales\".\"CS_ITEM_SK\",
+    \"catalog_sales_catalog_sales\".\"CS_SOLD_DATE_SK\"),
 concerned as (
 SELECT
-    catalog_sales_catalog_sales.\"CS_NET_PROFIT\" as \"catalog_sales_net_profit\",
-    catalog_sales_catalog_sales.\"CS_ORDER_NUMBER\" as \"catalog_sales_order_number\",
-    store_sales_item_items.\"I_ITEM_DESC\" as \"store_sales_item_desc\",
-    store_sales_item_items.\"I_ITEM_ID\" as \"store_sales_item_name\",
-    store_sales_item_items.\"I_ITEM_SK\" as \"store_sales_item_id\",
-    store_sales_store_store.\"S_STORE_ID\" as \"store_sales_store_text_id\",
-    store_sales_store_store.\"S_STORE_NAME\" as \"store_sales_store_name\"
+    \"catalog_sales_catalog_sales\".\"CS_NET_PROFIT\" as \"catalog_sales_net_profit\",
+    \"catalog_sales_catalog_sales\".\"CS_ORDER_NUMBER\" as \"catalog_sales_order_number\",
+    \"store_sales_item_items\".\"I_ITEM_DESC\" as \"store_sales_item_desc\",
+    \"store_sales_item_items\".\"I_ITEM_ID\" as \"store_sales_item_name\",
+    \"store_sales_item_items\".\"I_ITEM_SK\" as \"store_sales_item_id\",
+    \"store_sales_store_store\".\"S_STORE_ID\" as \"store_sales_store_text_id\",
+    \"store_sales_store_store\".\"S_STORE_NAME\" as \"store_sales_store_name\"
 FROM
-    memory.store_sales as store_sales_store_sales
-    INNER JOIN memory.date_dim as store_sales_date_date on store_sales_store_sales.\"SS_SOLD_DATE_SK\" = store_sales_date_date.\"D_DATE_SK\"
-    INNER JOIN memory.store as store_sales_store_store on store_sales_store_sales.\"SS_STORE_SK\" = store_sales_store_store.\"S_STORE_SK\"
-    INNER JOIN memory.catalog_sales as catalog_sales_catalog_sales on store_sales_store_sales.\"SS_CUSTOMER_SK\" = catalog_sales_catalog_sales.\"CS_BILL_CUSTOMER_SK\" AND store_sales_store_sales.\"SS_ITEM_SK\" = catalog_sales_catalog_sales.\"CS_ITEM_SK\"
-    INNER JOIN memory.date_dim as catalog_sales_date_date on catalog_sales_catalog_sales.\"CS_SOLD_DATE_SK\" = catalog_sales_date_date.\"D_DATE_SK\"
-    LEFT OUTER JOIN memory.store_returns as store_sales_store_returns on store_sales_store_sales.\"SS_ITEM_SK\" = store_sales_store_returns.\"SR_ITEM_SK\" AND store_sales_store_sales.\"SS_TICKET_NUMBER\" = store_sales_store_returns.\"SR_TICKET_NUMBER\"
-    LEFT OUTER JOIN memory.date_dim as store_sales_return_date_date on store_sales_store_returns.\"SR_RETURNED_DATE_SK\" = store_sales_return_date_date.\"D_DATE_SK\"
-    INNER JOIN memory.item as store_sales_item_items on catalog_sales_catalog_sales.\"CS_ITEM_SK\" = store_sales_item_items.\"I_ITEM_SK\"
+    \"memory\".\"store_sales\" as \"store_sales_store_sales\"
+    INNER JOIN \"memory\".\"date_dim\" as \"store_sales_date_date\" on \"store_sales_store_sales\".\"SS_SOLD_DATE_SK\" = \"store_sales_date_date\".\"D_DATE_SK\"
+    INNER JOIN \"memory\".\"store\" as \"store_sales_store_store\" on \"store_sales_store_sales\".\"SS_STORE_SK\" = \"store_sales_store_store\".\"S_STORE_SK\"
+    INNER JOIN \"memory\".\"catalog_sales\" as \"catalog_sales_catalog_sales\" on \"store_sales_store_sales\".\"SS_CUSTOMER_SK\" = \"catalog_sales_catalog_sales\".\"CS_BILL_CUSTOMER_SK\" AND \"store_sales_store_sales\".\"SS_ITEM_SK\" = \"catalog_sales_catalog_sales\".\"CS_ITEM_SK\"
+    INNER JOIN \"memory\".\"date_dim\" as \"catalog_sales_date_date\" on \"catalog_sales_catalog_sales\".\"CS_SOLD_DATE_SK\" = \"catalog_sales_date_date\".\"D_DATE_SK\"
+    LEFT OUTER JOIN \"memory\".\"store_returns\" as \"store_sales_store_returns\" on \"store_sales_store_sales\".\"SS_ITEM_SK\" = \"store_sales_store_returns\".\"SR_ITEM_SK\" AND \"store_sales_store_sales\".\"SS_TICKET_NUMBER\" = \"store_sales_store_returns\".\"SR_TICKET_NUMBER\"
+    LEFT OUTER JOIN \"memory\".\"date_dim\" as \"store_sales_return_date_date\" on \"store_sales_store_returns\".\"SR_RETURNED_DATE_SK\" = \"store_sales_return_date_date\".\"D_DATE_SK\"
+    INNER JOIN \"memory\".\"item\" as \"store_sales_item_items\" on \"catalog_sales_catalog_sales\".\"CS_ITEM_SK\" = \"store_sales_item_items\".\"I_ITEM_SK\"
 WHERE
-    cast(store_sales_date_date.\"D_YEAR\" as int) = 2001 and store_sales_date_date.\"D_MOY\" = 4 and cast(store_sales_return_date_date.\"D_YEAR\" as int) = 2001 and store_sales_return_date_date.\"D_MOY\" >= 4 and store_sales_return_date_date.\"D_MOY\" <= 10 and cast(catalog_sales_date_date.\"D_YEAR\" as int) = 2001 and catalog_sales_date_date.\"D_MOY\" >= 4 and catalog_sales_date_date.\"D_MOY\" <= 10 and store_sales_store_returns.\"SR_CUSTOMER_SK\" = store_sales_store_sales.\"SS_CUSTOMER_SK\" and CASE WHEN store_sales_store_returns.\"SR_RETURN_TIME_SK\" THEN TRUE ELSE FALSE END
+    cast(\"store_sales_date_date\".\"D_YEAR\" as int) = 2001 and \"store_sales_date_date\".\"D_MOY\" = 4 and cast(\"store_sales_return_date_date\".\"D_YEAR\" as int) = 2001 and \"store_sales_return_date_date\".\"D_MOY\" >= 4 and \"store_sales_return_date_date\".\"D_MOY\" <= 10 and cast(\"catalog_sales_date_date\".\"D_YEAR\" as int) = 2001 and \"catalog_sales_date_date\".\"D_MOY\" >= 4 and \"catalog_sales_date_date\".\"D_MOY\" <= 10 and \"store_sales_store_returns\".\"SR_CUSTOMER_SK\" = \"store_sales_store_sales\".\"SS_CUSTOMER_SK\" and CASE WHEN \"store_sales_store_returns\".\"SR_RETURN_TIME_SK\" THEN TRUE ELSE FALSE END
 ),
 yummy as (
 SELECT
-    store_sales_item_items.\"I_ITEM_DESC\" as \"store_sales_item_desc\",
-    store_sales_item_items.\"I_ITEM_ID\" as \"store_sales_item_name\",
-    store_sales_item_items.\"I_ITEM_SK\" as \"store_sales_item_id\",
-    store_sales_store_returns.\"SR_NET_LOSS\" as \"store_sales_return_net_loss\",
-    store_sales_store_sales.\"SS_NET_PROFIT\" as \"store_sales_net_profit\",
-    store_sales_store_sales.\"SS_TICKET_NUMBER\" as \"store_sales_ticket_number\",
-    store_sales_store_store.\"S_STORE_ID\" as \"store_sales_store_text_id\",
-    store_sales_store_store.\"S_STORE_NAME\" as \"store_sales_store_name\"
+    \"store_sales_item_items\".\"I_ITEM_DESC\" as \"store_sales_item_desc\",
+    \"store_sales_item_items\".\"I_ITEM_ID\" as \"store_sales_item_name\",
+    \"store_sales_item_items\".\"I_ITEM_SK\" as \"store_sales_item_id\",
+    \"store_sales_store_returns\".\"SR_NET_LOSS\" as \"store_sales_return_net_loss\",
+    \"store_sales_store_sales\".\"SS_NET_PROFIT\" as \"store_sales_net_profit\",
+    \"store_sales_store_sales\".\"SS_TICKET_NUMBER\" as \"store_sales_ticket_number\",
+    \"store_sales_store_store\".\"S_STORE_ID\" as \"store_sales_store_text_id\",
+    \"store_sales_store_store\".\"S_STORE_NAME\" as \"store_sales_store_name\"
 FROM
-    memory.store_sales as store_sales_store_sales
-    INNER JOIN memory.date_dim as store_sales_date_date on store_sales_store_sales.\"SS_SOLD_DATE_SK\" = store_sales_date_date.\"D_DATE_SK\"
-    INNER JOIN memory.store as store_sales_store_store on store_sales_store_sales.\"SS_STORE_SK\" = store_sales_store_store.\"S_STORE_SK\"
-    INNER JOIN uneven on store_sales_store_sales.\"SS_CUSTOMER_SK\" = uneven.\"store_sales_customer_id\" AND store_sales_store_sales.\"SS_ITEM_SK\" = uneven.\"store_sales_item_id\"
-    INNER JOIN memory.date_dim as catalog_sales_date_date on uneven.\"catalog_sales_date_id\" = catalog_sales_date_date.\"D_DATE_SK\"
-    LEFT OUTER JOIN memory.store_returns as store_sales_store_returns on store_sales_store_sales.\"SS_ITEM_SK\" = store_sales_store_returns.\"SR_ITEM_SK\" AND store_sales_store_sales.\"SS_TICKET_NUMBER\" = store_sales_store_returns.\"SR_TICKET_NUMBER\"
-    LEFT OUTER JOIN memory.date_dim as store_sales_return_date_date on store_sales_store_returns.\"SR_RETURNED_DATE_SK\" = store_sales_return_date_date.\"D_DATE_SK\"
-    INNER JOIN memory.item as store_sales_item_items on uneven.\"store_sales_item_id\" = store_sales_item_items.\"I_ITEM_SK\"
+    \"memory\".\"store_sales\" as \"store_sales_store_sales\"
+    INNER JOIN \"memory\".\"date_dim\" as \"store_sales_date_date\" on \"store_sales_store_sales\".\"SS_SOLD_DATE_SK\" = \"store_sales_date_date\".\"D_DATE_SK\"
+    INNER JOIN \"memory\".\"store\" as \"store_sales_store_store\" on \"store_sales_store_sales\".\"SS_STORE_SK\" = \"store_sales_store_store\".\"S_STORE_SK\"
+    INNER JOIN \"uneven\" on \"store_sales_store_sales\".\"SS_CUSTOMER_SK\" = \"uneven\".\"store_sales_customer_id\" AND \"store_sales_store_sales\".\"SS_ITEM_SK\" = \"uneven\".\"store_sales_item_id\"
+    INNER JOIN \"memory\".\"date_dim\" as \"catalog_sales_date_date\" on \"uneven\".\"catalog_sales_date_id\" = \"catalog_sales_date_date\".\"D_DATE_SK\"
+    LEFT OUTER JOIN \"memory\".\"store_returns\" as \"store_sales_store_returns\" on \"store_sales_store_sales\".\"SS_ITEM_SK\" = \"store_sales_store_returns\".\"SR_ITEM_SK\" AND \"store_sales_store_sales\".\"SS_TICKET_NUMBER\" = \"store_sales_store_returns\".\"SR_TICKET_NUMBER\"
+    LEFT OUTER JOIN \"memory\".\"date_dim\" as \"store_sales_return_date_date\" on \"store_sales_store_returns\".\"SR_RETURNED_DATE_SK\" = \"store_sales_return_date_date\".\"D_DATE_SK\"
+    INNER JOIN \"memory\".\"item\" as \"store_sales_item_items\" on \"uneven\".\"store_sales_item_id\" = \"store_sales_item_items\".\"I_ITEM_SK\"
 WHERE
-    cast(store_sales_date_date.\"D_YEAR\" as int) = 2001 and store_sales_date_date.\"D_MOY\" = 4 and cast(store_sales_return_date_date.\"D_YEAR\" as int) = 2001 and store_sales_return_date_date.\"D_MOY\" >= 4 and store_sales_return_date_date.\"D_MOY\" <= 10 and cast(catalog_sales_date_date.\"D_YEAR\" as int) = 2001 and catalog_sales_date_date.\"D_MOY\" >= 4 and catalog_sales_date_date.\"D_MOY\" <= 10 and store_sales_store_returns.\"SR_CUSTOMER_SK\" = store_sales_store_sales.\"SS_CUSTOMER_SK\" and CASE WHEN store_sales_store_returns.\"SR_RETURN_TIME_SK\" THEN TRUE ELSE FALSE END
+    cast(\"store_sales_date_date\".\"D_YEAR\" as int) = 2001 and \"store_sales_date_date\".\"D_MOY\" = 4 and cast(\"store_sales_return_date_date\".\"D_YEAR\" as int) = 2001 and \"store_sales_return_date_date\".\"D_MOY\" >= 4 and \"store_sales_return_date_date\".\"D_MOY\" <= 10 and cast(\"catalog_sales_date_date\".\"D_YEAR\" as int) = 2001 and \"catalog_sales_date_date\".\"D_MOY\" >= 4 and \"catalog_sales_date_date\".\"D_MOY\" <= 10 and \"store_sales_store_returns\".\"SR_CUSTOMER_SK\" = \"store_sales_store_sales\".\"SS_CUSTOMER_SK\" and CASE WHEN \"store_sales_store_returns\".\"SR_RETURN_TIME_SK\" THEN TRUE ELSE FALSE END
 ),
 young as (
 SELECT
-    concerned.\"catalog_sales_net_profit\" as \"catalog_sales_net_profit\",
-    concerned.\"catalog_sales_order_number\" as \"catalog_sales_order_number\",
-    concerned.\"store_sales_item_desc\" as \"store_sales_item_desc\",
-    concerned.\"store_sales_item_id\" as \"store_sales_item_id\",
-    concerned.\"store_sales_item_name\" as \"store_sales_item_name\",
-    concerned.\"store_sales_store_name\" as \"store_sales_store_name\",
-    concerned.\"store_sales_store_text_id\" as \"store_sales_store_text_id\"
+    \"concerned\".\"catalog_sales_net_profit\" as \"catalog_sales_net_profit\",
+    \"concerned\".\"catalog_sales_order_number\" as \"catalog_sales_order_number\",
+    \"concerned\".\"store_sales_item_desc\" as \"store_sales_item_desc\",
+    \"concerned\".\"store_sales_item_id\" as \"store_sales_item_id\",
+    \"concerned\".\"store_sales_item_name\" as \"store_sales_item_name\",
+    \"concerned\".\"store_sales_store_name\" as \"store_sales_store_name\",
+    \"concerned\".\"store_sales_store_text_id\" as \"store_sales_store_text_id\"
 FROM
-    concerned
+    \"concerned\"
 GROUP BY 
-    concerned.\"catalog_sales_net_profit\",
-    concerned.\"catalog_sales_order_number\",
-    concerned.\"store_sales_item_desc\",
-    concerned.\"store_sales_item_id\",
-    concerned.\"store_sales_item_name\",
-    concerned.\"store_sales_store_name\",
-    concerned.\"store_sales_store_text_id\"),
+    \"concerned\".\"catalog_sales_net_profit\",
+    \"concerned\".\"catalog_sales_order_number\",
+    \"concerned\".\"store_sales_item_desc\",
+    \"concerned\".\"store_sales_item_id\",
+    \"concerned\".\"store_sales_item_name\",
+    \"concerned\".\"store_sales_store_name\",
+    \"concerned\".\"store_sales_store_text_id\"),
 juicy as (
 SELECT
-    yummy.\"store_sales_item_desc\" as \"store_sales_item_desc\",
-    yummy.\"store_sales_item_id\" as \"store_sales_item_id\",
-    yummy.\"store_sales_item_name\" as \"store_sales_item_name\",
-    yummy.\"store_sales_net_profit\" as \"store_sales_net_profit\",
-    yummy.\"store_sales_return_net_loss\" as \"store_sales_return_net_loss\",
-    yummy.\"store_sales_store_name\" as \"store_sales_store_name\",
-    yummy.\"store_sales_store_text_id\" as \"store_sales_store_text_id\",
-    yummy.\"store_sales_ticket_number\" as \"store_sales_ticket_number\"
+    \"yummy\".\"store_sales_item_desc\" as \"store_sales_item_desc\",
+    \"yummy\".\"store_sales_item_id\" as \"store_sales_item_id\",
+    \"yummy\".\"store_sales_item_name\" as \"store_sales_item_name\",
+    \"yummy\".\"store_sales_net_profit\" as \"store_sales_net_profit\",
+    \"yummy\".\"store_sales_return_net_loss\" as \"store_sales_return_net_loss\",
+    \"yummy\".\"store_sales_store_name\" as \"store_sales_store_name\",
+    \"yummy\".\"store_sales_store_text_id\" as \"store_sales_store_text_id\",
+    \"yummy\".\"store_sales_ticket_number\" as \"store_sales_ticket_number\"
 FROM
-    yummy
+    \"yummy\"
 GROUP BY 
-    yummy.\"store_sales_item_desc\",
-    yummy.\"store_sales_item_id\",
-    yummy.\"store_sales_item_name\",
-    yummy.\"store_sales_net_profit\",
-    yummy.\"store_sales_return_net_loss\",
-    yummy.\"store_sales_store_name\",
-    yummy.\"store_sales_store_text_id\",
-    yummy.\"store_sales_ticket_number\"),
+    \"yummy\".\"store_sales_item_desc\",
+    \"yummy\".\"store_sales_item_id\",
+    \"yummy\".\"store_sales_item_name\",
+    \"yummy\".\"store_sales_net_profit\",
+    \"yummy\".\"store_sales_return_net_loss\",
+    \"yummy\".\"store_sales_store_name\",
+    \"yummy\".\"store_sales_store_text_id\",
+    \"yummy\".\"store_sales_ticket_number\"),
 sparkling as (
 SELECT
-    sum(young.\"catalog_sales_net_profit\") as \"catalog_sales_profit\",
-    young.\"store_sales_item_desc\" as \"store_sales_item_desc\",
-    young.\"store_sales_item_name\" as \"store_sales_item_name\",
-    young.\"store_sales_store_name\" as \"store_sales_store_name\",
-    young.\"store_sales_store_text_id\" as \"store_sales_store_text_id\"
+    \"young\".\"store_sales_item_desc\" as \"store_sales_item_desc\",
+    \"young\".\"store_sales_item_name\" as \"store_sales_item_name\",
+    \"young\".\"store_sales_store_name\" as \"store_sales_store_name\",
+    \"young\".\"store_sales_store_text_id\" as \"store_sales_store_text_id\",
+    sum(\"young\".\"catalog_sales_net_profit\") as \"catalog_sales_profit\"
 FROM
-    young
+    \"young\"
 GROUP BY 
-    young.\"store_sales_item_desc\",
-    young.\"store_sales_item_name\",
-    young.\"store_sales_store_name\",
-    young.\"store_sales_store_text_id\"),
+    \"young\".\"store_sales_item_desc\",
+    \"young\".\"store_sales_item_name\",
+    \"young\".\"store_sales_store_name\",
+    \"young\".\"store_sales_store_text_id\"),
 vacuous as (
 SELECT
-    juicy.\"store_sales_item_desc\" as \"store_sales_item_desc\",
-    juicy.\"store_sales_item_name\" as \"store_sales_item_name\",
-    juicy.\"store_sales_store_name\" as \"store_sales_store_name\",
-    juicy.\"store_sales_store_text_id\" as \"store_sales_store_text_id\",
-    sum(juicy.\"store_sales_net_profit\") as \"store_sales_profit\",
-    sum(juicy.\"store_sales_return_net_loss\") as \"store_returns_loss\"
+    \"juicy\".\"store_sales_item_desc\" as \"store_sales_item_desc\",
+    \"juicy\".\"store_sales_item_name\" as \"store_sales_item_name\",
+    \"juicy\".\"store_sales_store_name\" as \"store_sales_store_name\",
+    \"juicy\".\"store_sales_store_text_id\" as \"store_sales_store_text_id\",
+    sum(\"juicy\".\"store_sales_net_profit\") as \"store_sales_profit\",
+    sum(\"juicy\".\"store_sales_return_net_loss\") as \"store_returns_loss\"
 FROM
-    juicy
+    \"juicy\"
 GROUP BY 
-    juicy.\"store_sales_item_desc\",
-    juicy.\"store_sales_item_name\",
-    juicy.\"store_sales_store_name\",
-    juicy.\"store_sales_store_text_id\")
+    \"juicy\".\"store_sales_item_desc\",
+    \"juicy\".\"store_sales_item_name\",
+    \"juicy\".\"store_sales_store_name\",
+    \"juicy\".\"store_sales_store_text_id\")
 SELECT
-    vacuous.\"store_sales_item_name\" as \"store_sales_item_name\",
-    vacuous.\"store_sales_item_desc\" as \"store_sales_item_desc\",
-    vacuous.\"store_sales_store_text_id\" as \"store_sales_store_text_id\",
-    vacuous.\"store_sales_store_name\" as \"store_sales_store_name\",
-    vacuous.\"store_sales_profit\" as \"store_sales_profit\",
-    vacuous.\"store_returns_loss\" as \"store_returns_loss\",
-    sparkling.\"catalog_sales_profit\" as \"catalog_sales_profit\"
+    \"vacuous\".\"store_sales_item_name\" as \"store_sales_item_name\",
+    \"vacuous\".\"store_sales_item_desc\" as \"store_sales_item_desc\",
+    \"vacuous\".\"store_sales_store_text_id\" as \"store_sales_store_text_id\",
+    \"vacuous\".\"store_sales_store_name\" as \"store_sales_store_name\",
+    \"vacuous\".\"store_sales_profit\" as \"store_sales_profit\",
+    \"vacuous\".\"store_returns_loss\" as \"store_returns_loss\",
+    \"sparkling\".\"catalog_sales_profit\" as \"catalog_sales_profit\"
 FROM
-    vacuous
-    INNER JOIN sparkling on (vacuous.\"store_sales_item_desc\" = sparkling.\"store_sales_item_desc\" or (vacuous.\"store_sales_item_desc\" is null and sparkling.\"store_sales_item_desc\" is null)) AND vacuous.\"store_sales_item_name\" = sparkling.\"store_sales_item_name\" AND vacuous.\"store_sales_store_name\" = sparkling.\"store_sales_store_name\" AND vacuous.\"store_sales_store_text_id\" = sparkling.\"store_sales_store_text_id\"
+    \"vacuous\"
+    INNER JOIN \"sparkling\" on \"vacuous\".\"store_sales_item_name\" = \"sparkling\".\"store_sales_item_name\" AND \"vacuous\".\"store_sales_store_name\" = \"sparkling\".\"store_sales_store_name\" AND \"vacuous\".\"store_sales_store_text_id\" = \"sparkling\".\"store_sales_store_text_id\" AND (\"vacuous\".\"store_sales_item_desc\" = \"sparkling\".\"store_sales_item_desc\" or (\"vacuous\".\"store_sales_item_desc\" is null and \"sparkling\".\"store_sales_item_desc\" is null))
 ORDER BY 
-    vacuous.\"store_sales_item_name\" asc,
-    vacuous.\"store_sales_item_desc\" asc,
-    vacuous.\"store_sales_store_text_id\" asc,
-    vacuous.\"store_sales_store_name\" asc
+    \"vacuous\".\"store_sales_item_name\" asc,
+    \"vacuous\".\"store_sales_item_desc\" asc,
+    \"vacuous\".\"store_sales_store_text_id\" asc,
+    \"vacuous\".\"store_sales_store_name\" asc
 LIMIT (100)"""

--- a/tests/modeling/tpc_ds_duckdb/zquery26.log
+++ b/tests/modeling/tpc_ds_duckdb/zquery26.log
@@ -1,36 +1,36 @@
 query_id = 26
-gen_length = 1780
+gen_length = 1868
 generated_sql = """
 
 WITH 
 cooperative as (
 SELECT
-    cs_catalog_sales.\"CS_COUPON_AMT\" as \"cs_coupon_amt\",
-    cs_catalog_sales.\"CS_LIST_PRICE\" as \"cs_list_price\",
-    cs_catalog_sales.\"CS_ORDER_NUMBER\" as \"cs_order_number\",
-    cs_catalog_sales.\"CS_QUANTITY\" as \"cs_quantity\",
-    cs_catalog_sales.\"CS_SALES_PRICE\" as \"cs_sales_price\",
-    cs_item_items.\"I_ITEM_ID\" as \"cs_item_name\",
-    cs_item_items.\"I_ITEM_SK\" as \"cs_item_id\"
+    \"cs_catalog_sales\".\"CS_COUPON_AMT\" as \"cs_coupon_amt\",
+    \"cs_catalog_sales\".\"CS_LIST_PRICE\" as \"cs_list_price\",
+    \"cs_catalog_sales\".\"CS_ORDER_NUMBER\" as \"cs_order_number\",
+    \"cs_catalog_sales\".\"CS_QUANTITY\" as \"cs_quantity\",
+    \"cs_catalog_sales\".\"CS_SALES_PRICE\" as \"cs_sales_price\",
+    \"cs_item_items\".\"I_ITEM_ID\" as \"cs_item_name\",
+    \"cs_item_items\".\"I_ITEM_SK\" as \"cs_item_id\"
 FROM
-    memory.catalog_sales as cs_catalog_sales
-    INNER JOIN memory.date_dim as cs_date_date on cs_catalog_sales.\"CS_SOLD_DATE_SK\" = cs_date_date.\"D_DATE_SK\"
-    INNER JOIN memory.item as cs_item_items on cs_catalog_sales.\"CS_ITEM_SK\" = cs_item_items.\"I_ITEM_SK\"
-    INNER JOIN memory.promotion as cs_promotion_promotion on cs_catalog_sales.\"CS_PROMO_SK\" = cs_promotion_promotion.\"P_PROMO_SK\"
-    INNER JOIN memory.customer_demographics as cs_bill_customer_demographic_customer_demographics on cs_catalog_sales.\"CS_BILL_CDEMO_SK\" = cs_bill_customer_demographic_customer_demographics.\"CD_DEMO_SK\"
+    \"memory\".\"catalog_sales\" as \"cs_catalog_sales\"
+    INNER JOIN \"memory\".\"date_dim\" as \"cs_date_date\" on \"cs_catalog_sales\".\"CS_SOLD_DATE_SK\" = \"cs_date_date\".\"D_DATE_SK\"
+    INNER JOIN \"memory\".\"item\" as \"cs_item_items\" on \"cs_catalog_sales\".\"CS_ITEM_SK\" = \"cs_item_items\".\"I_ITEM_SK\"
+    INNER JOIN \"memory\".\"promotion\" as \"cs_promotion_promotion\" on \"cs_catalog_sales\".\"CS_PROMO_SK\" = \"cs_promotion_promotion\".\"P_PROMO_SK\"
+    INNER JOIN \"memory\".\"customer_demographics\" as \"cs_bill_customer_demographic_customer_demographics\" on \"cs_catalog_sales\".\"CS_BILL_CDEMO_SK\" = \"cs_bill_customer_demographic_customer_demographics\".\"CD_DEMO_SK\"
 WHERE
-    cs_bill_customer_demographic_customer_demographics.\"CD_GENDER\" = 'M' and cs_bill_customer_demographic_customer_demographics.\"CD_MARITAL_STATUS\" = 'S' and cs_bill_customer_demographic_customer_demographics.\"CD_EDUCATION_STATUS\" = 'College' and ( cs_promotion_promotion.\"P_CHANNEL_EMAIL\" = 'N' or cs_promotion_promotion.\"P_CHANNEL_EVENT\" = 'N' ) and cast(cs_date_date.\"D_YEAR\" as int) = 2000
+    \"cs_bill_customer_demographic_customer_demographics\".\"CD_GENDER\" = 'M' and \"cs_bill_customer_demographic_customer_demographics\".\"CD_MARITAL_STATUS\" = 'S' and \"cs_bill_customer_demographic_customer_demographics\".\"CD_EDUCATION_STATUS\" = 'College' and ( \"cs_promotion_promotion\".\"P_CHANNEL_EMAIL\" = 'N' or \"cs_promotion_promotion\".\"P_CHANNEL_EVENT\" = 'N' ) and cast(\"cs_date_date\".\"D_YEAR\" as int) = 2000
 )
 SELECT
-    cooperative.\"cs_item_name\" as \"cs_item_name\",
-    avg(cooperative.\"cs_quantity\") as \"agg1\",
-    avg(cooperative.\"cs_list_price\") as \"agg2\",
-    avg(cooperative.\"cs_coupon_amt\") as \"agg3\",
-    avg(cooperative.\"cs_sales_price\") as \"agg4\"
+    \"cooperative\".\"cs_item_name\" as \"cs_item_name\",
+    avg(\"cooperative\".\"cs_quantity\") as \"agg1\",
+    avg(\"cooperative\".\"cs_list_price\") as \"agg2\",
+    avg(\"cooperative\".\"cs_coupon_amt\") as \"agg3\",
+    avg(\"cooperative\".\"cs_sales_price\") as \"agg4\"
 FROM
-    cooperative
+    \"cooperative\"
 GROUP BY 
-    cooperative.\"cs_item_name\"
+    \"cooperative\".\"cs_item_name\"
 ORDER BY 
-    cooperative.\"cs_item_name\" asc
+    \"cooperative\".\"cs_item_name\" asc
 LIMIT (100)"""

--- a/tests/modeling/tpc_ds_duckdb/zquery30.log
+++ b/tests/modeling/tpc_ds_duckdb/zquery30.log
@@ -1,173 +1,173 @@
 query_id = 30
-gen_length = 10801
+gen_length = 11137
 generated_sql = """
 
 WITH 
 thoughtful as (
 SELECT
-    web_returns_web_returns.\"WR_RETURNING_ADDR_SK\" as \"web_returns_return_address_id\",
-    web_returns_web_returns.\"WR_RETURNING_CUSTOMER_SK\" as \"web_returns_customer_id\"
+    \"web_returns_web_returns\".\"WR_RETURNING_ADDR_SK\" as \"web_returns_return_address_id\",
+    \"web_returns_web_returns\".\"WR_RETURNING_CUSTOMER_SK\" as \"web_returns_customer_id\"
 FROM
-    memory.web_returns as web_returns_web_returns
+    \"memory\".\"web_returns\" as \"web_returns_web_returns\"
 GROUP BY 
-    web_returns_web_returns.\"WR_RETURNING_ADDR_SK\",
-    web_returns_web_returns.\"WR_RETURNING_CUSTOMER_SK\"),
+    \"web_returns_web_returns\".\"WR_RETURNING_ADDR_SK\",
+    \"web_returns_web_returns\".\"WR_RETURNING_CUSTOMER_SK\"),
 abundant as (
 SELECT
-    cast(web_returns_return_date_date.\"D_YEAR\" as int) as \"web_returns_return_date_year\",
-    web_returns_return_address_customer_address.\"CA_STATE\" as \"web_returns_return_address_state\",
-    web_returns_web_returns.\"WR_ITEM_SK\" as \"web_returns_item_id\",
-    web_returns_web_returns.\"WR_ORDER_NUMBER\" as \"web_returns_web_sales_order_number\",
-    web_returns_web_returns.\"WR_RETURNING_CUSTOMER_SK\" as \"web_returns_customer_id\",
-    web_returns_web_returns.\"WR_RETURN_AMT\" as \"web_returns_return_amount\"
+    \"web_returns_return_address_customer_address\".\"CA_STATE\" as \"web_returns_return_address_state\",
+    \"web_returns_web_returns\".\"WR_ITEM_SK\" as \"web_returns_item_id\",
+    \"web_returns_web_returns\".\"WR_ORDER_NUMBER\" as \"web_returns_web_sales_order_number\",
+    \"web_returns_web_returns\".\"WR_RETURNING_CUSTOMER_SK\" as \"web_returns_customer_id\",
+    \"web_returns_web_returns\".\"WR_RETURN_AMT\" as \"web_returns_return_amount\",
+    cast(\"web_returns_return_date_date\".\"D_YEAR\" as int) as \"web_returns_return_date_year\"
 FROM
-    memory.web_returns as web_returns_web_returns
-    INNER JOIN memory.date_dim as web_returns_return_date_date on web_returns_web_returns.\"WR_RETURNED_DATE_SK\" = web_returns_return_date_date.\"D_DATE_SK\"
-    INNER JOIN memory.customer_address as web_returns_return_address_customer_address on web_returns_web_returns.\"WR_RETURNING_ADDR_SK\" = web_returns_return_address_customer_address.\"CA_ADDRESS_SK\"
+    \"memory\".\"web_returns\" as \"web_returns_web_returns\"
+    INNER JOIN \"memory\".\"date_dim\" as \"web_returns_return_date_date\" on \"web_returns_web_returns\".\"WR_RETURNED_DATE_SK\" = \"web_returns_return_date_date\".\"D_DATE_SK\"
+    INNER JOIN \"memory\".\"customer_address\" as \"web_returns_return_address_customer_address\" on \"web_returns_web_returns\".\"WR_RETURNING_ADDR_SK\" = \"web_returns_return_address_customer_address\".\"CA_ADDRESS_SK\"
 WHERE
-    web_returns_return_address_customer_address.\"CA_STATE\" is not null
+    \"web_returns_return_address_customer_address\".\"CA_STATE\" is not null
 ),
 cooperative as (
 SELECT
-    web_returns_customer_customer_address.\"CA_STATE\" as \"web_returns_customer_state\",
-    web_returns_customer_customers.\"C_BIRTH_COUNTRY\" as \"web_returns_customer_birth_country\",
-    web_returns_customer_customers.\"C_BIRTH_DAY\" as \"web_returns_customer_birth_day\",
-    web_returns_customer_customers.\"C_BIRTH_MONTH\" as \"web_returns_customer_birth_month\",
-    web_returns_customer_customers.\"C_BIRTH_YEAR\" as \"web_returns_customer_birth_year\",
-    web_returns_customer_customers.\"C_CUSTOMER_ID\" as \"web_returns_customer_text_id\",
-    web_returns_customer_customers.\"C_CUSTOMER_SK\" as \"web_returns_customer_id\",
-    web_returns_customer_customers.\"C_EMAIL_ADDRESS\" as \"web_returns_customer_email_address\",
-    web_returns_customer_customers.\"C_FIRST_NAME\" as \"web_returns_customer_first_name\",
-    web_returns_customer_customers.\"C_LAST_NAME\" as \"web_returns_customer_last_name\",
-    web_returns_customer_customers.\"C_LAST_REVIEW_DATE_SK\" as \"web_returns_customer_last_review_date\",
-    web_returns_customer_customers.\"C_LOGIN\" as \"web_returns_customer_login\",
-    web_returns_customer_customers.\"C_PREFERRED_CUST_FLAG\" as \"web_returns_customer_preferred_cust_flag\",
-    web_returns_customer_customers.\"C_SALUTATION\" as \"web_returns_customer_salutation\",
-    web_returns_return_address_customer_address.\"CA_STATE\" as \"web_returns_return_address_state\"
+    \"web_returns_customer_customer_address\".\"CA_STATE\" as \"web_returns_customer_state\",
+    \"web_returns_customer_customers\".\"C_BIRTH_COUNTRY\" as \"web_returns_customer_birth_country\",
+    \"web_returns_customer_customers\".\"C_BIRTH_DAY\" as \"web_returns_customer_birth_day\",
+    \"web_returns_customer_customers\".\"C_BIRTH_MONTH\" as \"web_returns_customer_birth_month\",
+    \"web_returns_customer_customers\".\"C_BIRTH_YEAR\" as \"web_returns_customer_birth_year\",
+    \"web_returns_customer_customers\".\"C_CUSTOMER_ID\" as \"web_returns_customer_text_id\",
+    \"web_returns_customer_customers\".\"C_CUSTOMER_SK\" as \"web_returns_customer_id\",
+    \"web_returns_customer_customers\".\"C_EMAIL_ADDRESS\" as \"web_returns_customer_email_address\",
+    \"web_returns_customer_customers\".\"C_FIRST_NAME\" as \"web_returns_customer_first_name\",
+    \"web_returns_customer_customers\".\"C_LAST_NAME\" as \"web_returns_customer_last_name\",
+    \"web_returns_customer_customers\".\"C_LAST_REVIEW_DATE_SK\" as \"web_returns_customer_last_review_date\",
+    \"web_returns_customer_customers\".\"C_LOGIN\" as \"web_returns_customer_login\",
+    \"web_returns_customer_customers\".\"C_PREFERRED_CUST_FLAG\" as \"web_returns_customer_preferred_cust_flag\",
+    \"web_returns_customer_customers\".\"C_SALUTATION\" as \"web_returns_customer_salutation\",
+    \"web_returns_return_address_customer_address\".\"CA_STATE\" as \"web_returns_return_address_state\"
 FROM
-    thoughtful
-    INNER JOIN memory.customer as web_returns_customer_customers on thoughtful.\"web_returns_customer_id\" = web_returns_customer_customers.\"C_CUSTOMER_SK\"
-    INNER JOIN memory.customer_address as web_returns_return_address_customer_address on thoughtful.\"web_returns_return_address_id\" = web_returns_return_address_customer_address.\"CA_ADDRESS_SK\"
-    INNER JOIN memory.customer_address as web_returns_customer_customer_address on web_returns_customer_customers.\"C_CURRENT_ADDR_SK\" = web_returns_customer_customer_address.\"CA_ADDRESS_SK\"
+    \"thoughtful\"
+    INNER JOIN \"memory\".\"customer\" as \"web_returns_customer_customers\" on \"thoughtful\".\"web_returns_customer_id\" = \"web_returns_customer_customers\".\"C_CUSTOMER_SK\"
+    INNER JOIN \"memory\".\"customer_address\" as \"web_returns_return_address_customer_address\" on \"thoughtful\".\"web_returns_return_address_id\" = \"web_returns_return_address_customer_address\".\"CA_ADDRESS_SK\"
+    INNER JOIN \"memory\".\"customer_address\" as \"web_returns_customer_customer_address\" on \"web_returns_customer_customers\".\"C_CURRENT_ADDR_SK\" = \"web_returns_customer_customer_address\".\"CA_ADDRESS_SK\"
 WHERE
-    web_returns_customer_customer_address.\"CA_STATE\" = 'GA' and web_returns_return_address_customer_address.\"CA_STATE\" is not null
+    \"web_returns_customer_customer_address\".\"CA_STATE\" = 'GA' and \"web_returns_return_address_customer_address\".\"CA_STATE\" is not null
 ),
 uneven as (
 SELECT
-    CASE WHEN abundant.\"web_returns_return_date_year\" = 2002 THEN abundant.\"web_returns_return_amount\" ELSE NULL END as \"_virt_filter_return_amount_1075768703847083\",
-    abundant.\"web_returns_customer_id\" as \"web_returns_customer_id\",
-    abundant.\"web_returns_item_id\" as \"web_returns_item_id\",
-    abundant.\"web_returns_return_address_state\" as \"web_returns_return_address_state\",
-    abundant.\"web_returns_web_sales_order_number\" as \"web_returns_web_sales_order_number\"
+    \"abundant\".\"web_returns_customer_id\" as \"web_returns_customer_id\",
+    \"abundant\".\"web_returns_item_id\" as \"web_returns_item_id\",
+    \"abundant\".\"web_returns_return_address_state\" as \"web_returns_return_address_state\",
+    \"abundant\".\"web_returns_web_sales_order_number\" as \"web_returns_web_sales_order_number\",
+    CASE WHEN \"abundant\".\"web_returns_return_date_year\" = 2002 THEN \"abundant\".\"web_returns_return_amount\" ELSE NULL END as \"_virt_filter_return_amount_1075768703847083\"
 FROM
-    abundant),
+    \"abundant\"),
 yummy as (
 SELECT
-    sum(uneven.\"_virt_filter_return_amount_1075768703847083\") as \"customer_state_returns_2002\",
-    uneven.\"web_returns_customer_id\" as \"web_returns_customer_id\",
-    uneven.\"web_returns_return_address_state\" as \"web_returns_return_address_state\"
+    \"uneven\".\"web_returns_customer_id\" as \"web_returns_customer_id\",
+    \"uneven\".\"web_returns_return_address_state\" as \"web_returns_return_address_state\",
+    sum(\"uneven\".\"_virt_filter_return_amount_1075768703847083\") as \"customer_state_returns_2002\"
 FROM
-    uneven
+    \"uneven\"
 GROUP BY 
-    uneven.\"web_returns_customer_id\",
-    uneven.\"web_returns_return_address_state\"),
+    \"uneven\".\"web_returns_customer_id\",
+    \"uneven\".\"web_returns_return_address_state\"),
 vacuous as (
 SELECT
-    avg(yummy.\"customer_state_returns_2002\") as \"_virt_agg_avg_3885168128306444\",
-    yummy.\"web_returns_return_address_state\" as \"web_returns_return_address_state\"
+    \"yummy\".\"web_returns_return_address_state\" as \"web_returns_return_address_state\",
+    avg(\"yummy\".\"customer_state_returns_2002\") as \"_virt_agg_avg_3885168128306444\"
 FROM
-    yummy
+    \"yummy\"
 GROUP BY 
-    yummy.\"web_returns_return_address_state\"),
+    \"yummy\".\"web_returns_return_address_state\"),
 juicy as (
 SELECT
-    cooperative.\"web_returns_customer_birth_country\" as \"web_returns_customer_birth_country\",
-    cooperative.\"web_returns_customer_birth_day\" as \"web_returns_customer_birth_day\",
-    cooperative.\"web_returns_customer_birth_month\" as \"web_returns_customer_birth_month\",
-    cooperative.\"web_returns_customer_birth_year\" as \"web_returns_customer_birth_year\",
-    cooperative.\"web_returns_customer_email_address\" as \"web_returns_customer_email_address\",
-    cooperative.\"web_returns_customer_first_name\" as \"web_returns_customer_first_name\",
-    cooperative.\"web_returns_customer_id\" as \"web_returns_customer_id\",
-    cooperative.\"web_returns_customer_last_name\" as \"web_returns_customer_last_name\",
-    cooperative.\"web_returns_customer_last_review_date\" as \"web_returns_customer_last_review_date\",
-    cooperative.\"web_returns_customer_login\" as \"web_returns_customer_login\",
-    cooperative.\"web_returns_customer_preferred_cust_flag\" as \"web_returns_customer_preferred_cust_flag\",
-    cooperative.\"web_returns_customer_salutation\" as \"web_returns_customer_salutation\",
-    cooperative.\"web_returns_customer_state\" as \"web_returns_customer_state\",
-    cooperative.\"web_returns_customer_text_id\" as \"web_returns_customer_text_id\",
-    cooperative.\"web_returns_return_address_state\" as \"web_returns_return_address_state\",
-    yummy.\"customer_state_returns_2002\" as \"customer_state_returns_2002\"
+    \"cooperative\".\"web_returns_customer_birth_country\" as \"web_returns_customer_birth_country\",
+    \"cooperative\".\"web_returns_customer_birth_day\" as \"web_returns_customer_birth_day\",
+    \"cooperative\".\"web_returns_customer_birth_month\" as \"web_returns_customer_birth_month\",
+    \"cooperative\".\"web_returns_customer_birth_year\" as \"web_returns_customer_birth_year\",
+    \"cooperative\".\"web_returns_customer_email_address\" as \"web_returns_customer_email_address\",
+    \"cooperative\".\"web_returns_customer_first_name\" as \"web_returns_customer_first_name\",
+    \"cooperative\".\"web_returns_customer_id\" as \"web_returns_customer_id\",
+    \"cooperative\".\"web_returns_customer_last_name\" as \"web_returns_customer_last_name\",
+    \"cooperative\".\"web_returns_customer_last_review_date\" as \"web_returns_customer_last_review_date\",
+    \"cooperative\".\"web_returns_customer_login\" as \"web_returns_customer_login\",
+    \"cooperative\".\"web_returns_customer_preferred_cust_flag\" as \"web_returns_customer_preferred_cust_flag\",
+    \"cooperative\".\"web_returns_customer_salutation\" as \"web_returns_customer_salutation\",
+    \"cooperative\".\"web_returns_customer_state\" as \"web_returns_customer_state\",
+    \"cooperative\".\"web_returns_customer_text_id\" as \"web_returns_customer_text_id\",
+    \"cooperative\".\"web_returns_return_address_state\" as \"web_returns_return_address_state\",
+    \"yummy\".\"customer_state_returns_2002\" as \"customer_state_returns_2002\"
 FROM
-    yummy
-    INNER JOIN cooperative on (yummy.\"web_returns_return_address_state\" = cooperative.\"web_returns_return_address_state\" or (yummy.\"web_returns_return_address_state\" is null and cooperative.\"web_returns_return_address_state\" is null)) AND yummy.\"web_returns_customer_id\" = cooperative.\"web_returns_customer_id\"
+    \"yummy\"
+    INNER JOIN \"cooperative\" on \"yummy\".\"web_returns_customer_id\" = \"cooperative\".\"web_returns_customer_id\" AND (\"yummy\".\"web_returns_return_address_state\" = \"cooperative\".\"web_returns_return_address_state\" or (\"yummy\".\"web_returns_return_address_state\" is null and \"cooperative\".\"web_returns_return_address_state\" is null))
 WHERE
-    cooperative.\"web_returns_customer_state\" = 'GA' and cooperative.\"web_returns_return_address_state\" is not null
+    \"cooperative\".\"web_returns_customer_state\" = 'GA' and \"cooperative\".\"web_returns_return_address_state\" is not null
 ),
 concerned as (
 SELECT
-    juicy.\"customer_state_returns_2002\" as \"customer_state_returns_2002\",
-    juicy.\"web_returns_customer_birth_country\" as \"web_returns_customer_birth_country\",
-    juicy.\"web_returns_customer_birth_day\" as \"web_returns_customer_birth_day\",
-    juicy.\"web_returns_customer_birth_month\" as \"web_returns_customer_birth_month\",
-    juicy.\"web_returns_customer_birth_year\" as \"web_returns_customer_birth_year\",
-    juicy.\"web_returns_customer_email_address\" as \"web_returns_customer_email_address\",
-    juicy.\"web_returns_customer_first_name\" as \"web_returns_customer_first_name\",
-    juicy.\"web_returns_customer_id\" as \"web_returns_customer_id\",
-    juicy.\"web_returns_customer_last_name\" as \"web_returns_customer_last_name\",
-    juicy.\"web_returns_customer_last_review_date\" as \"web_returns_customer_last_review_date\",
-    juicy.\"web_returns_customer_login\" as \"web_returns_customer_login\",
-    juicy.\"web_returns_customer_preferred_cust_flag\" as \"web_returns_customer_preferred_cust_flag\",
-    juicy.\"web_returns_customer_salutation\" as \"web_returns_customer_salutation\",
-    juicy.\"web_returns_customer_text_id\" as \"web_returns_customer_text_id\"
+    \"juicy\".\"customer_state_returns_2002\" as \"customer_state_returns_2002\",
+    \"juicy\".\"web_returns_customer_birth_country\" as \"web_returns_customer_birth_country\",
+    \"juicy\".\"web_returns_customer_birth_day\" as \"web_returns_customer_birth_day\",
+    \"juicy\".\"web_returns_customer_birth_month\" as \"web_returns_customer_birth_month\",
+    \"juicy\".\"web_returns_customer_birth_year\" as \"web_returns_customer_birth_year\",
+    \"juicy\".\"web_returns_customer_email_address\" as \"web_returns_customer_email_address\",
+    \"juicy\".\"web_returns_customer_first_name\" as \"web_returns_customer_first_name\",
+    \"juicy\".\"web_returns_customer_id\" as \"web_returns_customer_id\",
+    \"juicy\".\"web_returns_customer_last_name\" as \"web_returns_customer_last_name\",
+    \"juicy\".\"web_returns_customer_last_review_date\" as \"web_returns_customer_last_review_date\",
+    \"juicy\".\"web_returns_customer_login\" as \"web_returns_customer_login\",
+    \"juicy\".\"web_returns_customer_preferred_cust_flag\" as \"web_returns_customer_preferred_cust_flag\",
+    \"juicy\".\"web_returns_customer_salutation\" as \"web_returns_customer_salutation\",
+    \"juicy\".\"web_returns_customer_text_id\" as \"web_returns_customer_text_id\"
 FROM
-    juicy
-    INNER JOIN vacuous on (juicy.\"web_returns_return_address_state\" = vacuous.\"web_returns_return_address_state\" or (juicy.\"web_returns_return_address_state\" is null and vacuous.\"web_returns_return_address_state\" is null))
+    \"juicy\"
+    INNER JOIN \"vacuous\" on (\"juicy\".\"web_returns_return_address_state\" = \"vacuous\".\"web_returns_return_address_state\" or (\"juicy\".\"web_returns_return_address_state\" is null and \"vacuous\".\"web_returns_return_address_state\" is null))
 WHERE
-    juicy.\"customer_state_returns_2002\" > 1.2 * vacuous.\"_virt_agg_avg_3885168128306444\" and juicy.\"web_returns_customer_state\" = 'GA' and juicy.\"web_returns_return_address_state\" is not null
+    \"juicy\".\"customer_state_returns_2002\" > 1.2 * \"vacuous\".\"_virt_agg_avg_3885168128306444\" and \"juicy\".\"web_returns_customer_state\" = 'GA' and \"juicy\".\"web_returns_return_address_state\" is not null
 )
 SELECT
-    concerned.\"web_returns_customer_text_id\" as \"web_returns_customer_text_id\",
-    concerned.\"web_returns_customer_salutation\" as \"web_returns_customer_salutation\",
-    concerned.\"web_returns_customer_first_name\" as \"web_returns_customer_first_name\",
-    concerned.\"web_returns_customer_last_name\" as \"web_returns_customer_last_name\",
-    concerned.\"web_returns_customer_preferred_cust_flag\" as \"web_returns_customer_preferred_cust_flag\",
-    concerned.\"web_returns_customer_birth_day\" as \"web_returns_customer_birth_day\",
-    concerned.\"web_returns_customer_birth_month\" as \"web_returns_customer_birth_month\",
-    concerned.\"web_returns_customer_birth_year\" as \"web_returns_customer_birth_year\",
-    concerned.\"web_returns_customer_birth_country\" as \"web_returns_customer_birth_country\",
-    concerned.\"web_returns_customer_login\" as \"web_returns_customer_login\",
-    concerned.\"web_returns_customer_email_address\" as \"web_returns_customer_email_address\",
-    concerned.\"web_returns_customer_last_review_date\" as \"web_returns_customer_last_review_date\",
-    concerned.\"customer_state_returns_2002\" as \"customer_state_returns_2002\"
+    \"concerned\".\"web_returns_customer_text_id\" as \"web_returns_customer_text_id\",
+    \"concerned\".\"web_returns_customer_salutation\" as \"web_returns_customer_salutation\",
+    \"concerned\".\"web_returns_customer_first_name\" as \"web_returns_customer_first_name\",
+    \"concerned\".\"web_returns_customer_last_name\" as \"web_returns_customer_last_name\",
+    \"concerned\".\"web_returns_customer_preferred_cust_flag\" as \"web_returns_customer_preferred_cust_flag\",
+    \"concerned\".\"web_returns_customer_birth_day\" as \"web_returns_customer_birth_day\",
+    \"concerned\".\"web_returns_customer_birth_month\" as \"web_returns_customer_birth_month\",
+    \"concerned\".\"web_returns_customer_birth_year\" as \"web_returns_customer_birth_year\",
+    \"concerned\".\"web_returns_customer_birth_country\" as \"web_returns_customer_birth_country\",
+    \"concerned\".\"web_returns_customer_login\" as \"web_returns_customer_login\",
+    \"concerned\".\"web_returns_customer_email_address\" as \"web_returns_customer_email_address\",
+    \"concerned\".\"web_returns_customer_last_review_date\" as \"web_returns_customer_last_review_date\",
+    \"concerned\".\"customer_state_returns_2002\" as \"customer_state_returns_2002\"
 FROM
-    concerned
+    \"concerned\"
 GROUP BY 
-    concerned.\"customer_state_returns_2002\",
-    concerned.\"web_returns_customer_birth_country\",
-    concerned.\"web_returns_customer_birth_day\",
-    concerned.\"web_returns_customer_birth_month\",
-    concerned.\"web_returns_customer_birth_year\",
-    concerned.\"web_returns_customer_email_address\",
-    concerned.\"web_returns_customer_first_name\",
-    concerned.\"web_returns_customer_id\",
-    concerned.\"web_returns_customer_last_name\",
-    concerned.\"web_returns_customer_last_review_date\",
-    concerned.\"web_returns_customer_login\",
-    concerned.\"web_returns_customer_preferred_cust_flag\",
-    concerned.\"web_returns_customer_salutation\",
-    concerned.\"web_returns_customer_text_id\"
+    \"concerned\".\"customer_state_returns_2002\",
+    \"concerned\".\"web_returns_customer_birth_country\",
+    \"concerned\".\"web_returns_customer_birth_day\",
+    \"concerned\".\"web_returns_customer_birth_month\",
+    \"concerned\".\"web_returns_customer_birth_year\",
+    \"concerned\".\"web_returns_customer_email_address\",
+    \"concerned\".\"web_returns_customer_first_name\",
+    \"concerned\".\"web_returns_customer_id\",
+    \"concerned\".\"web_returns_customer_last_name\",
+    \"concerned\".\"web_returns_customer_last_review_date\",
+    \"concerned\".\"web_returns_customer_login\",
+    \"concerned\".\"web_returns_customer_preferred_cust_flag\",
+    \"concerned\".\"web_returns_customer_salutation\",
+    \"concerned\".\"web_returns_customer_text_id\"
 ORDER BY 
-    concerned.\"web_returns_customer_text_id\" asc nulls first,
-    concerned.\"web_returns_customer_salutation\" asc nulls first,
-    concerned.\"web_returns_customer_first_name\" asc nulls first,
-    concerned.\"web_returns_customer_last_name\" asc nulls first,
-    concerned.\"web_returns_customer_preferred_cust_flag\" asc nulls first,
-    concerned.\"web_returns_customer_birth_day\" asc nulls first,
-    concerned.\"web_returns_customer_birth_month\" asc nulls first,
-    concerned.\"web_returns_customer_birth_year\" asc nulls first,
-    concerned.\"web_returns_customer_birth_country\" asc nulls first,
-    concerned.\"web_returns_customer_login\" asc nulls first,
-    concerned.\"web_returns_customer_email_address\" asc nulls first,
-    concerned.\"web_returns_customer_last_review_date\" asc nulls first,
-    concerned.\"customer_state_returns_2002\" asc nulls first
+    \"concerned\".\"web_returns_customer_text_id\" asc nulls first,
+    \"concerned\".\"web_returns_customer_salutation\" asc nulls first,
+    \"concerned\".\"web_returns_customer_first_name\" asc nulls first,
+    \"concerned\".\"web_returns_customer_last_name\" asc nulls first,
+    \"concerned\".\"web_returns_customer_preferred_cust_flag\" asc nulls first,
+    \"concerned\".\"web_returns_customer_birth_day\" asc nulls first,
+    \"concerned\".\"web_returns_customer_birth_month\" asc nulls first,
+    \"concerned\".\"web_returns_customer_birth_year\" asc nulls first,
+    \"concerned\".\"web_returns_customer_birth_country\" asc nulls first,
+    \"concerned\".\"web_returns_customer_login\" asc nulls first,
+    \"concerned\".\"web_returns_customer_email_address\" asc nulls first,
+    \"concerned\".\"web_returns_customer_last_review_date\" asc nulls first,
+    \"concerned\".\"customer_state_returns_2002\" asc nulls first
 LIMIT (100)"""

--- a/tests/modeling/tpc_ds_duckdb/zquery32.log
+++ b/tests/modeling/tpc_ds_duckdb/zquery32.log
@@ -1,59 +1,59 @@
 query_id = 32
-gen_length = 2256
+gen_length = 2370
 generated_sql = """
 
 WITH 
 thoughtful as (
 SELECT
-    cast(sold_date_date.\"D_DATE\" as date) as \"sold_date_date\",
-    catalog_sales.\"CS_EXT_DISCOUNT_AMT\" as \"discount_amount\",
-    catalog_sales.\"CS_ITEM_SK\" as \"item_id\",
-    catalog_sales.\"CS_ORDER_NUMBER\" as \"order_number\"
+    \"catalog_sales\".\"CS_EXT_DISCOUNT_AMT\" as \"discount_amount\",
+    \"catalog_sales\".\"CS_ITEM_SK\" as \"item_id\",
+    \"catalog_sales\".\"CS_ORDER_NUMBER\" as \"order_number\",
+    cast(\"sold_date_date\".\"D_DATE\" as date) as \"sold_date_date\"
 FROM
-    memory.catalog_sales as catalog_sales
-    INNER JOIN memory.date_dim as sold_date_date on catalog_sales.\"CS_SOLD_DATE_SK\" = sold_date_date.\"D_DATE_SK\"),
+    \"memory\".\"catalog_sales\" as \"catalog_sales\"
+    INNER JOIN \"memory\".\"date_dim\" as \"sold_date_date\" on \"catalog_sales\".\"CS_SOLD_DATE_SK\" = \"sold_date_date\".\"D_DATE_SK\"),
 cheerful as (
 SELECT
-    cast(sold_date_date.\"D_DATE\" as date) as \"sold_date_date\",
-    catalog_sales.\"CS_EXT_DISCOUNT_AMT\" as \"discount_amount\",
-    catalog_sales.\"CS_ORDER_NUMBER\" as \"order_number\",
-    item_items.\"I_ITEM_SK\" as \"item_id\",
-    item_items.\"I_MANUFACT_ID\" as \"item_manufacturer_id\"
+    \"catalog_sales\".\"CS_EXT_DISCOUNT_AMT\" as \"discount_amount\",
+    \"catalog_sales\".\"CS_ORDER_NUMBER\" as \"order_number\",
+    \"item_items\".\"I_ITEM_SK\" as \"item_id\",
+    \"item_items\".\"I_MANUFACT_ID\" as \"item_manufacturer_id\",
+    cast(\"sold_date_date\".\"D_DATE\" as date) as \"sold_date_date\"
 FROM
-    memory.catalog_sales as catalog_sales
-    INNER JOIN memory.item as item_items on catalog_sales.\"CS_ITEM_SK\" = item_items.\"I_ITEM_SK\"
-    INNER JOIN memory.date_dim as sold_date_date on catalog_sales.\"CS_SOLD_DATE_SK\" = sold_date_date.\"D_DATE_SK\"
+    \"memory\".\"catalog_sales\" as \"catalog_sales\"
+    INNER JOIN \"memory\".\"item\" as \"item_items\" on \"catalog_sales\".\"CS_ITEM_SK\" = \"item_items\".\"I_ITEM_SK\"
+    INNER JOIN \"memory\".\"date_dim\" as \"sold_date_date\" on \"catalog_sales\".\"CS_SOLD_DATE_SK\" = \"sold_date_date\".\"D_DATE_SK\"
 WHERE
-    item_items.\"I_MANUFACT_ID\" = 977 and cast(sold_date_date.\"D_DATE\" as date) >= :start_date and cast(sold_date_date.\"D_DATE\" as date) <= :end_date
+    \"item_items\".\"I_MANUFACT_ID\" = 977 and cast(\"sold_date_date\".\"D_DATE\" as date) >= :start_date and cast(\"sold_date_date\".\"D_DATE\" as date) <= :end_date
 ),
 cooperative as (
 SELECT
-    CASE WHEN thoughtful.\"sold_date_date\" >= :start_date and thoughtful.\"sold_date_date\" <= :end_date THEN thoughtful.\"discount_amount\" ELSE NULL END as \"_virt_filter_discount_amount_8859191248994797\",
-    thoughtful.\"item_id\" as \"item_id\",
-    thoughtful.\"order_number\" as \"order_number\"
+    \"thoughtful\".\"item_id\" as \"item_id\",
+    \"thoughtful\".\"order_number\" as \"order_number\",
+    CASE WHEN \"thoughtful\".\"sold_date_date\" >= :start_date and \"thoughtful\".\"sold_date_date\" <= :end_date THEN \"thoughtful\".\"discount_amount\" ELSE NULL END as \"_virt_filter_discount_amount_8859191248994797\"
 FROM
-    thoughtful),
+    \"thoughtful\"),
 questionable as (
 SELECT
-    avg(cooperative.\"_virt_filter_discount_amount_8859191248994797\") as \"_virt_agg_avg_721736882945984\",
-    cooperative.\"item_id\" as \"item_id\"
+    \"cooperative\".\"item_id\" as \"item_id\",
+    avg(\"cooperative\".\"_virt_filter_discount_amount_8859191248994797\") as \"_virt_agg_avg_721736882945984\"
 FROM
-    cooperative
+    \"cooperative\"
 GROUP BY 
-    cooperative.\"item_id\"),
+    \"cooperative\".\"item_id\"),
 abundant as (
 SELECT
-    cheerful.\"discount_amount\" as \"discount_amount\",
-    cheerful.\"item_id\" as \"item_id\",
-    cheerful.\"order_number\" as \"order_number\"
+    \"cheerful\".\"discount_amount\" as \"discount_amount\",
+    \"cheerful\".\"item_id\" as \"item_id\",
+    \"cheerful\".\"order_number\" as \"order_number\"
 FROM
-    questionable
-    INNER JOIN cheerful on questionable.\"item_id\" = cheerful.\"item_id\"
+    \"questionable\"
+    INNER JOIN \"cheerful\" on \"questionable\".\"item_id\" = \"cheerful\".\"item_id\"
 WHERE
-    cheerful.\"item_manufacturer_id\" = 977 and cheerful.\"sold_date_date\" >= :start_date and cheerful.\"sold_date_date\" <= :end_date and cheerful.\"discount_amount\" > 1.3 * questionable.\"_virt_agg_avg_721736882945984\"
+    \"cheerful\".\"item_manufacturer_id\" = 977 and \"cheerful\".\"sold_date_date\" >= :start_date and \"cheerful\".\"sold_date_date\" <= :end_date and \"cheerful\".\"discount_amount\" > 1.3 * \"questionable\".\"_virt_agg_avg_721736882945984\"
 )
 SELECT
-    sum(abundant.\"discount_amount\") as \"total_discount\"
+    sum(\"abundant\".\"discount_amount\") as \"total_discount\"
 FROM
-    abundant
+    \"abundant\"
 LIMIT (100)"""

--- a/tests/modeling/tpc_ds_duckdb/zquery95.log
+++ b/tests/modeling/tpc_ds_duckdb/zquery95.log
@@ -1,121 +1,121 @@
 query_id = 95
-gen_length = 5557
+gen_length = 5777
 generated_sql = """
 
 WITH 
 cooperative as (
 SELECT
-    web_sales_web_sales.\"WS_ORDER_NUMBER\" as \"web_sales_order_number\",
-    web_sales_web_sales.\"WS_WAREHOUSE_SK\" as \"web_sales_warehouse_id\"
+    \"web_sales_web_sales\".\"WS_ORDER_NUMBER\" as \"web_sales_order_number\",
+    \"web_sales_web_sales\".\"WS_WAREHOUSE_SK\" as \"web_sales_warehouse_id\"
 FROM
-    memory.web_sales as web_sales_web_sales
+    \"memory\".\"web_sales\" as \"web_sales_web_sales\"
 GROUP BY 
-    web_sales_web_sales.\"WS_ORDER_NUMBER\",
-    web_sales_web_sales.\"WS_WAREHOUSE_SK\"),
+    \"web_sales_web_sales\".\"WS_ORDER_NUMBER\",
+    \"web_sales_web_sales\".\"WS_WAREHOUSE_SK\"),
 juicy as (
 SELECT
-    web_sales_web_sales.\"WS_ORDER_NUMBER\" as \"returned_orders\"
+    \"web_sales_web_sales\".\"WS_ORDER_NUMBER\" as \"returned_orders\"
 FROM
-    memory.web_sales as web_sales_web_sales
-    LEFT OUTER JOIN memory.web_returns as web_sales_web_returns on web_sales_web_sales.\"WS_ITEM_SK\" = web_sales_web_returns.\"WR_ITEM_SK\" AND web_sales_web_sales.\"WS_ORDER_NUMBER\" = web_sales_web_returns.\"WR_ORDER_NUMBER\"
+    \"memory\".\"web_sales\" as \"web_sales_web_sales\"
+    LEFT OUTER JOIN \"memory\".\"web_returns\" as \"web_sales_web_returns\" on \"web_sales_web_sales\".\"WS_ITEM_SK\" = \"web_sales_web_returns\".\"WR_ITEM_SK\" AND \"web_sales_web_sales\".\"WS_ORDER_NUMBER\" = \"web_sales_web_returns\".\"WR_ORDER_NUMBER\"
 WHERE
     CASE WHEN WR_ORDER_NUMBER IS NOT NULL THEN 1 else 0 END is True
 
 GROUP BY 
-    web_sales_web_sales.\"WS_ORDER_NUMBER\"),
+    \"web_sales_web_sales\".\"WS_ORDER_NUMBER\"),
 questionable as (
 SELECT
-    cooperative.\"web_sales_order_number\" as \"web_sales_order_number\",
-    count(cooperative.\"web_sales_warehouse_id\") as \"_virt_agg_count_2435454530783120\"
+    \"cooperative\".\"web_sales_order_number\" as \"web_sales_order_number\",
+    count(\"cooperative\".\"web_sales_warehouse_id\") as \"_virt_agg_count_2435454530783120\"
 FROM
-    cooperative
+    \"cooperative\"
 GROUP BY 
-    cooperative.\"web_sales_order_number\"),
+    \"cooperative\".\"web_sales_order_number\"),
 vacuous as (
 SELECT
-    juicy.\"returned_orders\" as \"returned_orders\"
+    \"juicy\".\"returned_orders\" as \"returned_orders\"
 FROM
-    juicy
+    \"juicy\"
 GROUP BY 
-    juicy.\"returned_orders\"),
+    \"juicy\".\"returned_orders\"),
 abundant as (
 SELECT
-    CASE WHEN questionable.\"_virt_agg_count_2435454530783120\" > 1 THEN questionable.\"web_sales_order_number\" ELSE NULL END as \"multi_warehouse_order\"
+    CASE WHEN \"questionable\".\"_virt_agg_count_2435454530783120\" > 1 THEN \"questionable\".\"web_sales_order_number\" ELSE NULL END as \"multi_warehouse_order\"
 FROM
-    questionable),
+    \"questionable\"),
 uneven as (
 SELECT
-    abundant.\"multi_warehouse_order\" as \"multi_warehouse_order\"
+    \"abundant\".\"multi_warehouse_order\" as \"multi_warehouse_order\"
 FROM
-    abundant
+    \"abundant\"
 GROUP BY 
-    abundant.\"multi_warehouse_order\"),
+    \"abundant\".\"multi_warehouse_order\"),
 thoughtful as (
 SELECT
-    web_sales_web_sales.\"WS_ORDER_NUMBER\" as \"web_sales_order_number\",
-    web_sales_web_sales.\"WS_SHIP_ADDR_SK\" as \"web_sales_ship_address_id\",
-    web_sales_web_sales.\"WS_SHIP_DATE_SK\" as \"web_sales_ship_date_id\",
-    web_sales_web_sales.\"WS_WEB_SITE_SK\" as \"web_sales_web_site_id\"
+    \"web_sales_web_sales\".\"WS_ORDER_NUMBER\" as \"web_sales_order_number\",
+    \"web_sales_web_sales\".\"WS_SHIP_ADDR_SK\" as \"web_sales_ship_address_id\",
+    \"web_sales_web_sales\".\"WS_SHIP_DATE_SK\" as \"web_sales_ship_date_id\",
+    \"web_sales_web_sales\".\"WS_WEB_SITE_SK\" as \"web_sales_web_site_id\"
 FROM
-    memory.web_sales as web_sales_web_sales
+    \"memory\".\"web_sales\" as \"web_sales_web_sales\"
 WHERE
-    web_sales_web_sales.\"WS_ORDER_NUMBER\" in (select uneven.\"multi_warehouse_order\" from uneven where uneven.\"multi_warehouse_order\" is not null) and web_sales_web_sales.\"WS_ORDER_NUMBER\" in (select vacuous.\"returned_orders\" from vacuous where vacuous.\"returned_orders\" is not null)
+    \"web_sales_web_sales\".\"WS_ORDER_NUMBER\" in (select uneven.\"multi_warehouse_order\" from uneven where uneven.\"multi_warehouse_order\" is not null) and \"web_sales_web_sales\".\"WS_ORDER_NUMBER\" in (select vacuous.\"returned_orders\" from vacuous where vacuous.\"returned_orders\" is not null)
 
 GROUP BY 
-    web_sales_web_sales.\"WS_ORDER_NUMBER\",
-    web_sales_web_sales.\"WS_SHIP_ADDR_SK\",
-    web_sales_web_sales.\"WS_SHIP_DATE_SK\",
-    web_sales_web_sales.\"WS_WEB_SITE_SK\"),
+    \"web_sales_web_sales\".\"WS_ORDER_NUMBER\",
+    \"web_sales_web_sales\".\"WS_SHIP_ADDR_SK\",
+    \"web_sales_web_sales\".\"WS_SHIP_DATE_SK\",
+    \"web_sales_web_sales\".\"WS_WEB_SITE_SK\"),
 abhorrent as (
 SELECT
-    web_sales_web_sales.\"WS_EXT_SHIP_COST\" as \"web_sales_extra_ship_cost\",
-    web_sales_web_sales.\"WS_ITEM_SK\" as \"web_sales_item_id\",
-    web_sales_web_sales.\"WS_NET_PROFIT\" as \"web_sales_net_profit\",
-    web_sales_web_sales.\"WS_ORDER_NUMBER\" as \"web_sales_order_number\"
+    \"web_sales_web_sales\".\"WS_EXT_SHIP_COST\" as \"web_sales_extra_ship_cost\",
+    \"web_sales_web_sales\".\"WS_ITEM_SK\" as \"web_sales_item_id\",
+    \"web_sales_web_sales\".\"WS_NET_PROFIT\" as \"web_sales_net_profit\",
+    \"web_sales_web_sales\".\"WS_ORDER_NUMBER\" as \"web_sales_order_number\"
 FROM
-    memory.web_sales as web_sales_web_sales
-    INNER JOIN memory.web_site as web_sales_web_site_web_site on web_sales_web_sales.\"WS_WEB_SITE_SK\" = web_sales_web_site_web_site.\"web_site_sk\"
-    INNER JOIN memory.date_dim as web_sales_ship_date_date on web_sales_web_sales.\"WS_SHIP_DATE_SK\" = web_sales_ship_date_date.\"D_DATE_SK\"
-    INNER JOIN memory.customer_address as web_sales_ship_address_customer_address on web_sales_web_sales.\"WS_SHIP_ADDR_SK\" = web_sales_ship_address_customer_address.\"CA_ADDRESS_SK\"
+    \"memory\".\"web_sales\" as \"web_sales_web_sales\"
+    INNER JOIN \"memory\".\"web_site\" as \"web_sales_web_site_web_site\" on \"web_sales_web_sales\".\"WS_WEB_SITE_SK\" = \"web_sales_web_site_web_site\".\"web_site_sk\"
+    INNER JOIN \"memory\".\"date_dim\" as \"web_sales_ship_date_date\" on \"web_sales_web_sales\".\"WS_SHIP_DATE_SK\" = \"web_sales_ship_date_date\".\"D_DATE_SK\"
+    INNER JOIN \"memory\".\"customer_address\" as \"web_sales_ship_address_customer_address\" on \"web_sales_web_sales\".\"WS_SHIP_ADDR_SK\" = \"web_sales_ship_address_customer_address\".\"CA_ADDRESS_SK\"
 WHERE
-    cast(web_sales_ship_date_date.\"D_DATE\" as date) >= date '1999-02-01' and cast(web_sales_ship_date_date.\"D_DATE\" as date) <= date '1999-04-02' and web_sales_ship_address_customer_address.\"CA_STATE\" = 'IL' and web_sales_web_site_web_site.\"web_company_name\" = 'pri' and web_sales_web_sales.\"WS_ORDER_NUMBER\" in (select uneven.\"multi_warehouse_order\" from uneven where uneven.\"multi_warehouse_order\" is not null) and web_sales_web_sales.\"WS_ORDER_NUMBER\" in (select vacuous.\"returned_orders\" from vacuous where vacuous.\"returned_orders\" is not null)
+    cast(\"web_sales_ship_date_date\".\"D_DATE\" as date) >= date '1999-02-01' and cast(\"web_sales_ship_date_date\".\"D_DATE\" as date) <= date '1999-04-02' and \"web_sales_ship_address_customer_address\".\"CA_STATE\" = 'IL' and \"web_sales_web_site_web_site\".\"web_company_name\" = 'pri' and \"web_sales_web_sales\".\"WS_ORDER_NUMBER\" in (select uneven.\"multi_warehouse_order\" from uneven where uneven.\"multi_warehouse_order\" is not null) and \"web_sales_web_sales\".\"WS_ORDER_NUMBER\" in (select vacuous.\"returned_orders\" from vacuous where vacuous.\"returned_orders\" is not null)
 ),
 concerned as (
 SELECT
-    thoughtful.\"web_sales_order_number\" as \"web_sales_order_number\"
+    \"thoughtful\".\"web_sales_order_number\" as \"web_sales_order_number\"
 FROM
-    thoughtful
-    INNER JOIN memory.web_site as web_sales_web_site_web_site on thoughtful.\"web_sales_web_site_id\" = web_sales_web_site_web_site.\"web_site_sk\"
-    INNER JOIN memory.date_dim as web_sales_ship_date_date on thoughtful.\"web_sales_ship_date_id\" = web_sales_ship_date_date.\"D_DATE_SK\"
-    INNER JOIN memory.customer_address as web_sales_ship_address_customer_address on thoughtful.\"web_sales_ship_address_id\" = web_sales_ship_address_customer_address.\"CA_ADDRESS_SK\"
+    \"thoughtful\"
+    INNER JOIN \"memory\".\"web_site\" as \"web_sales_web_site_web_site\" on \"thoughtful\".\"web_sales_web_site_id\" = \"web_sales_web_site_web_site\".\"web_site_sk\"
+    INNER JOIN \"memory\".\"date_dim\" as \"web_sales_ship_date_date\" on \"thoughtful\".\"web_sales_ship_date_id\" = \"web_sales_ship_date_date\".\"D_DATE_SK\"
+    INNER JOIN \"memory\".\"customer_address\" as \"web_sales_ship_address_customer_address\" on \"thoughtful\".\"web_sales_ship_address_id\" = \"web_sales_ship_address_customer_address\".\"CA_ADDRESS_SK\"
 WHERE
-    cast(web_sales_ship_date_date.\"D_DATE\" as date) >= date '1999-02-01' and cast(web_sales_ship_date_date.\"D_DATE\" as date) <= date '1999-04-02' and web_sales_ship_address_customer_address.\"CA_STATE\" = 'IL' and web_sales_web_site_web_site.\"web_company_name\" = 'pri' and thoughtful.\"web_sales_order_number\" in (select uneven.\"multi_warehouse_order\" from uneven where uneven.\"multi_warehouse_order\" is not null) and thoughtful.\"web_sales_order_number\" in (select vacuous.\"returned_orders\" from vacuous where vacuous.\"returned_orders\" is not null)
+    cast(\"web_sales_ship_date_date\".\"D_DATE\" as date) >= date '1999-02-01' and cast(\"web_sales_ship_date_date\".\"D_DATE\" as date) <= date '1999-04-02' and \"web_sales_ship_address_customer_address\".\"CA_STATE\" = 'IL' and \"web_sales_web_site_web_site\".\"web_company_name\" = 'pri' and \"thoughtful\".\"web_sales_order_number\" in (select uneven.\"multi_warehouse_order\" from uneven where uneven.\"multi_warehouse_order\" is not null) and \"thoughtful\".\"web_sales_order_number\" in (select vacuous.\"returned_orders\" from vacuous where vacuous.\"returned_orders\" is not null)
 ),
 sweltering as (
 SELECT
-    sum(abhorrent.\"web_sales_extra_ship_cost\") as \"total_shipping_cost\",
-    sum(abhorrent.\"web_sales_net_profit\") as \"total_net_profit\"
+    sum(\"abhorrent\".\"web_sales_extra_ship_cost\") as \"total_shipping_cost\",
+    sum(\"abhorrent\".\"web_sales_net_profit\") as \"total_net_profit\"
 FROM
-    abhorrent),
+    \"abhorrent\"),
 young as (
 SELECT
-    concerned.\"web_sales_order_number\" as \"web_sales_order_number\"
+    \"concerned\".\"web_sales_order_number\" as \"web_sales_order_number\"
 FROM
-    concerned
+    \"concerned\"
 GROUP BY 
-    concerned.\"web_sales_order_number\"),
+    \"concerned\".\"web_sales_order_number\"),
 sparkling as (
 SELECT
-    count(young.\"web_sales_order_number\") as \"order_count\"
+    count(\"young\".\"web_sales_order_number\") as \"order_count\"
 FROM
-    young)
+    \"young\")
 SELECT
-    sparkling.\"order_count\" as \"order_count\",
-    sweltering.\"total_shipping_cost\" as \"total_shipping_cost\",
-    sweltering.\"total_net_profit\" as \"total_net_profit\"
+    \"sparkling\".\"order_count\" as \"order_count\",
+    \"sweltering\".\"total_shipping_cost\" as \"total_shipping_cost\",
+    \"sweltering\".\"total_net_profit\" as \"total_net_profit\"
 FROM
-    sparkling
-    FULL JOIN sweltering on 1=1
+    \"sparkling\"
+    FULL JOIN \"sweltering\" on 1=1
 ORDER BY 
-    sparkling.\"order_count\" desc
+    \"sparkling\".\"order_count\" desc
 LIMIT (100)"""

--- a/tests/modeling/tpc_ds_duckdb/zquery97.log
+++ b/tests/modeling/tpc_ds_duckdb/zquery97.log
@@ -1,106 +1,106 @@
 query_id = 97
-gen_length = 4153
+gen_length = 4323
 generated_sql = """
 
 WITH 
 abundant as (
 SELECT
-    catalog_sales_catalog_sales.\"CS_BILL_CUSTOMER_SK\" as \"catalog_sales_bill_customer_id\",
-    catalog_sales_catalog_sales.\"CS_ITEM_SK\" as \"catalog_sales_item_id\",
-    catalog_sales_catalog_sales.\"CS_SOLD_DATE_SK\" as \"catalog_sales_date_id\"
+    \"catalog_sales_catalog_sales\".\"CS_BILL_CUSTOMER_SK\" as \"catalog_sales_bill_customer_id\",
+    \"catalog_sales_catalog_sales\".\"CS_ITEM_SK\" as \"catalog_sales_item_id\",
+    \"catalog_sales_catalog_sales\".\"CS_SOLD_DATE_SK\" as \"catalog_sales_date_id\"
 FROM
-    memory.catalog_sales as catalog_sales_catalog_sales
+    \"memory\".\"catalog_sales\" as \"catalog_sales_catalog_sales\"
 GROUP BY 
-    catalog_sales_catalog_sales.\"CS_BILL_CUSTOMER_SK\",
-    catalog_sales_catalog_sales.\"CS_ITEM_SK\",
-    catalog_sales_catalog_sales.\"CS_SOLD_DATE_SK\"),
+    \"catalog_sales_catalog_sales\".\"CS_BILL_CUSTOMER_SK\",
+    \"catalog_sales_catalog_sales\".\"CS_ITEM_SK\",
+    \"catalog_sales_catalog_sales\".\"CS_SOLD_DATE_SK\"),
 wakeful as (
 SELECT
-    store_sales_store_sales.\"SS_CUSTOMER_SK\" as \"store_sales_customer_id\",
-    store_sales_store_sales.\"SS_ITEM_SK\" as \"store_sales_item_id\",
-    store_sales_store_sales.\"SS_SOLD_DATE_SK\" as \"store_sales_date_id\"
+    \"store_sales_store_sales\".\"SS_CUSTOMER_SK\" as \"store_sales_customer_id\",
+    \"store_sales_store_sales\".\"SS_ITEM_SK\" as \"store_sales_item_id\",
+    \"store_sales_store_sales\".\"SS_SOLD_DATE_SK\" as \"store_sales_date_id\"
 FROM
-    memory.store_sales as store_sales_store_sales
+    \"memory\".\"store_sales\" as \"store_sales_store_sales\"
 GROUP BY 
-    store_sales_store_sales.\"SS_CUSTOMER_SK\",
-    store_sales_store_sales.\"SS_ITEM_SK\",
-    store_sales_store_sales.\"SS_SOLD_DATE_SK\"),
+    \"store_sales_store_sales\".\"SS_CUSTOMER_SK\",
+    \"store_sales_store_sales\".\"SS_ITEM_SK\",
+    \"store_sales_store_sales\".\"SS_SOLD_DATE_SK\"),
 uneven as (
 SELECT
-    abundant.\"catalog_sales_bill_customer_id\" as \"catalog_sales_bill_customer_id\",
-    abundant.\"catalog_sales_item_id\" as \"catalog_sales_item_id\",
-    catalog_sales_date_date.\"D_MONTH_SEQ\" as \"catalog_sales_date_month_seq\"
+    \"abundant\".\"catalog_sales_bill_customer_id\" as \"catalog_sales_bill_customer_id\",
+    \"abundant\".\"catalog_sales_item_id\" as \"catalog_sales_item_id\",
+    \"catalog_sales_date_date\".\"D_MONTH_SEQ\" as \"catalog_sales_date_month_seq\"
 FROM
-    abundant
-    INNER JOIN memory.date_dim as catalog_sales_date_date on abundant.\"catalog_sales_date_id\" = catalog_sales_date_date.\"D_DATE_SK\"
+    \"abundant\"
+    INNER JOIN \"memory\".\"date_dim\" as \"catalog_sales_date_date\" on \"abundant\".\"catalog_sales_date_id\" = \"catalog_sales_date_date\".\"D_DATE_SK\"
 WHERE
-    catalog_sales_date_date.\"D_MONTH_SEQ\" >= 1200 and catalog_sales_date_date.\"D_MONTH_SEQ\" <= 1200 + 11
+    \"catalog_sales_date_date\".\"D_MONTH_SEQ\" >= 1200 and \"catalog_sales_date_date\".\"D_MONTH_SEQ\" <= 1200 + 11
 ),
 cheerful as (
 SELECT
-    store_sales_date_date.\"D_MONTH_SEQ\" as \"store_sales_date_month_seq\",
-    wakeful.\"store_sales_customer_id\" as \"store_sales_customer_id\",
-    wakeful.\"store_sales_item_id\" as \"store_sales_item_id\"
+    \"store_sales_date_date\".\"D_MONTH_SEQ\" as \"store_sales_date_month_seq\",
+    \"wakeful\".\"store_sales_customer_id\" as \"store_sales_customer_id\",
+    \"wakeful\".\"store_sales_item_id\" as \"store_sales_item_id\"
 FROM
-    wakeful
-    INNER JOIN memory.date_dim as store_sales_date_date on wakeful.\"store_sales_date_id\" = store_sales_date_date.\"D_DATE_SK\"
+    \"wakeful\"
+    INNER JOIN \"memory\".\"date_dim\" as \"store_sales_date_date\" on \"wakeful\".\"store_sales_date_id\" = \"store_sales_date_date\".\"D_DATE_SK\"
 WHERE
-    store_sales_date_date.\"D_MONTH_SEQ\" >= 1200 and store_sales_date_date.\"D_MONTH_SEQ\" <= 1200 + 11
+    \"store_sales_date_date\".\"D_MONTH_SEQ\" >= 1200 and \"store_sales_date_date\".\"D_MONTH_SEQ\" <= 1200 + 11
 ),
 yummy as (
 SELECT
-    uneven.\"catalog_sales_bill_customer_id\" as \"catalog_sales_bill_customer_id\",
-    uneven.\"catalog_sales_bill_customer_id\" as \"customer_id\",
-    uneven.\"catalog_sales_item_id\" as \"catalog_sales_item_id\",
-    uneven.\"catalog_sales_item_id\" as \"item_id\"
+    \"uneven\".\"catalog_sales_bill_customer_id\" as \"catalog_sales_bill_customer_id\",
+    \"uneven\".\"catalog_sales_bill_customer_id\" as \"customer_id\",
+    \"uneven\".\"catalog_sales_item_id\" as \"catalog_sales_item_id\",
+    \"uneven\".\"catalog_sales_item_id\" as \"item_id\"
 FROM
-    uneven
+    \"uneven\"
 GROUP BY 
-    uneven.\"catalog_sales_bill_customer_id\",
-    uneven.\"catalog_sales_date_month_seq\",
-    uneven.\"catalog_sales_item_id\"),
+    \"uneven\".\"catalog_sales_bill_customer_id\",
+    \"uneven\".\"catalog_sales_date_month_seq\",
+    \"uneven\".\"catalog_sales_item_id\"),
 thoughtful as (
 SELECT
-    cheerful.\"store_sales_customer_id\" as \"customer_id\",
-    cheerful.\"store_sales_customer_id\" as \"store_sales_customer_id\",
-    cheerful.\"store_sales_item_id\" as \"item_id\",
-    cheerful.\"store_sales_item_id\" as \"store_sales_item_id\"
+    \"cheerful\".\"store_sales_customer_id\" as \"customer_id\",
+    \"cheerful\".\"store_sales_customer_id\" as \"store_sales_customer_id\",
+    \"cheerful\".\"store_sales_item_id\" as \"item_id\",
+    \"cheerful\".\"store_sales_item_id\" as \"store_sales_item_id\"
 FROM
-    cheerful
+    \"cheerful\"
 GROUP BY 
-    cheerful.\"store_sales_customer_id\",
-    cheerful.\"store_sales_date_month_seq\",
-    cheerful.\"store_sales_item_id\"),
+    \"cheerful\".\"store_sales_customer_id\",
+    \"cheerful\".\"store_sales_date_month_seq\",
+    \"cheerful\".\"store_sales_item_id\"),
 juicy as (
 SELECT
-    coalesce(thoughtful.\"customer_id\",yummy.\"customer_id\") as \"merged_customer_id\",
-    coalesce(thoughtful.\"item_id\",yummy.\"item_id\") as \"merged_item_id\",
-    thoughtful.\"store_sales_customer_id\" as \"merged_store_sales_customer_id\",
-    thoughtful.\"store_sales_item_id\" as \"merged_store_sales_item_id\",
-    yummy.\"catalog_sales_bill_customer_id\" as \"merged_catalog_sales_bill_customer_id\",
-    yummy.\"catalog_sales_item_id\" as \"merged_catalog_sales_item_id\"
+    \"thoughtful\".\"store_sales_customer_id\" as \"merged_store_sales_customer_id\",
+    \"thoughtful\".\"store_sales_item_id\" as \"merged_store_sales_item_id\",
+    \"yummy\".\"catalog_sales_bill_customer_id\" as \"merged_catalog_sales_bill_customer_id\",
+    \"yummy\".\"catalog_sales_item_id\" as \"merged_catalog_sales_item_id\",
+    coalesce(\"thoughtful\".\"customer_id\",\"yummy\".\"customer_id\") as \"merged_customer_id\",
+    coalesce(\"thoughtful\".\"item_id\",\"yummy\".\"item_id\") as \"merged_item_id\"
 FROM
-    thoughtful
-    FULL JOIN yummy on thoughtful.\"customer_id\" = yummy.\"customer_id\" AND thoughtful.\"item_id\" = yummy.\"item_id\"
+    \"thoughtful\"
+    FULL JOIN \"yummy\" on \"thoughtful\".\"customer_id\" = \"yummy\".\"customer_id\" AND \"thoughtful\".\"item_id\" = \"yummy\".\"item_id\"
 GROUP BY 
-    coalesce(thoughtful.\"customer_id\",yummy.\"customer_id\"),
-    coalesce(thoughtful.\"item_id\",yummy.\"item_id\"),
-    thoughtful.\"store_sales_customer_id\",
-    thoughtful.\"store_sales_item_id\",
-    yummy.\"catalog_sales_bill_customer_id\",
-    yummy.\"catalog_sales_item_id\")
+    \"thoughtful\".\"store_sales_customer_id\",
+    \"thoughtful\".\"store_sales_item_id\",
+    \"yummy\".\"catalog_sales_bill_customer_id\",
+    \"yummy\".\"catalog_sales_item_id\",
+    coalesce(\"thoughtful\".\"customer_id\",\"yummy\".\"customer_id\"),
+    coalesce(\"thoughtful\".\"item_id\",\"yummy\".\"item_id\"))
 SELECT
     sum(CASE
-	WHEN juicy.\"merged_store_sales_customer_id\" is not null and juicy.\"merged_catalog_sales_bill_customer_id\" is null THEN 1
+	WHEN \"juicy\".\"merged_store_sales_customer_id\" is not null and \"juicy\".\"merged_catalog_sales_bill_customer_id\" is null THEN 1
 	ELSE 0
 	END) as \"store_sales\",
     sum(CASE
-	WHEN juicy.\"merged_store_sales_customer_id\" is null and juicy.\"merged_catalog_sales_bill_customer_id\" is not null THEN 1
+	WHEN \"juicy\".\"merged_store_sales_customer_id\" is null and \"juicy\".\"merged_catalog_sales_bill_customer_id\" is not null THEN 1
 	ELSE 0
 	END) as \"catalog_sales\",
     sum(CASE
-	WHEN juicy.\"merged_store_sales_customer_id\" is not null and juicy.\"merged_catalog_sales_bill_customer_id\" is not null THEN 1
+	WHEN \"juicy\".\"merged_store_sales_customer_id\" is not null and \"juicy\".\"merged_catalog_sales_bill_customer_id\" is not null THEN 1
 	ELSE 0
 	END) as \"both_sales\"
 FROM
-    juicy"""
+    \"juicy\""""

--- a/tests/modeling/tpc_ds_duckdb/zquery98.log
+++ b/tests/modeling/tpc_ds_duckdb/zquery98.log
@@ -1,75 +1,75 @@
 query_id = 98
-gen_length = 4552
+gen_length = 4724
 generated_sql = """
 
 WITH 
 cheerful as (
 SELECT
-    store_sales_item_items.\"I_CATEGORY\" as \"store_sales_item_category\",
-    store_sales_item_items.\"I_CLASS\" as \"store_sales_item_class\",
-    store_sales_item_items.\"I_CURRENT_PRICE\" as \"store_sales_item_current_price\",
-    store_sales_item_items.\"I_ITEM_DESC\" as \"store_sales_item_desc\",
-    store_sales_item_items.\"I_ITEM_ID\" as \"store_sales_item_name\",
-    store_sales_item_items.\"I_ITEM_SK\" as \"store_sales_item_id\",
-    store_sales_store_sales.\"SS_EXT_SALES_PRICE\" as \"store_sales_ext_sales_price\",
-    store_sales_store_sales.\"SS_TICKET_NUMBER\" as \"store_sales_ticket_number\"
+    \"store_sales_item_items\".\"I_CATEGORY\" as \"store_sales_item_category\",
+    \"store_sales_item_items\".\"I_CLASS\" as \"store_sales_item_class\",
+    \"store_sales_item_items\".\"I_CURRENT_PRICE\" as \"store_sales_item_current_price\",
+    \"store_sales_item_items\".\"I_ITEM_DESC\" as \"store_sales_item_desc\",
+    \"store_sales_item_items\".\"I_ITEM_ID\" as \"store_sales_item_name\",
+    \"store_sales_item_items\".\"I_ITEM_SK\" as \"store_sales_item_id\",
+    \"store_sales_store_sales\".\"SS_EXT_SALES_PRICE\" as \"store_sales_ext_sales_price\",
+    \"store_sales_store_sales\".\"SS_TICKET_NUMBER\" as \"store_sales_ticket_number\"
 FROM
-    memory.store_sales as store_sales_store_sales
-    INNER JOIN memory.date_dim as store_sales_date_date on store_sales_store_sales.\"SS_SOLD_DATE_SK\" = store_sales_date_date.\"D_DATE_SK\"
-    INNER JOIN memory.item as store_sales_item_items on store_sales_store_sales.\"SS_ITEM_SK\" = store_sales_item_items.\"I_ITEM_SK\"
+    \"memory\".\"store_sales\" as \"store_sales_store_sales\"
+    INNER JOIN \"memory\".\"date_dim\" as \"store_sales_date_date\" on \"store_sales_store_sales\".\"SS_SOLD_DATE_SK\" = \"store_sales_date_date\".\"D_DATE_SK\"
+    INNER JOIN \"memory\".\"item\" as \"store_sales_item_items\" on \"store_sales_store_sales\".\"SS_ITEM_SK\" = \"store_sales_item_items\".\"I_ITEM_SK\"
 WHERE
-    store_sales_item_items.\"I_CATEGORY\" in ('Sports','Books','Home') and cast(store_sales_date_date.\"D_DATE\" as date) >= date '1999-02-22' and cast(store_sales_date_date.\"D_DATE\" as date) <= date '1999-03-24'
+    \"store_sales_item_items\".\"I_CATEGORY\" in ('Sports','Books','Home') and cast(\"store_sales_date_date\".\"D_DATE\" as date) >= date '1999-02-22' and cast(\"store_sales_date_date\".\"D_DATE\" as date) <= date '1999-03-24'
 ),
 thoughtful as (
 SELECT
-    cheerful.\"store_sales_item_category\" as \"store_sales_item_category\",
-    cheerful.\"store_sales_item_class\" as \"store_sales_item_class\",
-    cheerful.\"store_sales_item_current_price\" as \"store_sales_item_current_price\",
-    cheerful.\"store_sales_item_desc\" as \"store_sales_item_desc\",
-    cheerful.\"store_sales_item_name\" as \"store_sales_item_name\",
-    sum(cheerful.\"store_sales_ext_sales_price\") as \"_virt_agg_sum_9873055619986236\",
-    sum(cheerful.\"store_sales_ext_sales_price\") as \"item_revenue\"
+    \"cheerful\".\"store_sales_item_category\" as \"store_sales_item_category\",
+    \"cheerful\".\"store_sales_item_class\" as \"store_sales_item_class\",
+    \"cheerful\".\"store_sales_item_current_price\" as \"store_sales_item_current_price\",
+    \"cheerful\".\"store_sales_item_desc\" as \"store_sales_item_desc\",
+    \"cheerful\".\"store_sales_item_name\" as \"store_sales_item_name\",
+    sum(\"cheerful\".\"store_sales_ext_sales_price\") as \"_virt_agg_sum_9873055619986236\",
+    sum(\"cheerful\".\"store_sales_ext_sales_price\") as \"item_revenue\"
 FROM
-    cheerful
+    \"cheerful\"
 GROUP BY 
-    cheerful.\"store_sales_item_category\",
-    cheerful.\"store_sales_item_class\",
-    cheerful.\"store_sales_item_current_price\",
-    cheerful.\"store_sales_item_desc\",
-    cheerful.\"store_sales_item_name\"),
+    \"cheerful\".\"store_sales_item_category\",
+    \"cheerful\".\"store_sales_item_class\",
+    \"cheerful\".\"store_sales_item_current_price\",
+    \"cheerful\".\"store_sales_item_desc\",
+    \"cheerful\".\"store_sales_item_name\"),
 cooperative as (
 SELECT
-    cheerful.\"store_sales_item_class\" as \"store_sales_item_class\",
-    sum(cheerful.\"store_sales_ext_sales_price\") as \"_virt_agg_sum_7595906549305205\"
+    \"cheerful\".\"store_sales_item_class\" as \"store_sales_item_class\",
+    sum(\"cheerful\".\"store_sales_ext_sales_price\") as \"_virt_agg_sum_7595906549305205\"
 FROM
-    cheerful
+    \"cheerful\"
 GROUP BY 
-    cheerful.\"store_sales_item_class\"),
+    \"cheerful\".\"store_sales_item_class\"),
 questionable as (
 SELECT
-    thoughtful.\"_virt_agg_sum_9873055619986236\" * 100.0 / (cooperative.\"_virt_agg_sum_7595906549305205\") as \"revenueratio\",
-    thoughtful.\"store_sales_item_category\" as \"store_sales_item_category\",
-    thoughtful.\"store_sales_item_class\" as \"store_sales_item_class\",
-    thoughtful.\"store_sales_item_current_price\" as \"store_sales_item_current_price\",
-    thoughtful.\"store_sales_item_desc\" as \"store_sales_item_desc\",
-    thoughtful.\"store_sales_item_name\" as \"store_sales_item_name\"
+    \"thoughtful\".\"_virt_agg_sum_9873055619986236\" * 100.0 / (\"cooperative\".\"_virt_agg_sum_7595906549305205\") as \"revenueratio\",
+    \"thoughtful\".\"store_sales_item_category\" as \"store_sales_item_category\",
+    \"thoughtful\".\"store_sales_item_class\" as \"store_sales_item_class\",
+    \"thoughtful\".\"store_sales_item_current_price\" as \"store_sales_item_current_price\",
+    \"thoughtful\".\"store_sales_item_desc\" as \"store_sales_item_desc\",
+    \"thoughtful\".\"store_sales_item_name\" as \"store_sales_item_name\"
 FROM
-    thoughtful
-    INNER JOIN cooperative on (thoughtful.\"store_sales_item_class\" = cooperative.\"store_sales_item_class\" or (thoughtful.\"store_sales_item_class\" is null and cooperative.\"store_sales_item_class\" is null)))
+    \"thoughtful\"
+    INNER JOIN \"cooperative\" on (\"thoughtful\".\"store_sales_item_class\" = \"cooperative\".\"store_sales_item_class\" or (\"thoughtful\".\"store_sales_item_class\" is null and \"cooperative\".\"store_sales_item_class\" is null)))
 SELECT
-    questionable.\"store_sales_item_name\" as \"store_sales_item_name\",
-    questionable.\"store_sales_item_desc\" as \"store_sales_item_desc\",
-    questionable.\"store_sales_item_category\" as \"store_sales_item_category\",
-    questionable.\"store_sales_item_class\" as \"store_sales_item_class\",
-    questionable.\"store_sales_item_current_price\" as \"store_sales_item_current_price\",
-    thoughtful.\"item_revenue\" as \"item_revenue\",
-    questionable.\"revenueratio\" as \"revenueratio\"
+    \"questionable\".\"store_sales_item_name\" as \"store_sales_item_name\",
+    \"questionable\".\"store_sales_item_desc\" as \"store_sales_item_desc\",
+    \"questionable\".\"store_sales_item_category\" as \"store_sales_item_category\",
+    \"questionable\".\"store_sales_item_class\" as \"store_sales_item_class\",
+    \"questionable\".\"store_sales_item_current_price\" as \"store_sales_item_current_price\",
+    \"thoughtful\".\"item_revenue\" as \"item_revenue\",
+    \"questionable\".\"revenueratio\" as \"revenueratio\"
 FROM
-    questionable
-    INNER JOIN thoughtful on (questionable.\"store_sales_item_category\" = thoughtful.\"store_sales_item_category\" or (questionable.\"store_sales_item_category\" is null and thoughtful.\"store_sales_item_category\" is null)) AND (questionable.\"store_sales_item_class\" = thoughtful.\"store_sales_item_class\" or (questionable.\"store_sales_item_class\" is null and thoughtful.\"store_sales_item_class\" is null)) AND (questionable.\"store_sales_item_current_price\" = thoughtful.\"store_sales_item_current_price\" or (questionable.\"store_sales_item_current_price\" is null and thoughtful.\"store_sales_item_current_price\" is null)) AND (questionable.\"store_sales_item_desc\" = thoughtful.\"store_sales_item_desc\" or (questionable.\"store_sales_item_desc\" is null and thoughtful.\"store_sales_item_desc\" is null)) AND questionable.\"store_sales_item_name\" = thoughtful.\"store_sales_item_name\"
+    \"questionable\"
+    INNER JOIN \"thoughtful\" on \"questionable\".\"store_sales_item_name\" = \"thoughtful\".\"store_sales_item_name\" AND (\"questionable\".\"store_sales_item_category\" = \"thoughtful\".\"store_sales_item_category\" or (\"questionable\".\"store_sales_item_category\" is null and \"thoughtful\".\"store_sales_item_category\" is null)) AND (\"questionable\".\"store_sales_item_class\" = \"thoughtful\".\"store_sales_item_class\" or (\"questionable\".\"store_sales_item_class\" is null and \"thoughtful\".\"store_sales_item_class\" is null)) AND (\"questionable\".\"store_sales_item_current_price\" = \"thoughtful\".\"store_sales_item_current_price\" or (\"questionable\".\"store_sales_item_current_price\" is null and \"thoughtful\".\"store_sales_item_current_price\" is null)) AND (\"questionable\".\"store_sales_item_desc\" = \"thoughtful\".\"store_sales_item_desc\" or (\"questionable\".\"store_sales_item_desc\" is null and \"thoughtful\".\"store_sales_item_desc\" is null))
 ORDER BY 
-    questionable.\"store_sales_item_category\" asc nulls first,
-    questionable.\"store_sales_item_class\" asc nulls first,
-    questionable.\"store_sales_item_name\" asc nulls first,
-    questionable.\"store_sales_item_desc\" asc nulls first,
-    questionable.\"revenueratio\" asc nulls first"""
+    \"questionable\".\"store_sales_item_category\" asc nulls first,
+    \"questionable\".\"store_sales_item_class\" asc nulls first,
+    \"questionable\".\"store_sales_item_name\" asc nulls first,
+    \"questionable\".\"store_sales_item_desc\" asc nulls first,
+    \"questionable\".\"revenueratio\" asc nulls first"""

--- a/tests/modeling/tpc_ds_duckdb/zquery99.log
+++ b/tests/modeling/tpc_ds_duckdb/zquery99.log
@@ -1,58 +1,58 @@
 query_id = 99
-gen_length = 3584
+gen_length = 3738
 generated_sql = """
 
 WITH 
 questionable as (
 SELECT
-    (cast(catalog_sales.\"CS_ORDER_NUMBER\" as string) || cast(catalog_sales.\"CS_ITEM_SK\" as string)) as \"catalog_pk\",
-    LOWER(call_center_call_center.\"CC_NAME\")  as \"cc_name_lower\",
-    SUBSTRING(warehouse_warehouse.\"w_warehouse_name\",1,20) as \"warehouse_short_name\",
-    catalog_sales.\"CS_ITEM_SK\" as \"item_id\",
-    catalog_sales.\"CS_ORDER_NUMBER\" as \"order_number\",
-    date_diff('day', cast(sold_date_date.\"D_DATE\" as date), cast(ship_date_date.\"D_DATE\" as date)) as \"days_to_ship\",
-    ship_mode_ship_mode.\"SM_TYPE\" as \"ship_mode_type\"
+    \"catalog_sales\".\"CS_ITEM_SK\" as \"item_id\",
+    \"catalog_sales\".\"CS_ORDER_NUMBER\" as \"order_number\",
+    \"ship_mode_ship_mode\".\"SM_TYPE\" as \"ship_mode_type\",
+    (cast(\"catalog_sales\".\"CS_ORDER_NUMBER\" as string) || cast(\"catalog_sales\".\"CS_ITEM_SK\" as string)) as \"catalog_pk\",
+    LOWER(\"call_center_call_center\".\"CC_NAME\")  as \"cc_name_lower\",
+    SUBSTRING(\"warehouse_warehouse\".\"w_warehouse_name\",1,20) as \"warehouse_short_name\",
+    date_diff('day', cast(\"sold_date_date\".\"D_DATE\" as date), cast(\"ship_date_date\".\"D_DATE\" as date)) as \"days_to_ship\"
 FROM
-    memory.catalog_sales as catalog_sales
-    INNER JOIN memory.date_dim as ship_date_date on catalog_sales.\"CS_SHIP_DATE_SK\" = ship_date_date.\"D_DATE_SK\"
-    INNER JOIN memory.ship_mode as ship_mode_ship_mode on catalog_sales.\"CS_SHIP_MODE_SK\" = ship_mode_ship_mode.\"SM_SHIP_MODE_SK\"
-    INNER JOIN memory.date_dim as sold_date_date on catalog_sales.\"CS_SOLD_DATE_SK\" = sold_date_date.\"D_DATE_SK\"
-    INNER JOIN memory.warehouse as warehouse_warehouse on catalog_sales.\"CS_WAREHOUSE_SK\" = warehouse_warehouse.\"w_warehouse_sk\"
-    INNER JOIN memory.call_center as call_center_call_center on catalog_sales.\"CS_CALL_CENTER_SK\" = call_center_call_center.\"CC_CALL_CENTER_SK\"
+    \"memory\".\"catalog_sales\" as \"catalog_sales\"
+    INNER JOIN \"memory\".\"date_dim\" as \"ship_date_date\" on \"catalog_sales\".\"CS_SHIP_DATE_SK\" = \"ship_date_date\".\"D_DATE_SK\"
+    INNER JOIN \"memory\".\"ship_mode\" as \"ship_mode_ship_mode\" on \"catalog_sales\".\"CS_SHIP_MODE_SK\" = \"ship_mode_ship_mode\".\"SM_SHIP_MODE_SK\"
+    INNER JOIN \"memory\".\"date_dim\" as \"sold_date_date\" on \"catalog_sales\".\"CS_SOLD_DATE_SK\" = \"sold_date_date\".\"D_DATE_SK\"
+    INNER JOIN \"memory\".\"warehouse\" as \"warehouse_warehouse\" on \"catalog_sales\".\"CS_WAREHOUSE_SK\" = \"warehouse_warehouse\".\"w_warehouse_sk\"
+    INNER JOIN \"memory\".\"call_center\" as \"call_center_call_center\" on \"catalog_sales\".\"CS_CALL_CENTER_SK\" = \"call_center_call_center\".\"CC_CALL_CENTER_SK\"
 WHERE
-    ship_date_date.\"D_MONTH_SEQ\" >= 1200 and ship_date_date.\"D_MONTH_SEQ\" <= 1211 and catalog_sales.\"CS_ORDER_NUMBER\" is not null and call_center_call_center.\"CC_CALL_CENTER_SK\" is not null and warehouse_warehouse.\"w_warehouse_sk\" is not null and ship_mode_ship_mode.\"SM_SHIP_MODE_SK\" is not null
+    \"ship_date_date\".\"D_MONTH_SEQ\" >= 1200 and \"ship_date_date\".\"D_MONTH_SEQ\" <= 1211 and \"catalog_sales\".\"CS_ORDER_NUMBER\" is not null and \"call_center_call_center\".\"CC_CALL_CENTER_SK\" is not null and \"warehouse_warehouse\".\"w_warehouse_sk\" is not null and \"ship_mode_ship_mode\".\"SM_SHIP_MODE_SK\" is not null
 ),
 abundant as (
 SELECT
-    CASE WHEN questionable.\"days_to_ship\" <= 30 THEN questionable.\"catalog_pk\" ELSE NULL END as \"_virt_filter_catalog_pk_8168372723999465\",
-    CASE WHEN questionable.\"days_to_ship\" > 120 THEN questionable.\"catalog_pk\" ELSE NULL END as \"_virt_filter_catalog_pk_5945567725420865\",
-    CASE WHEN questionable.\"days_to_ship\" > 30 and questionable.\"days_to_ship\" <= 60 THEN questionable.\"catalog_pk\" ELSE NULL END as \"_virt_filter_catalog_pk_6661083751970711\",
-    CASE WHEN questionable.\"days_to_ship\" > 60 and questionable.\"days_to_ship\" <= 90 THEN questionable.\"catalog_pk\" ELSE NULL END as \"_virt_filter_catalog_pk_3717011266371848\",
-    CASE WHEN questionable.\"days_to_ship\" > 90 and questionable.\"days_to_ship\" <= 120 THEN questionable.\"catalog_pk\" ELSE NULL END as \"_virt_filter_catalog_pk_5603765296623263\",
-    questionable.\"cc_name_lower\" as \"cc_name_lower\",
-    questionable.\"item_id\" as \"item_id\",
-    questionable.\"order_number\" as \"order_number\",
-    questionable.\"ship_mode_type\" as \"ship_mode_type\",
-    questionable.\"warehouse_short_name\" as \"warehouse_short_name\"
+    \"questionable\".\"cc_name_lower\" as \"cc_name_lower\",
+    \"questionable\".\"item_id\" as \"item_id\",
+    \"questionable\".\"order_number\" as \"order_number\",
+    \"questionable\".\"ship_mode_type\" as \"ship_mode_type\",
+    \"questionable\".\"warehouse_short_name\" as \"warehouse_short_name\",
+    CASE WHEN \"questionable\".\"days_to_ship\" <= 30 THEN \"questionable\".\"catalog_pk\" ELSE NULL END as \"_virt_filter_catalog_pk_8168372723999465\",
+    CASE WHEN \"questionable\".\"days_to_ship\" > 120 THEN \"questionable\".\"catalog_pk\" ELSE NULL END as \"_virt_filter_catalog_pk_5945567725420865\",
+    CASE WHEN \"questionable\".\"days_to_ship\" > 30 and \"questionable\".\"days_to_ship\" <= 60 THEN \"questionable\".\"catalog_pk\" ELSE NULL END as \"_virt_filter_catalog_pk_6661083751970711\",
+    CASE WHEN \"questionable\".\"days_to_ship\" > 60 and \"questionable\".\"days_to_ship\" <= 90 THEN \"questionable\".\"catalog_pk\" ELSE NULL END as \"_virt_filter_catalog_pk_3717011266371848\",
+    CASE WHEN \"questionable\".\"days_to_ship\" > 90 and \"questionable\".\"days_to_ship\" <= 120 THEN \"questionable\".\"catalog_pk\" ELSE NULL END as \"_virt_filter_catalog_pk_5603765296623263\"
 FROM
-    questionable)
+    \"questionable\")
 SELECT
-    abundant.\"warehouse_short_name\" as \"warehouse_short_name\",
-    abundant.\"ship_mode_type\" as \"ship_mode_type\",
-    abundant.\"cc_name_lower\" as \"cc_name_lower\",
-    count(abundant.\"_virt_filter_catalog_pk_8168372723999465\") as \"less_than_30_days\",
-    count(abundant.\"_virt_filter_catalog_pk_6661083751970711\") as \"between_31_and_60_days\",
-    count(abundant.\"_virt_filter_catalog_pk_3717011266371848\") as \"between_61_and_90_days\",
-    count(abundant.\"_virt_filter_catalog_pk_5603765296623263\") as \"between_91_and_120_days\",
-    count(abundant.\"_virt_filter_catalog_pk_5945567725420865\") as \"over_120_days\"
+    \"abundant\".\"warehouse_short_name\" as \"warehouse_short_name\",
+    \"abundant\".\"ship_mode_type\" as \"ship_mode_type\",
+    \"abundant\".\"cc_name_lower\" as \"cc_name_lower\",
+    count(\"abundant\".\"_virt_filter_catalog_pk_8168372723999465\") as \"less_than_30_days\",
+    count(\"abundant\".\"_virt_filter_catalog_pk_6661083751970711\") as \"between_31_and_60_days\",
+    count(\"abundant\".\"_virt_filter_catalog_pk_3717011266371848\") as \"between_61_and_90_days\",
+    count(\"abundant\".\"_virt_filter_catalog_pk_5603765296623263\") as \"between_91_and_120_days\",
+    count(\"abundant\".\"_virt_filter_catalog_pk_5945567725420865\") as \"over_120_days\"
 FROM
-    abundant
+    \"abundant\"
 GROUP BY 
-    abundant.\"cc_name_lower\",
-    abundant.\"ship_mode_type\",
-    abundant.\"warehouse_short_name\"
+    \"abundant\".\"cc_name_lower\",
+    \"abundant\".\"ship_mode_type\",
+    \"abundant\".\"warehouse_short_name\"
 ORDER BY 
-    abundant.\"warehouse_short_name\" asc nulls first,
-    abundant.\"ship_mode_type\" asc nulls first,
-    abundant.\"cc_name_lower\" asc nulls first
+    \"abundant\".\"warehouse_short_name\" asc nulls first,
+    \"abundant\".\"ship_mode_type\" asc nulls first,
+    \"abundant\".\"cc_name_lower\" asc nulls first
 LIMIT (100)"""

--- a/tests/modeling/tpc_ds_duckdb/zquery_timing_amd64-intel64_family_6_model_183_stepping_1_genuineintel-16.log
+++ b/tests/modeling/tpc_ds_duckdb/zquery_timing_amd64-intel64_family_6_model_183_stepping_1_genuineintel-16.log
@@ -1,104 +1,104 @@
 [query_01]
-parse_time = 0.237496
-exec_time = 0.045411
-comp_time = 0.146956
+parse_time = 0.161129
+exec_time = 0.031051
+comp_time = 0.106026
 
 [query_02]
-parse_time = 1.114932
-exec_time = 0.179756
-comp_time = 0.103727
+parse_time = 0.796146
+exec_time = 0.117098
+comp_time = 0.084431
 
 [query_03]
-parse_time = 0.139115
-exec_time = 0.042225
-comp_time = 0.05038
+parse_time = 0.108992
+exec_time = 0.029584
+comp_time = 0.026276
 
 [query_06]
-parse_time = 0.191366
-exec_time = 0.047822
-comp_time = 0.051277
+parse_time = 0.134825
+exec_time = 0.039068
+comp_time = 0.039646
 
 [query_07]
-parse_time = 0.132557
-exec_time = 0.116607
-comp_time = 0.083539
+parse_time = 0.119221
+exec_time = 0.111574
+comp_time = 0.078567
 
 [query_08]
-parse_time = 0.246295
-exec_time = 0.071149
-comp_time = 0.052839
+parse_time = 0.173285
+exec_time = 0.043312
+comp_time = 0.037728
 
 [query_10]
-parse_time = 0.842077
-exec_time = 0.148738
-comp_time = 0.303031
+parse_time = 0.620997
+exec_time = 0.108632
+comp_time = 0.247263
 
 [query_12]
-parse_time = 0.124745
-exec_time = 0.042575
-comp_time = 0.069627
+parse_time = 0.11185
+exec_time = 0.034118
+comp_time = 0.059699
 
 [query_15]
-parse_time = 0.124096
-exec_time = 0.023202
-comp_time = 0.165782
+parse_time = 0.101608
+exec_time = 0.016465
+comp_time = 0.137495
 
 [query_16]
-parse_time = 0.356479
-exec_time = 0.122555
-comp_time = 0.023965
+parse_time = 0.290674
+exec_time = 0.1086
+comp_time = 0.019415
 
 [query_20]
-parse_time = 0.146883
-exec_time = 0.117491
-comp_time = 0.129973
+parse_time = 0.104049
+exec_time = 0.099644
+comp_time = 0.086161
 
 [query_21]
-parse_time = 0.035422
-exec_time = 0.025979
-comp_time = 0.028526
+parse_time = 0.033338
+exec_time = 0.017739
+comp_time = 0.017111
 
 [query_24]
-parse_time = 0.881584
-exec_time = 0.871516
-comp_time = 0.294387
+parse_time = 0.722497
+exec_time = 0.329622
+comp_time = 0.217254
 
 [query_25]
-parse_time = 0.514234
-exec_time = 0.219992
-comp_time = 0.05175
+parse_time = 0.411059
+exec_time = 0.155751
+comp_time = 0.045618
 
 [query_26]
-parse_time = 0.13221
-exec_time = 0.071383
-comp_time = 0.058741
+parse_time = 0.12727
+exec_time = 0.071357
+comp_time = 0.05616
 
 [query_30]
-parse_time = 0.279273
-exec_time = 0.089965
-comp_time = 0.071269
+parse_time = 0.253303
+exec_time = 0.055857
+comp_time = 0.045486
 
 [query_32]
-parse_time = 0.529375
-exec_time = 0.060548
-comp_time = 0.005842
+parse_time = 0.133574
+exec_time = 0.05451
+comp_time = 0.0051
 
 [query_95]
-parse_time = 0.253624
-exec_time = 0.088427
-comp_time = 0.577242
+parse_time = 0.477082
+exec_time = 0.053942
+comp_time = 0.481938
 
 [query_97]
-parse_time = 0.460478
-exec_time = 0.361268
-comp_time = 0.078718
+parse_time = 0.385416
+exec_time = 0.265577
+comp_time = 0.068563
 
 [query_98]
-parse_time = 0.18894
-exec_time = 0.043459
-comp_time = 0.177817
+parse_time = 0.151435
+exec_time = 0.030034
+comp_time = 0.152518
 
 [query_99]
-parse_time = 0.143243
-exec_time = 0.117132
-comp_time = 0.076346
+parse_time = 0.116481
+exec_time = 0.093376
+comp_time = 0.059866

--- a/tests/modeling/usa_names/test_names.py
+++ b/tests/modeling/usa_names/test_names.py
@@ -22,7 +22,7 @@ limit 100
 
     sql = exec.generate_sql(query)[0]
 
-    assert 'sum(names_usa_names."number") as' in sql, sql
+    assert 'sum("names_usa_names"."number") as' in sql, sql
 
 
 def test_ranking_inclusion():
@@ -49,45 +49,45 @@ order by
         == """WITH 
 wakeful as (
 SELECT
-    names_usa_names."name" as "names_name",
-    sum(names_usa_names."number") as "_virt_agg_sum_7286114413769231"
+    "names_usa_names"."name" as "names_name",
+    sum("names_usa_names"."number") as "_virt_agg_sum_7286114413769231"
 FROM
-    "bigquery-public-data.usa_names.usa_1910_current" as names_usa_names
+    "bigquery-public-data"."usa_names"."usa_1910_current" as "names_usa_names"
 GROUP BY 
-    names_usa_names."name"),
+    "names_usa_names"."name"),
 highfalutin as (
 SELECT
-    names_usa_names."name" as "names_name",
-    names_usa_names."year" as "names_year",
-    sum(names_usa_names."number") as "total_births"
+    "names_usa_names"."name" as "names_name",
+    "names_usa_names"."year" as "names_year",
+    sum("names_usa_names"."number") as "total_births"
 FROM
-    "bigquery-public-data.usa_names.usa_1910_current" as names_usa_names
+    "bigquery-public-data"."usa_names"."usa_1910_current" as "names_usa_names"
 GROUP BY 
-    names_usa_names."name",
-    names_usa_names."year"),
+    "names_usa_names"."name",
+    "names_usa_names"."year"),
 cheerful as (
 SELECT
-    rank() over (order by wakeful."_virt_agg_sum_7286114413769231" desc ) as "name_rank",
-    wakeful."_virt_agg_sum_7286114413769231" as "_virt_agg_sum_7286114413769231",
-    wakeful."names_name" as "names_name"
+    "wakeful"."_virt_agg_sum_7286114413769231" as "_virt_agg_sum_7286114413769231",
+    "wakeful"."names_name" as "names_name",
+    rank() over (order by "wakeful"."_virt_agg_sum_7286114413769231" desc ) as "name_rank"
 FROM
-    wakeful),
+    "wakeful"),
 thoughtful as (
 SELECT
-    cheerful."name_rank" as "name_rank",
-    cheerful."names_name" as "names_name"
+    "cheerful"."name_rank" as "name_rank",
+    "cheerful"."names_name" as "names_name"
 FROM
-    cheerful)
+    "cheerful")
 SELECT
-    highfalutin."names_year" as "names_year",
-    highfalutin."names_name" as "names_name",
-    highfalutin."total_births" as "total_births",
-    thoughtful."name_rank" as "name_rank"
+    "highfalutin"."names_year" as "names_year",
+    "highfalutin"."names_name" as "names_name",
+    "highfalutin"."total_births" as "total_births",
+    "thoughtful"."name_rank" as "name_rank"
 FROM
-    thoughtful
-    INNER JOIN highfalutin on thoughtful."names_name" = highfalutin."names_name"
+    "thoughtful"
+    INNER JOIN "highfalutin" on "thoughtful"."names_name" = "highfalutin"."names_name"
 ORDER BY 
-    thoughtful."name_rank" asc""".strip()
+    "thoughtful"."name_rank" asc""".strip()
     )
 
 
@@ -107,7 +107,7 @@ def test_aggregate_filter_anonymous():
 
     pattern = r"""[a-z]+ as \(
 SELECT
-    ([a-z]+)\."name" as "name",
+    (["a-z]+)\."name" as "name",
     sum\(\1\."_virt_filter_births_\d+"\) as "_virt_agg_sum_\d+",
     sum\(\1\."_virt_filter_births_\d+"\) as "_virt_agg_sum_\d+",
     sum\(\1\."births"\) as "_virt_agg_sum_\d+"
@@ -133,7 +133,7 @@ def test_aggregate_filter():
     sql = exec.generate_sql(query)[0]
     pattern = r"""[a-z]+ as \(
 SELECT
-    ([a-z]+)\."name" as "name",
+    (["a-z]+)\."name" as "name",
     sum\(\1\."_virt_filter_births_\d+"\) as "_virt_agg_sum_\d+",
     sum\(\1\."_virt_filter_births_\d+"\) as "_virt_agg_sum_\d+",
     sum\(\1\."births"\) as "_virt_agg_sum_\d+"
@@ -159,7 +159,7 @@ def test_aggregate_filter_short_syntax():
     sql = exec.generate_sql(query)[0]
     pattern = r"""[a-z]+ as \(
 SELECT
-    ([a-z]+)\."name" as "name",
+    (["a-z]+)\."name" as "name",
     sum\(\1\."_virt_filter_births_\d+"\) as "_virt_agg_sum_\d+",
     sum\(\1\."_virt_filter_births_\d+"\) as "_virt_agg_sum_\d+",
     sum\(\1\."births"\) as "_virt_agg_sum_\d+"
@@ -191,9 +191,9 @@ order by
 
     assert (
         """FROM
-    "bigquery-public-data.usa_names.usa_1910_current" as usa_names
+    "bigquery-public-data"."usa_names"."usa_1910_current" as "usa_names"
 GROUP BY 
-    usa_names."name"),"""
+    "usa_names"."name"),"""
         in sql
     ), sql
 
@@ -230,9 +230,9 @@ def test_multi_window():
     #     ), sql
     pattern = r"""[a-z]+ as \(
 SELECT
-    rank\(\) over \(order by ([a-z]+)\."_virt_agg_sum_\d+" desc \) as "all_rank",
-    \1\."_virt_agg_sum_\d+" as "_virt_agg_sum_\d+",
-    \1\."name" as "name"
+    (["a-z]+)\."_virt_agg_sum_\d+" as "_virt_agg_sum_\d+",
+    \1\."name" as "name",
+    rank\(\) over \(order by \1\."_virt_agg_sum_\d+" desc \) as "all_rank"
 FROM
     \1\)"""
 
@@ -262,7 +262,7 @@ order by names.state asc, total_births desc;
         ["names.state", "names.name"]
     ), env.concepts["rank_by_births"].keys
 
-    pattern = r"""INNER JOIN highfalutin on abundant."names_name" = highfalutin."names_name" AND abundant."names_state" = highfalutin."names_state"""
+    pattern = r"""INNER JOIN "highfalutin" on "abundant"."names_name" = "highfalutin"."names_name" AND "abundant"."names_state" = "highfalutin"."names_state"""
     assert re.search(pattern, sql, re.DOTALL) is not None
 
 

--- a/tests/nodes/utility/test_joins.py
+++ b/tests/nodes/utility/test_joins.py
@@ -49,7 +49,7 @@ address x_source;
         concept=concept,
     )
 
-    assert rendered == "x_source.`y` + 1"
+    assert rendered == "`x_source`.`y` + 1"
 
     env, _ = parse(
         """key x int;

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -261,6 +261,9 @@ def test_string_functions(test_environment):
     property strpos_name <- strpos(category_name, 'a');
     property like_name <- like(category_name, 'a%');
     property like_alt <- category_name like 'a%';
+    property regex_contains <- regexp_contains(category_name, 'a');
+    property regex_substring <- regexp_extract(category_name, 'a');
+    property regex_replace <- regexp_replace(category_name, 'a', 'b');
 
     select
         test_name,

--- a/tests/test_parse_engine.py
+++ b/tests/test_parse_engine.py
@@ -46,6 +46,36 @@ FROM a
 """
 
 
+def test_parse_datatype_in_datasource():
+    env = Environment()
+    x = ParseToObjects(environment=env)
+    test_text = """
+key x int;
+property x.timestamp timestamp;
+
+datasource funky (
+    x: x,
+    timestamp:timestamp)
+address fun;
+
+"""
+    x.set_text(test_text)
+
+    tokens = PARSER.parse(test_text)
+    x.transform(tokens)
+    x.run_second_parse_pass()
+
+
+TEXT2 = """
+const a <- 1;
+
+select
+    a,
+FROM a
+;
+"""
+
+
 def test_from_error():
     env = Environment()
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -496,7 +496,7 @@ select x;
 
     results = Dialects.DUCK_DB.default_executor().generate_sql(text)[0]
 
-    assert '"abc:def" as test' in results
+    assert '"abc:def" as "test"' in results
 
     text = """
 key x int;
@@ -516,7 +516,7 @@ select x;
 
     results = Dialects.DUCK_DB.default_executor().generate_sql(text)[0]
 
-    assert "abcdef as test" in results, results
+    assert '"abcdef" as "test"' in results, results
 
 
 def test_datasource_where_equivalent():

--- a/tests/test_show.py
+++ b/tests/test_show.py
@@ -53,5 +53,5 @@ def test_show_bigquery():
         .fetchall()
     )
     assert (
-        "FULL JOIN cheerful on 1=1" in query[0]["__preql_internal_query_text"]
+        'FULL JOIN "cheerful" on 1=1' in query[0]["__preql_internal_query_text"]
     ), query[0]["__preql_internal_query_text"]

--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -4,6 +4,6 @@ from trilogy.dialect.enums import Dialects
 from trilogy.executor import Executor
 from trilogy.parser import parse
 
-__version__ = "0.0.3.52"
+__version__ = "0.0.3.53"
 
 __all__ = ["parse", "Executor", "Dialects", "Environment", "CONFIG"]

--- a/trilogy/core/enums.py
+++ b/trilogy/core/enums.py
@@ -181,7 +181,7 @@ class FunctionType(Enum):
     STRPOS = "strpos"
     CONTAINS = "contains"
 
-    #STRING REGEX
+    # STRING REGEX
     REGEXP_CONTAINS = "regexp_contains"
     REGEXP_EXTRACT = "regexp_extract"
     REGEXP_REPLACE = "regexp_replace"

--- a/trilogy/core/enums.py
+++ b/trilogy/core/enums.py
@@ -181,6 +181,11 @@ class FunctionType(Enum):
     STRPOS = "strpos"
     CONTAINS = "contains"
 
+    #STRING REGEX
+    REGEXP_CONTAINS = "regexp_contains"
+    REGEXP_EXTRACT = "regexp_extract"
+    REGEXP_REPLACE = "regexp_replace"
+
     # Dates
     DATE = "date"
     DATETIME = "datetime"

--- a/trilogy/core/functions.py
+++ b/trilogy/core/functions.py
@@ -173,6 +173,7 @@ def get_date_trunc_output(
     else:
         raise InvalidSyntaxException(f"Date truncation not supported for {target}")
 
+
 FUNCTION_REGISTRY: dict[FunctionType, FunctionConfig] = {
     FunctionType.ALIAS: FunctionConfig(
         arg_count=1,

--- a/trilogy/core/functions.py
+++ b/trilogy/core/functions.py
@@ -360,6 +360,24 @@ FUNCTION_REGISTRY: dict[FunctionType, FunctionConfig] = {
         output_type=DataType.STRING,
         arg_count=1,
     ),
+    FunctionType.REGEXP_CONTAINS: FunctionConfig(
+        valid_inputs={DataType.STRING},
+        output_purpose=Purpose.PROPERTY,
+        output_type=DataType.BOOL,
+        arg_count=2,
+    ),
+    FunctionType.REGEXP_EXTRACT: FunctionConfig(
+        valid_inputs={DataType.STRING},
+        output_purpose=Purpose.PROPERTY,
+        output_type=DataType.STRING,
+        arg_count=2,
+    ),
+    FunctionType.REGEXP_REPLACE: FunctionConfig(
+        valid_inputs={DataType.STRING},
+        output_purpose=Purpose.PROPERTY,
+        output_type=DataType.STRING,
+        arg_count=3,
+    ),
     FunctionType.DATE: FunctionConfig(
         valid_inputs={
             DataType.DATE,

--- a/trilogy/core/functions.py
+++ b/trilogy/core/functions.py
@@ -173,7 +173,6 @@ def get_date_trunc_output(
     else:
         raise InvalidSyntaxException(f"Date truncation not supported for {target}")
 
-
 FUNCTION_REGISTRY: dict[FunctionType, FunctionConfig] = {
     FunctionType.ALIAS: FunctionConfig(
         arg_count=1,

--- a/trilogy/core/models/execute.py
+++ b/trilogy/core/models/execute.py
@@ -324,10 +324,10 @@ class CTE(BaseModel):
         return self.source.name
 
     @property
-    def quote_address(self) -> dict[str, bool]:
+    def quote_address(self) -> bool:
         if self.is_root_datasource:
             root = self.source.datasources[0]
-            if isinstance(root.address, Address):
+            if isinstance(root, BuildDatasource) and isinstance(root.address, Address):
                 return not root.address.is_query
             return True
         elif not self.source.datasources:

--- a/trilogy/core/utility.py
+++ b/trilogy/core/utility.py
@@ -1,0 +1,8 @@
+def safe_quote(string: str, quote_char: str):
+    # split dotted identifiers
+    # TODO: evaluate if we need smarter parsing for strings that could actually include .
+    if string.startswith("https://"):
+        # it's a url, no splitting
+        return f"{quote_char}{string}{quote_char}"
+    components = string.split(".")
+    return ".".join([f"{quote_char}{string}{quote_char}" for string in components])

--- a/trilogy/dialect/bigquery.py
+++ b/trilogy/dialect/bigquery.py
@@ -18,6 +18,7 @@ FUNCTION_MAP = {
     FunctionType.LIKE: lambda x: (
         f" CASE WHEN {x[0]} like {x[1]} THEN True ELSE False END"
     ),
+    FunctionType.IS_NULL: lambda x: f"CASE WHEN {x[0]} IS NULL THEN True ELSE False END",
     FunctionType.MINUTE: lambda x: f"EXTRACT(MINUTE from {x[0]})",
     FunctionType.SECOND: lambda x: f"EXTRACT(SECOND from {x[0]})",
     FunctionType.HOUR: lambda x: f"EXTRACT(HOUR from {x[0]})",

--- a/trilogy/dialect/common.py
+++ b/trilogy/dialect/common.py
@@ -63,8 +63,8 @@ def render_join_concept(
         elif isinstance(raw_content, BuildFunction):
             rval = render_expr(raw_content, cte=cte)
             return rval
-        return f"{name}.{quote_character}{raw_content}{quote_character}"
-    return f"{name}.{quote_character}{concept.safe_address}{quote_character}"
+        return f"{quote_character}{name}{quote_character}.{quote_character}{raw_content}{quote_character}"
+    return f"{quote_character}{name}{quote_character}.{quote_character}{concept.safe_address}{quote_character}"
 
 
 def render_join(
@@ -91,8 +91,9 @@ def render_join(
         return f"FULL JOIN {render_unnest(unnest_mode, quote_character, join.object_to_unnest, render_expr_func, cte)}"
     # left_name = join.left_name
     right_name = join.right_name
-    if cte.quote_address.get(join.right_name, False):
-        join.quote = quote_character
+    join.quote = quote_character
+    # if cte.quote_address.get(join.right_name, False):
+    #     join.quote = quote_character
     right_base = join.right_ref
     base_joinkeys = []
     if join.joinkey_pairs:

--- a/trilogy/parsing/parse_engine.py
+++ b/trilogy/parsing/parse_engine.py
@@ -1746,18 +1746,24 @@ class ParseToObjects(Transformer):
     @v_args(meta=True)
     def flower(self, meta, args):
         return self.function_factory.create_function(args, FunctionType.LOWER, meta)
-    
+
     @v_args(meta=True)
     def fregexp_contains(self, meta, args):
-        return self.function_factory.create_function(args, FunctionType.REGEXP_CONTAINS, meta)
-    
+        return self.function_factory.create_function(
+            args, FunctionType.REGEXP_CONTAINS, meta
+        )
+
     @v_args(meta=True)
     def fregexp_extract(self, meta, args):
-        return self.function_factory.create_function(args, FunctionType.REGEXP_EXTRACT, meta)
+        return self.function_factory.create_function(
+            args, FunctionType.REGEXP_EXTRACT, meta
+        )
 
     @v_args(meta=True)
     def fregexp_replace(self, meta, args):
-        return self.function_factory.create_function(args, FunctionType.REGEXP_REPLACE, meta)
+        return self.function_factory.create_function(
+            args, FunctionType.REGEXP_REPLACE, meta
+        )
 
     # date functions
     @v_args(meta=True)

--- a/trilogy/parsing/parse_engine.py
+++ b/trilogy/parsing/parse_engine.py
@@ -1744,8 +1744,20 @@ class ParseToObjects(Transformer):
         return self.function_factory.create_function(args, FunctionType.SUBSTRING, meta)
 
     @v_args(meta=True)
-    def lower(self, meta, args):
+    def flower(self, meta, args):
         return self.function_factory.create_function(args, FunctionType.LOWER, meta)
+    
+    @v_args(meta=True)
+    def fregexp_contains(self, meta, args):
+        return self.function_factory.create_function(args, FunctionType.REGEXP_CONTAINS, meta)
+    
+    @v_args(meta=True)
+    def fregexp_extract(self, meta, args):
+        return self.function_factory.create_function(args, FunctionType.REGEXP_EXTRACT, meta)
+
+    @v_args(meta=True)
+    def fregexp_replace(self, meta, args):
+        return self.function_factory.create_function(args, FunctionType.REGEXP_REPLACE, meta)
 
     # date functions
     @v_args(meta=True)

--- a/trilogy/parsing/trilogy.lark
+++ b/trilogy/parsing/trilogy.lark
@@ -267,7 +267,7 @@
     _UPPER.1: "upper("i
     upper: _UPPER expr ")"
     _LOWER.1: "lower("i
-    lower: _LOWER expr ")"  
+    flower: _LOWER expr ")"  
     _SPLIT.1: "split("i  
     fsplit: _SPLIT expr "," string_lit ")"
     _STRPOS.1: "strpos("i
@@ -276,8 +276,14 @@
     fcontains: _CONTAINS expr "," expr ")"
     _SUBSTRING.1: "substring("i
     fsubstring: _SUBSTRING expr "," expr "," expr ")"
-    
-    _string_functions: like | ilike | upper | lower | fsplit | fstrpos | fsubstring | fcontains
+    _REGEXP_EXTRACT.1: "regexp_extract("
+    fregexp_extract: _REGEXP_EXTRACT expr "," expr ")"
+    _REGEXP_CONTAINS.1: "regexp_contains("
+    fregexp_contains: _REGEXP_CONTAINS expr "," expr  ")"
+    _REGEXP_REPLACE.1: "regexp_replace("
+    fregexp_replace: _REGEXP_REPLACE expr "," expr "," expr   ")"
+
+    _string_functions: like | ilike | upper | flower | fsplit | fstrpos | fsubstring | fcontains | fregexp_extract | fregexp_contains | fregexp_replace
     
     // special aggregate
     _GROUP.1: "group("i
@@ -311,7 +317,8 @@
     _DATE.1: "date("i
     fdate:  _DATE expr ")"
     fdatetime: "datetime"i "(" expr ")"
-    ftimestamp: "timestamp"i "(" expr ")"
+    _TIMESTAMP.1: "timestamp("i
+    ftimestamp: _TIMESTAMP expr ")"
     
     _SECOND.1: "second("i
     fsecond: _SECOND expr ")"


### PR DESCRIPTION
## Description

BigQuery syntax can be pretty finicky about keywords. This was a problem when users name datasources after keywords. Explicitly quote everywhere by default to eliminate this whole class of errors.

Add in regex string functions (contains/extract/replace)

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
