### PR TITLE
Basic Recursion

### DIFF
--- a/tests/engine/recursive.preql
+++ b/tests/engine/recursive.preql
@@ -1,0 +1,44 @@
+key id int;
+property id.parent int;
+
+property id.label string;
+
+
+datasource nodes (
+    id: id,
+    label: label
+)
+grain (id)
+query '''
+select 1 as id, 'A' as label
+union all
+select 2, 'B'
+union all
+select 3, 'C'
+union all
+select 4, 'D'
+union all
+select 5, 'E'
+union all
+select 6, 'F'
+''';
+
+
+datasource edges (
+    id: id,
+    parent: parent
+)
+grain (id)
+query '''
+select 1 as id, null as parent
+union all
+select 2, 1
+union all
+select 3, 2
+union all
+select 4, 3
+union all 
+select 5, null
+union all
+select 6, 5
+''';

--- a/tests/engine/test_duckdb.py
+++ b/tests/engine/test_duckdb.py
@@ -1407,6 +1407,12 @@ merge first_parent into parent.id;
                                """
     )
 
+    recursive = executor.environment.alias_origin_lookup["local.first_parent"]
+    assert (
+        recursive.derivation == Derivation.RECURSIVE
+    ), "recursive should be recursive"
+    
+
     results = executor.execute_text(
         """where
 first_parent = 1

--- a/tests/engine/test_duckdb.py
+++ b/tests/engine/test_duckdb.py
@@ -1369,7 +1369,7 @@ auto first_parent <- recurse_edge(id, parent);"""
     assert (
         executor.environment.concepts["first_parent"].derivation == Derivation.RECURSIVE
     )
-    sql = executor.generate_sql(
+    executor.generate_sql(
         """where
 first_parent = 1    
 select id, label
@@ -1408,10 +1408,7 @@ merge first_parent into parent.id;
     )
 
     recursive = executor.environment.alias_origin_lookup["local.first_parent"]
-    assert (
-        recursive.derivation == Derivation.RECURSIVE
-    ), "recursive should be recursive"
-    
+    assert recursive.derivation == Derivation.RECURSIVE, "recursive should be recursive"
 
     results = executor.execute_text(
         """where

--- a/tests/engine/test_duckdb.py
+++ b/tests/engine/test_duckdb.py
@@ -1349,3 +1349,78 @@ select
 
     assert len(results) == 1
     assert results[0].avg_customer_orders == 1
+
+
+def test_recursive():
+    from trilogy.hooks.query_debugger import DebuggingHook
+
+    DebuggingHook()
+
+    executor: Executor = Dialects.DUCK_DB.default_executor(
+        environment=Environment(working_path=Path(__file__).parent)
+    )
+
+    executor.environment.parse(
+        """import recursive;
+# traverse parent-> id until you hit a null
+auto first_parent <- recurse_edge(id, parent);"""
+    )
+
+    assert (
+        executor.environment.concepts["first_parent"].derivation == Derivation.RECURSIVE
+    )
+    sql = executor.generate_sql(
+        """where
+first_parent = 1    
+select id, label
+order by label asc;
+"""
+    )[-1]
+    results = executor.execute_text(
+        """where
+first_parent = 1
+select id, label;
+"""
+    )[0].fetchall()
+    assert len(results) == 4
+    assert results[0].label == "A"
+
+
+def test_recursive_enrichment():
+    from trilogy.hooks.query_debugger import DebuggingHook
+
+    DebuggingHook()
+
+    executor: Executor = Dialects.DUCK_DB.default_executor(
+        environment=Environment(working_path=Path(__file__).parent)
+    )
+
+    executor.environment.parse(
+        """
+import recursive;
+import recursive as parent;
+# traverse parent-> id until you hit a null
+auto first_parent <- recurse_edge(id, parent);  
+
+merge first_parent into parent.id;                 
+                               
+                               """
+    )
+
+    results = executor.execute_text(
+        """where
+first_parent = 1
+select id, parent.label;
+"""
+    )[0].fetchall()
+    assert len(results) == 4
+    assert results[-1].parent_label == "A"
+
+    results = executor.execute_text(
+        """where
+parent.label = 'A'
+select count(id) as a_children;
+"""
+    )[0].fetchall()
+    assert len(results) == 1
+    assert results[0].a_children == 4

--- a/tests/modeling/hackernews/adhoc01.preql
+++ b/tests/modeling/hackernews/adhoc01.preql
@@ -1,0 +1,3 @@
+import hackernews as hackernews;
+
+select hackernews.id, recurse_edge(hackernews.id, hackernews.parent) as parent limit 10;

--- a/tests/modeling/hackernews/adhoc02.preql
+++ b/tests/modeling/hackernews/adhoc02.preql
@@ -1,0 +1,5 @@
+import hackernews;
+
+
+where  create_time.year= 2024
+select root_parent.id, create_time.year, id limit 10;

--- a/tests/modeling/hackernews/adhoc03.preql
+++ b/tests/modeling/hackernews/adhoc03.preql
@@ -1,0 +1,5 @@
+import hackernews;
+
+
+where  create_time.year= 2024 and root_parent.type = 'story'
+select root_parent.id, id limit 10;

--- a/tests/modeling/hackernews/hackernews.preql
+++ b/tests/modeling/hackernews/hackernews.preql
@@ -1,0 +1,7 @@
+import post;
+import post as root_parent;
+# import post as recursive_children;
+
+auto recursive_parent<- recurse_edge(id, parent);
+
+merge recursive_parent into root_parent.id;

--- a/tests/modeling/hackernews/post.preql
+++ b/tests/modeling/hackernews/post.preql
@@ -1,0 +1,36 @@
+
+
+key id int;  #The item's unique id.
+property id.title string;  #Story title
+property id.url string;  #Story url
+property id.text string;  #Story or comment text
+property id.dead bool;  #dead when true; can be false or null
+property id.by string;  #The username of the item's author.
+property id.score int;  #Story score.
+property id.time int;  #Unix time
+property id.create_time timestamp;  #Timestamp for the unix time
+property id.type string;  #type of details (comment comment_ranking poll story job pollopt)
+property id.parent int;  #Parent comment ID
+property id.descendants int;  #Number of story or poll descendants
+property id.ranking int;  #Comment ranking
+property id.deleted bool;  #deleted if true; can be false or null
+
+datasource full (
+	title:title,
+	url:url,
+	text:text,
+	dead:dead,
+	by:by,
+	score:score,
+	time:time,
+    timestamp:create_time,
+	type:type,
+	id:id,
+	parent:parent,
+	descendants:descendants,
+	ranking:ranking,
+	deleted:deleted,
+)
+grain (id)
+
+address `bigquery-public-data.hacker_news.full`;

--- a/tests/modeling/hackernews/test_hackernews_queries.py
+++ b/tests/modeling/hackernews/test_hackernews_queries.py
@@ -1,9 +1,7 @@
 from pathlib import Path
 
-
 from trilogy import Dialects, Executor
 from trilogy.core.models.environment import Environment
-
 from trilogy.dialect.bigquery import BigqueryDialect
 
 working_path = Path(__file__).parent
@@ -39,5 +37,5 @@ def test_adhoc03():
 
     statement = engine.parse_text(text)[-1]
     generated = BigqueryDialect().compile_statement(statement)
-    #TODO: better test
+    # TODO: better test
     assert "WITH RECURSIVE" in generated

--- a/tests/modeling/hackernews/test_hackernews_queries.py
+++ b/tests/modeling/hackernews/test_hackernews_queries.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+
+from trilogy import Dialects, Executor
+from trilogy.core.models.environment import Environment
+
+from trilogy.dialect.bigquery import BigqueryDialect
+
+working_path = Path(__file__).parent
+
+
+def test_adhoc01():
+    env = Environment(working_path=working_path)
+    with open(working_path / "adhoc01.preql") as f:
+        text = f.read()
+    engine: Executor = Dialects.DUCK_DB.default_executor(environment=env, hooks=[])
+
+    statement = engine.parse_text(text)[-1]
+    generated = BigqueryDialect().compile_statement(statement)
+    assert "WITH RECURSIVE" in generated
+
+
+def test_adhoc02():
+    env = Environment(working_path=working_path)
+    with open(working_path / "adhoc02.preql") as f:
+        text = f.read()
+    engine: Executor = Dialects.DUCK_DB.default_executor(environment=env, hooks=[])
+
+    statement = engine.parse_text(text)[-1]
+    generated = BigqueryDialect().compile_statement(statement)
+    assert "WITH RECURSIVE" in generated, generated
+
+
+def test_adhoc03():
+    env = Environment(working_path=working_path)
+    with open(working_path / "adhoc03.preql") as f:
+        text = f.read()
+    engine: Executor = Dialects.DUCK_DB.default_executor(environment=env, hooks=[])
+
+    statement = engine.parse_text(text)[-1]
+    generated = BigqueryDialect().compile_statement(statement)
+    #TODO: better test
+    assert "WITH RECURSIVE" in generated

--- a/tests/modeling/tpc_ds_duckdb/zquery_timing_amd64-intel64_family_6_model_183_stepping_1_genuineintel-16.log
+++ b/tests/modeling/tpc_ds_duckdb/zquery_timing_amd64-intel64_family_6_model_183_stepping_1_genuineintel-16.log
@@ -1,104 +1,104 @@
 [query_01]
-parse_time = 0.393067
-exec_time = 0.030528
-comp_time = 0.098187
+parse_time = 0.344957
+exec_time = 0.053777
+comp_time = 1.284597
 
 [query_02]
-parse_time = 0.498007
-exec_time = 0.088558
-comp_time = 0.079351
+parse_time = 0.624161
+exec_time = 0.135679
+comp_time = 0.126997
 
 [query_03]
-parse_time = 0.123348
-exec_time = 0.029228
-comp_time = 0.026762
+parse_time = 0.453351
+exec_time = 0.038409
+comp_time = 0.035608
 
 [query_06]
-parse_time = 0.176182
-exec_time = 0.040672
-comp_time = 0.038275
+parse_time = 0.219506
+exec_time = 0.063365
+comp_time = 0.060327
 
 [query_07]
-parse_time = 0.251673
-exec_time = 0.108064
-comp_time = 0.078826
+parse_time = 0.217913
+exec_time = 0.168272
+comp_time = 0.132083
 
 [query_08]
-parse_time = 0.199227
-exec_time = 0.049146
-comp_time = 0.037932
+parse_time = 0.325984
+exec_time = 0.065576
+comp_time = 0.061814
 
 [query_10]
-parse_time = 0.41983
-exec_time = 0.119904
-comp_time = 0.2639
+parse_time = 1.019989
+exec_time = 0.173961
+comp_time = 0.360255
 
 [query_12]
-parse_time = 0.139861
-exec_time = 0.034986
-comp_time = 0.06501
+parse_time = 0.203724
+exec_time = 0.05804
+comp_time = 0.116213
 
 [query_15]
-parse_time = 0.264378
-exec_time = 0.015381
-comp_time = 0.144433
+parse_time = 0.29056
+exec_time = 0.022948
+comp_time = 0.224837
 
 [query_16]
-parse_time = 0.340134
-exec_time = 0.109792
-comp_time = 0.019324
+parse_time = 0.550696
+exec_time = 0.170683
+comp_time = 0.032164
 
 [query_20]
-parse_time = 0.141985
-exec_time = 0.102288
-comp_time = 0.095441
+parse_time = 0.208319
+exec_time = 0.164506
+comp_time = 0.136908
 
 [query_21]
-parse_time = 0.036009
-exec_time = 0.018115
-comp_time = 0.017196
+parse_time = 0.052405
+exec_time = 0.03107
+comp_time = 0.02656
 
 [query_24]
-parse_time = 0.500472
-exec_time = 0.301678
-comp_time = 0.196789
+parse_time = 1.029256
+exec_time = 0.392754
+comp_time = 0.267172
 
 [query_25]
-parse_time = 0.573593
-exec_time = 0.137499
-comp_time = 0.053448
+parse_time = 0.534619
+exec_time = 0.203433
+comp_time = 0.056896
 
 [query_26]
-parse_time = 0.11983
-exec_time = 0.066173
-comp_time = 0.05757
+parse_time = 0.172794
+exec_time = 0.084682
+comp_time = 0.069169
 
 [query_30]
-parse_time = 0.288711
-exec_time = 0.064648
-comp_time = 0.056982
+parse_time = 0.373868
+exec_time = 0.094324
+comp_time = 0.081682
 
 [query_32]
-parse_time = 0.1608
-exec_time = 0.050747
-comp_time = 0.004563
+parse_time = 0.214407
+exec_time = 0.07557
+comp_time = 0.007221
 
 [query_95]
-parse_time = 0.413972
-exec_time = 0.060025
-comp_time = 0.472143
+parse_time = 0.642326
+exec_time = 0.100224
+comp_time = 0.613629
 
 [query_97]
-parse_time = 0.46068
-exec_time = 0.255413
-comp_time = 0.069544
+parse_time = 0.604886
+exec_time = 0.409133
+comp_time = 0.08434
 
 [query_98]
-parse_time = 0.179957
-exec_time = 0.032531
-comp_time = 0.16315
+parse_time = 0.248629
+exec_time = 0.060511
+comp_time = 0.231429
 
 [query_99]
-parse_time = 0.140906
-exec_time = 0.092176
-comp_time = 0.059152
+parse_time = 0.193067
+exec_time = 0.124341
+comp_time = 0.081142

--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -4,6 +4,6 @@ from trilogy.dialect.enums import Dialects
 from trilogy.executor import Executor
 from trilogy.parser import parse
 
-__version__ = "0.0.3.54"
+__version__ = "0.0.3.55"
 
 __all__ = ["parse", "Executor", "Dialects", "Environment", "CONFIG"]

--- a/trilogy/constants.py
+++ b/trilogy/constants.py
@@ -7,6 +7,8 @@ logger = getLogger("trilogy")
 
 DEFAULT_NAMESPACE = "local"
 
+RECURSIVE_GATING_CONCEPT = "_terminal"
+
 VIRTUAL_CONCEPT_PREFIX = "_virt"
 
 ENV_CACHE_NAME = ".preql_cache.json"

--- a/trilogy/core/enums.py
+++ b/trilogy/core/enums.py
@@ -235,6 +235,7 @@ class FunctionClass(Enum):
 
     ONE_TO_MANY = [FunctionType.UNNEST]
 
+    RECURSIVE = [FunctionType.RECURSE_EDGE]
 
 class Boolean(Enum):
     TRUE = "true"

--- a/trilogy/core/enums.py
+++ b/trilogy/core/enums.py
@@ -237,6 +237,7 @@ class FunctionClass(Enum):
 
     RECURSIVE = [FunctionType.RECURSE_EDGE]
 
+
 class Boolean(Enum):
     TRUE = "true"
     FALSE = "false"

--- a/trilogy/core/enums.py
+++ b/trilogy/core/enums.py
@@ -51,6 +51,7 @@ class Derivation(Enum):
     ROOT = "root"
     ROWSET = "rowset"
     MULTISELECT = "multiselect"
+    RECURSIVE = "recursive"
 
 
 class Granularity(Enum):
@@ -117,6 +118,7 @@ class FunctionType(Enum):
 
     # structural
     UNNEST = "unnest"
+    RECURSE_EDGE = "recurse_edge"
 
     UNION = "union"
 
@@ -333,6 +335,7 @@ class SourceType(Enum):
     MERGE = "merge"
     BASIC = "basic"
     UNION = "union"
+    RECURSIVE = "recursive"
 
 
 class ShowCategory(Enum):

--- a/trilogy/core/functions.py
+++ b/trilogy/core/functions.py
@@ -190,6 +190,9 @@ FUNCTION_REGISTRY: dict[FunctionType, FunctionConfig] = {
         output_type_function=get_unnest_output_type,
         arg_count=1,
     ),
+    FunctionType.RECURSE_EDGE: FunctionConfig(
+        arg_count=2,
+    ),
     FunctionType.GROUP: FunctionConfig(
         arg_count=-1,
         output_type_function=lambda args: get_output_type_at_index(args, 0),

--- a/trilogy/core/models/author.py
+++ b/trilogy/core/models/author.py
@@ -1165,7 +1165,8 @@ class Concept(Addressable, DataTyped, ConceptArgs, Mergeable, Namespaced, BaseMo
         ):
             return Derivation.UNNEST
         elif (
-            lineage and isinstance(lineage, (BuildFunction, Function))
+            lineage
+            and isinstance(lineage, (BuildFunction, Function))
             and lineage.operator == FunctionType.RECURSE_EDGE
         ):
             return Derivation.RECURSIVE

--- a/trilogy/core/models/author.py
+++ b/trilogy/core/models/author.py
@@ -1165,6 +1165,11 @@ class Concept(Addressable, DataTyped, ConceptArgs, Mergeable, Namespaced, BaseMo
         ):
             return Derivation.UNNEST
         elif (
+            lineage and isinstance(lineage, (BuildFunction, Function))
+            and lineage.operator == FunctionType.RECURSE_EDGE
+        ):
+            return Derivation.RECURSIVE
+        elif (
             lineage
             and isinstance(lineage, (BuildFunction, Function))
             and lineage.operator == FunctionType.UNION

--- a/trilogy/core/models/execute.py
+++ b/trilogy/core/models/execute.py
@@ -39,11 +39,12 @@ from trilogy.core.models.build import (
     BuildCaseElse,
     BuildExpr,
     LooseBuildConceptList,
+    DataType
 )
 from trilogy.core.models.datasource import Address
 from trilogy.core.utility import safe_quote
 from trilogy.utility import unique
-from trilogy.constants import DEFAULT_NAMESPACE, RECURSIVE_GATING_CONCEPT
+from trilogy.constants import DEFAULT_NAMESPACE, RECURSIVE_GATING_CONCEPT, MagicConstants
 
 LOGGER_PREFIX = "[MODELS_EXECUTE]"
 

--- a/trilogy/core/models/execute.py
+++ b/trilogy/core/models/execute.py
@@ -996,6 +996,7 @@ class RecursiveCTE(CTE):
             order_by=self.order_by,
             limit=self.limit,
         )
+        top_cte_array: list[CTE | UnionCTE] = [top]
         bottom_source_map = {
             left_recurse_concept.address: [top.identifier],
             right_recurse_concept.address: [parent_identifier],
@@ -1010,7 +1011,7 @@ class RecursiveCTE(CTE):
             source_map=bottom_source_map,
             grain=self.grain,
             existence_source_map=self.existence_source_map,
-            parent_ctes=[top] + parent_ctes,
+            parent_ctes=top_cte_array + parent_ctes,
             joins=[
                 Join(
                     right_cte=loop_input_cte,
@@ -1109,7 +1110,7 @@ class UnionCTE(BaseModel):
 
 
 class Join(BaseModel):
-    right_cte: CTE
+    right_cte: CTE | UnionCTE
     jointype: JoinType
     left_cte: CTE | None = None
     joinkey_pairs: List[CTEConceptPair] | None = None

--- a/trilogy/core/optimization.py
+++ b/trilogy/core/optimization.py
@@ -3,7 +3,7 @@ from trilogy.core.enums import BooleanOperator, Derivation
 from trilogy.core.models.build import (
     BuildConditional,
 )
-from trilogy.core.models.execute import CTE, UnionCTE
+from trilogy.core.models.execute import CTE, RecursiveCTE, UnionCTE
 from trilogy.core.optimizations import (
     InlineDatasource,
     OptimizationRule,
@@ -123,7 +123,7 @@ def gen_inverse_map(input: list[CTE | UnionCTE]) -> dict[str, list[CTE | UnionCT
 SENSITIVE_DERIVATIONS = [
     Derivation.UNNEST,
     Derivation.WINDOW,
-    # Derivation.AGGREGATE,
+    Derivation.RECURSIVE,
 ]
 
 
@@ -133,7 +133,7 @@ def is_direct_return_eligible(cte: CTE | UnionCTE) -> CTE | UnionCTE | None:
     if len(cte.parent_ctes) != 1:
         return None
     direct_parent = cte.parent_ctes[0]
-    if isinstance(direct_parent, UnionCTE):
+    if isinstance(direct_parent, (UnionCTE, RecursiveCTE)):
         return None
 
     output_addresses = set([x.address for x in cte.output_columns])

--- a/trilogy/core/processing/concept_strategies_v3.py
+++ b/trilogy/core/processing/concept_strategies_v3.py
@@ -24,12 +24,12 @@ from trilogy.core.processing.node_generators import (
     gen_group_to_node,
     gen_merge_node,
     gen_multiselect_node,
+    gen_recursive_node,
     gen_rowset_node,
     gen_synonym_node,
     gen_union_node,
     gen_unnest_node,
     gen_window_node,
-    gen_recursive_node,
 )
 from trilogy.core.processing.nodes import (
     ConstantNode,

--- a/trilogy/core/processing/concept_strategies_v3.py
+++ b/trilogy/core/processing/concept_strategies_v3.py
@@ -151,6 +151,7 @@ def get_priority_concept(
             + [c for c in remaining_concept if c.derivation == Derivation.FILTER]
             # unnests are weird?
             + [c for c in remaining_concept if c.derivation == Derivation.UNNEST]
+            + [c for c in remaining_concept if c.derivation == Derivation.RECURSIVE]
             + [c for c in remaining_concept if c.derivation == Derivation.BASIC]
             # finally our plain selects
             + [

--- a/trilogy/core/processing/concept_strategies_v3.py
+++ b/trilogy/core/processing/concept_strategies_v3.py
@@ -29,6 +29,7 @@ from trilogy.core.processing.node_generators import (
     gen_union_node,
     gen_unnest_node,
     gen_window_node,
+    gen_recursive_node,
 )
 from trilogy.core.processing.nodes import (
     ConstantNode,
@@ -285,6 +286,20 @@ def generate_node(
             f"{depth_to_prefix(depth)}{LOGGER_PREFIX} for {concept.address}, generating unnest node with optional {[x.address for x in local_optional]} and condition {conditions}"
         )
         return gen_unnest_node(
+            concept,
+            local_optional,
+            history=history,
+            environment=environment,
+            g=g,
+            depth=depth + 1,
+            source_concepts=source_concepts,
+            conditions=conditions,
+        )
+    elif concept.derivation == Derivation.RECURSIVE:
+        logger.info(
+            f"{depth_to_prefix(depth)}{LOGGER_PREFIX} for {concept.address}, generating recursive node with optional {[x.address for x in local_optional]} and condition {conditions}"
+        )
+        return gen_recursive_node(
             concept,
             local_optional,
             history=history,
@@ -920,6 +935,7 @@ def _search_concepts(
                     Derivation.FILTER,
                     Derivation.WINDOW,
                     Derivation.UNNEST,
+                    Derivation.RECURSIVE,
                     Derivation.ROWSET,
                     Derivation.BASIC,
                     Derivation.MULTISELECT,

--- a/trilogy/core/processing/node_generators/__init__.py
+++ b/trilogy/core/processing/node_generators/__init__.py
@@ -10,6 +10,7 @@ from .synonym_node import gen_synonym_node
 from .union_node import gen_union_node
 from .unnest_node import gen_unnest_node
 from .window_node import gen_window_node
+from .recursive_node import gen_recursive_node
 
 __all__ = [
     "gen_filter_node",
@@ -24,4 +25,5 @@ __all__ = [
     "gen_rowset_node",
     "gen_multiselect_node",
     "gen_synonym_node",
+    "gen_recursive_node",
 ]

--- a/trilogy/core/processing/node_generators/__init__.py
+++ b/trilogy/core/processing/node_generators/__init__.py
@@ -4,13 +4,13 @@ from .group_node import gen_group_node
 from .group_to_node import gen_group_to_node
 from .multiselect_node import gen_multiselect_node
 from .node_merge_node import gen_merge_node
+from .recursive_node import gen_recursive_node
 from .rowset_node import gen_rowset_node
 from .select_node import gen_select_node
 from .synonym_node import gen_synonym_node
 from .union_node import gen_union_node
 from .unnest_node import gen_unnest_node
 from .window_node import gen_window_node
-from .recursive_node import gen_recursive_node
 
 __all__ = [
     "gen_filter_node",

--- a/trilogy/core/processing/node_generators/recursive_node.py
+++ b/trilogy/core/processing/node_generators/recursive_node.py
@@ -1,21 +1,20 @@
 from typing import List
 
-from trilogy.constants import logger
+from trilogy.constants import DEFAULT_NAMESPACE, RECURSIVE_GATING_CONCEPT, logger
 from trilogy.core.models.build import (
+    BuildComparison,
     BuildConcept,
     BuildFunction,
-    BuildWhereClause,
-    BuildComparison,
     BuildGrain,
+    BuildWhereClause,
     ComparisonOperator,
     DataType,
     Derivation,
     Purpose,
 )
 from trilogy.core.models.build_environment import BuildEnvironment
-from trilogy.core.processing.nodes import History, StrategyNode, RecursiveNode
+from trilogy.core.processing.nodes import History, RecursiveNode, StrategyNode
 from trilogy.core.processing.utility import padding
-from trilogy.constants import DEFAULT_NAMESPACE, RECURSIVE_GATING_CONCEPT
 
 LOGGER_PREFIX = "[GEN_RECURSIVE_NODE]"
 

--- a/trilogy/core/processing/node_generators/recursive_node.py
+++ b/trilogy/core/processing/node_generators/recursive_node.py
@@ -1,0 +1,88 @@
+from typing import List
+
+from trilogy.constants import logger
+from trilogy.core.models.build import (
+    BuildConcept,
+    BuildFunction,
+    BuildWhereClause,
+    BuildComparison,
+    BuildGrain,
+    ComparisonOperator,
+    DataType,
+    Derivation,
+    Purpose,
+)
+from trilogy.core.models.build_environment import BuildEnvironment
+from trilogy.core.processing.nodes import History, StrategyNode, RecursiveNode
+from trilogy.core.processing.utility import padding
+from trilogy.constants import DEFAULT_NAMESPACE, RECURSIVE_GATING_CONCEPT
+
+LOGGER_PREFIX = "[GEN_RECURSIVE_NODE]"
+
+GATING_CONCEPT = BuildConcept(
+    name=RECURSIVE_GATING_CONCEPT,
+    namespace=DEFAULT_NAMESPACE,
+    grain=BuildGrain(),
+    build_is_aggregate=False,
+    datatype=DataType.BOOL,
+    purpose=Purpose.KEY,
+    derivation=Derivation.BASIC,
+)
+
+
+def gen_recursive_node(
+    concept: BuildConcept,
+    local_optional: List[BuildConcept],
+    history: History,
+    environment: BuildEnvironment,
+    g,
+    depth: int,
+    source_concepts,
+    conditions: BuildWhereClause | None = None,
+) -> StrategyNode | None:
+    arguments = []
+    if isinstance(concept.lineage, BuildFunction):
+        arguments = concept.lineage.concept_arguments
+    logger.info(
+        f"{padding(depth)}{LOGGER_PREFIX} Fetching recursive node for {concept.name} with arguments {arguments} and conditions {conditions}"
+    )
+    parent = source_concepts(
+        mandatory_list=arguments,
+        environment=environment,
+        g=g,
+        depth=depth + 1,
+        history=history,
+        # conditions=conditions,
+    )
+    if not parent:
+        logger.info(
+            f"{padding(depth)}{LOGGER_PREFIX} could not find recursive node parents"
+        )
+        return None
+    outputs = (
+        [concept]
+        + arguments
+        + [
+            GATING_CONCEPT,
+        ]
+    )
+    base = RecursiveNode(
+        input_concepts=arguments,
+        output_concepts=outputs,
+        environment=environment,
+        parents=([parent] if (arguments or local_optional) else []),
+        # preexisting_conditions=conditions
+    )
+    # TODO:
+    # recursion will result in a union; group up to our final targets
+    wrapped_base = StrategyNode(
+        input_concepts=outputs,
+        output_concepts=outputs,
+        environment=environment,
+        parents=[base],
+        depth=depth,
+        conditions=BuildComparison(
+            left=GATING_CONCEPT, right=True, operator=ComparisonOperator.IS
+        ),
+    )
+    return wrapped_base

--- a/trilogy/core/processing/nodes/__init__.py
+++ b/trilogy/core/processing/nodes/__init__.py
@@ -10,11 +10,11 @@ from .base_node import NodeJoin, StrategyNode, WhereSafetyNode
 from .filter_node import FilterNode
 from .group_node import GroupNode
 from .merge_node import MergeNode
+from .recursive_node import RecursiveNode
 from .select_node_v2 import ConstantNode, SelectNode
 from .union_node import UnionNode
 from .unnest_node import UnnestNode
 from .window_node import WindowNode
-from .recursive_node import RecursiveNode
 
 
 class History(BaseModel):

--- a/trilogy/core/processing/nodes/__init__.py
+++ b/trilogy/core/processing/nodes/__init__.py
@@ -14,6 +14,7 @@ from .select_node_v2 import ConstantNode, SelectNode
 from .union_node import UnionNode
 from .unnest_node import UnnestNode
 from .window_node import WindowNode
+from .recursive_node import RecursiveNode
 
 
 class History(BaseModel):
@@ -194,4 +195,5 @@ __all__ = [
     "UnionNode",
     "History",
     "WhereSafetyNode",
+    "RecursiveNode",
 ]

--- a/trilogy/core/processing/nodes/recursive_node.py
+++ b/trilogy/core/processing/nodes/recursive_node.py
@@ -1,0 +1,46 @@
+from typing import List
+
+from trilogy.core.enums import SourceType
+from trilogy.core.models.build import BuildConcept
+from trilogy.core.models.build_environment import BuildEnvironment
+from trilogy.core.models.execute import QueryDatasource
+from trilogy.core.processing.nodes.base_node import StrategyNode
+
+
+class RecursiveNode(StrategyNode):
+    """Union nodes represent combining two keyspaces"""
+
+    source_type = SourceType.RECURSIVE
+
+    def __init__(
+        self,
+        input_concepts: List[BuildConcept],
+        output_concepts: List[BuildConcept],
+        environment: BuildEnvironment,
+        whole_grain: bool = False,
+        parents: List["StrategyNode"] | None = None,
+        depth: int = 0,
+    ):
+        super().__init__(
+            input_concepts=input_concepts,
+            output_concepts=output_concepts,
+            environment=environment,
+            whole_grain=whole_grain,
+            parents=parents,
+            depth=depth,
+        )
+
+    def _resolve(self) -> QueryDatasource:
+        """We need to ensure that any filtered values are removed from the output to avoid inappropriate references"""
+        base = super()._resolve()
+        return base
+
+    def copy(self) -> "RecursiveNode":
+        return RecursiveNode(
+            input_concepts=list(self.input_concepts),
+            output_concepts=list(self.output_concepts),
+            environment=self.environment,
+            whole_grain=self.whole_grain,
+            parents=self.parents,
+            depth=self.depth,
+        )

--- a/trilogy/core/query_processor.py
+++ b/trilogy/core/query_processor.py
@@ -21,12 +21,12 @@ from trilogy.core.models.build import (
 from trilogy.core.models.environment import Environment
 from trilogy.core.models.execute import (
     CTE,
-    RecursiveCTE,
     BaseJoin,
     CTEConceptPair,
     InstantiatedUnnestJoin,
     Join,
     QueryDatasource,
+    RecursiveCTE,
     UnionCTE,
     UnnestJoin,
 )
@@ -294,7 +294,6 @@ def datasource_to_cte(
             order_by=query_datasource.ordering,
         )
         return final
-
 
     if len(query_datasource.datasources) > 1 or any(
         [isinstance(x, QueryDatasource) for x in query_datasource.datasources]

--- a/trilogy/core/query_processor.py
+++ b/trilogy/core/query_processor.py
@@ -21,6 +21,7 @@ from trilogy.core.models.build import (
 from trilogy.core.models.environment import Environment
 from trilogy.core.models.execute import (
     CTE,
+    RecursiveCTE,
     BaseJoin,
     CTEConceptPair,
     InstantiatedUnnestJoin,
@@ -294,6 +295,7 @@ def datasource_to_cte(
         )
         return final
 
+
     if len(query_datasource.datasources) > 1 or any(
         [isinstance(x, QueryDatasource) for x in query_datasource.datasources]
     ):
@@ -340,7 +342,12 @@ def datasource_to_cte(
     base_name, base_alias = resolve_cte_base_name_and_alias_v2(
         human_id, query_datasource, source_map, final_joins
     )
-    cte = CTE(
+    cte_class = CTE
+
+    if query_datasource.source_type == SourceType.RECURSIVE:
+        cte_class = RecursiveCTE
+        # extra_kwargs['left_recursive_concept'] = query_datasource.left
+    cte = cte_class(
         name=human_id,
         source=query_datasource,
         # output columns are what are selected/grouped by

--- a/trilogy/dialect/base.py
+++ b/trilogy/dialect/base.py
@@ -48,7 +48,7 @@ from trilogy.core.models.core import (
 )
 from trilogy.core.models.datasource import Datasource, RawColumnExpr
 from trilogy.core.models.environment import Environment
-from trilogy.core.models.execute import CTE, CompiledCTE, UnionCTE, RecursiveCTE
+from trilogy.core.models.execute import CTE, CompiledCTE, RecursiveCTE, UnionCTE
 from trilogy.core.processing.utility import (
     decompose_condition,
     is_scalar_condition,
@@ -273,7 +273,6 @@ ORDER BY{% for order in order_by %}
 {% endif %}{% endif %}
 """
 )
-
 
 
 def safe_get_cte_value(coalesce, cte: CTE | UnionCTE, c: BuildConcept, quote_char: str):
@@ -737,8 +736,8 @@ class BaseDialect:
                 base_statement += "\nORDER BY " + ",".join(ordering)
             return CompiledCTE(name=cte.name, statement=base_statement)
         elif isinstance(cte, RecursiveCTE):
-            base_statement = f"\nUNION ALL\n".join(
-                [self.render_cte(child).statement for child in cte.internal_ctes]
+            base_statement = "\nUNION ALL\n".join(
+                [self.render_cte(child, False).statement for child in cte.internal_ctes]
             )
             return CompiledCTE(name=cte.name, statement=base_statement)
         if self.UNNEST_MODE in (
@@ -1008,7 +1007,7 @@ class BaseDialect:
                 f"Did not get all output addresses in select - missing: {missing}, have"
                 f" {selected}"
             )
-        
+
         recursive = any(isinstance(x, RecursiveCTE) for x in query.ctes)
 
         compiled_ctes = self.generate_ctes(query)

--- a/trilogy/dialect/base.py
+++ b/trilogy/dialect/base.py
@@ -48,7 +48,7 @@ from trilogy.core.models.core import (
 )
 from trilogy.core.models.datasource import Datasource, RawColumnExpr
 from trilogy.core.models.environment import Environment
-from trilogy.core.models.execute import CTE, CompiledCTE, UnionCTE
+from trilogy.core.models.execute import CTE, CompiledCTE, UnionCTE, RecursiveCTE
 from trilogy.core.processing.utility import (
     decompose_condition,
     is_scalar_condition,
@@ -173,6 +173,7 @@ FUNCTION_MAP = {
     FunctionType.INDEX_ACCESS: lambda x: f"{x[0]}[{x[1]}]",
     FunctionType.MAP_ACCESS: lambda x: f"{x[0]}[{x[1]}]",
     FunctionType.UNNEST: lambda x: f"unnest({x[0]})",
+    FunctionType.RECURSE_EDGE: lambda x: f"CASE WHEN {x[1]} IS NULL THEN {x[0]} ELSE {x[1]} END",
     FunctionType.ATTR_ACCESS: lambda x: f"""{x[0]}.{x[1].replace("'", "")}""",
     FunctionType.STRUCT: lambda x: f"{{{', '.join(struct_arg(x))}}}",
     FunctionType.ARRAY: lambda x: f"[{', '.join(x)}]",
@@ -247,7 +248,7 @@ FUNCTION_GRAIN_MATCH_MAP = {
 
 GENERIC_SQL_TEMPLATE = Template(
     """{%- if ctes %}
-WITH {% for cte in ctes %}
+WITH {% if recursive%} RECURSIVE {% endif %}{% for cte in ctes %}
 {{cte.name}} as (
 {{cte.statement}}){% if not loop.last %},{% endif %}{% endfor %}{% endif %}
 {%- if full_select -%}
@@ -272,6 +273,7 @@ ORDER BY{% for order in order_by %}
 {% endif %}{% endif %}
 """
 )
+
 
 
 def safe_get_cte_value(coalesce, cte: CTE | UnionCTE, c: BuildConcept, quote_char: str):
@@ -734,6 +736,11 @@ class BaseDialect:
                 ]
                 base_statement += "\nORDER BY " + ",".join(ordering)
             return CompiledCTE(name=cte.name, statement=base_statement)
+        elif isinstance(cte, RecursiveCTE):
+            base_statement = f"\nUNION ALL\n".join(
+                [self.render_cte(child).statement for child in cte.internal_ctes]
+            )
+            return CompiledCTE(name=cte.name, statement=base_statement)
         if self.UNNEST_MODE in (
             UnnestMode.CROSS_APPLY,
             UnnestMode.CROSS_JOIN,
@@ -1001,10 +1008,13 @@ class BaseDialect:
                 f"Did not get all output addresses in select - missing: {missing}, have"
                 f" {selected}"
             )
+        
+        recursive = any(isinstance(x, RecursiveCTE) for x in query.ctes)
 
         compiled_ctes = self.generate_ctes(query)
 
         final = self.SQL_TEMPLATE.render(
+            recursive=recursive,
             output=(
                 query.output_to if isinstance(query, ProcessedQueryPersist) else None
             ),

--- a/trilogy/dialect/bigquery.py
+++ b/trilogy/dialect/bigquery.py
@@ -59,8 +59,9 @@ BQ_SQL_TEMPLATE = Template(
     """{%- if output %}
 CREATE OR REPLACE TABLE {{ output.address.location }} AS
 {% endif %}{%- if ctes %}
-WITH {% for cte in ctes %}
-{{cte.name}} as ({{cte.statement}}){% if not loop.last %},{% endif %}{% endfor %}{% endif %}
+WITH {% if recursive%}RECURSIVE{% endif %}{% for cte in ctes %}
+{{cte.name}} as ({{cte.statement}}){% if not loop.last %},{% else%}
+{% endif %}{% endfor %}{% endif %}
 {%- if full_select -%}
 {{full_select}}
 {%- else -%}
@@ -68,10 +69,8 @@ SELECT
 {%- for select in select_columns %}
     {{ select }}{% if not loop.last %},{% endif %}{% endfor %}
 {% if base %}FROM
-    {{ base }}{% endif %}{% if joins %}
-{% for join in joins %}
-{{ join }}
-{% endfor %}{% endif %}
+    {{ base }}{% endif %}{% if joins %}{% for join in joins %}
+    {{ join }}{% endfor %}{% endif %}
 {% if where %}WHERE
     {{ where }}
 {% endif %}

--- a/trilogy/dialect/common.py
+++ b/trilogy/dialect/common.py
@@ -127,4 +127,7 @@ def render_join(
         base_joinkeys = ["1=1"]
 
     joinkeys = " AND ".join(sorted(base_joinkeys))
-    return f"{join.jointype.value.upper()} JOIN {right_base} on {joinkeys}"
+    base = f"{join.jointype.value.upper()} JOIN {right_base} on {joinkeys}"
+    if join.condition:
+        base = f"{base} and {render_expr_func(join.condition, cte)}"
+    return base

--- a/trilogy/dialect/common.py
+++ b/trilogy/dialect/common.py
@@ -2,15 +2,19 @@ from typing import Callable
 
 from trilogy.core.enums import Modifier, UnnestMode
 from trilogy.core.models.build import (
+    BuildComparison,
     BuildConcept,
+    BuildConditional,
     BuildFunction,
     BuildParamaterizedConceptReference,
+    BuildParenthetical,
 )
 from trilogy.core.models.datasource import RawColumnExpr
 from trilogy.core.models.execute import (
     CTE,
     InstantiatedUnnestJoin,
     Join,
+    UnionCTE,
 )
 
 
@@ -49,7 +53,7 @@ def render_unnest(
 def render_join_concept(
     name: str,
     quote_character: str,
-    cte: CTE,
+    cte: CTE | UnionCTE,
     concept: BuildConcept,
     render_expr,
     inlined_ctes: set[str],
@@ -71,7 +75,16 @@ def render_join(
     join: Join | InstantiatedUnnestJoin,
     quote_character: str,
     render_expr_func: Callable[
-        [BuildConcept | BuildParamaterizedConceptReference | BuildFunction, CTE], str
+        [
+            BuildConcept
+            | BuildParamaterizedConceptReference
+            | BuildFunction
+            | BuildConditional
+            | BuildComparison
+            | BuildParenthetical,
+            CTE,
+        ],
+        str,
     ],
     cte: CTE,
     unnest_mode: UnnestMode = UnnestMode.CROSS_APPLY,

--- a/trilogy/dialect/duckdb.py
+++ b/trilogy/dialect/duckdb.py
@@ -58,7 +58,7 @@ DUCKDB_TEMPLATE = Template(
     """{%- if output %}
 CREATE OR REPLACE TABLE {{ output.address.location }} AS
 {% endif %}{%- if ctes %}
-WITH {% for cte in ctes %}
+WITH {% if recursive%}RECURSIVE{% endif %}{% for cte in ctes %}
 {{cte.name}} as (
 {{cte.statement}}){% if not loop.last %},{% else %}
 {% endif %}{% endfor %}{% endif %}

--- a/trilogy/dialect/snowflake.py
+++ b/trilogy/dialect/snowflake.py
@@ -41,12 +41,14 @@ FUNCTION_GRAIN_MATCH_MAP = {
     FunctionType.AVG: lambda args: f"{args[0]}",
 }
 
-BQ_SQL_TEMPLATE = Template(
+
+SNOWFLAKE_SQL_TEMPLATE = Template(
     """{%- if output %}
 CREATE OR REPLACE TABLE {{ output.address.location }} AS
 {% endif %}{%- if ctes %}
-WITH {% for cte in ctes %}
-{{cte.name}} as ({{cte.statement}}){% if not loop.last %},{% endif %}{% endfor %}{% endif %}
+WITH {% if recursive%}RECURSIVE{% endif %}{% for cte in ctes %}
+{{cte.name}} as ({{cte.statement}}){% if not loop.last %},{% endif %}{% else %}
+{% endfor %}{% endif %}
 {%- if full_select -%}
 {{full_select}}
 {%- else -%}
@@ -55,10 +57,8 @@ SELECT
 {%- for select in select_columns %}
     {{ select }}{% if not loop.last %},{% endif %}{% endfor %}
 {% if base %}FROM
-    {{ base }}{% endif %}{% if joins %}
-{% for join in joins %}
-{{ join }}
-{% endfor %}{% endif %}
+    {{ base }}{% endif %}{% if joins %}{% for join in joins %}
+    {{ join }}{% endfor %}{% endif %}
 {% if where %}WHERE
     {{ where }}
 {% endif %}
@@ -84,5 +84,5 @@ class SnowflakeDialect(BaseDialect):
         **FUNCTION_GRAIN_MATCH_MAP,
     }
     QUOTE_CHARACTER = '"'
-    SQL_TEMPLATE = BQ_SQL_TEMPLATE
+    SQL_TEMPLATE = SNOWFLAKE_SQL_TEMPLATE
     UNNEST_MODE = UnnestMode.SNOWFLAKE

--- a/trilogy/parsing/common.py
+++ b/trilogy/parsing/common.py
@@ -476,6 +476,9 @@ def function_to_concept(
     elif parent.operator == FunctionType.UNNEST:
         derivation = Derivation.UNNEST
         granularity = Granularity.MULTI_ROW
+    elif parent.operator == FunctionType.RECURSE_EDGE:
+        derivation = Derivation.RECURSIVE
+        granularity = Granularity.MULTI_ROW
     elif parent.operator in FunctionClass.SINGLE_ROW.value:
         derivation = Derivation.CONSTANT
         granularity = Granularity.SINGLE_ROW

--- a/trilogy/parsing/parse_engine.py
+++ b/trilogy/parsing/parse_engine.py
@@ -1656,13 +1656,13 @@ class ParseToObjects(Transformer):
     @v_args(meta=True)
     def fnullif(self, meta, args):
         return self.function_factory.create_function(args, FunctionType.NULLIF, meta)
-    
+
     @v_args(meta=True)
     def frecurse_edge(self, meta, args):
         return self.function_factory.create_function(
             args, FunctionType.RECURSE_EDGE, meta
         )
-    
+
     @v_args(meta=True)
     def unnest(self, meta, args):
         return self.function_factory.create_function(args, FunctionType.UNNEST, meta)

--- a/trilogy/parsing/parse_engine.py
+++ b/trilogy/parsing/parse_engine.py
@@ -1656,7 +1656,13 @@ class ParseToObjects(Transformer):
     @v_args(meta=True)
     def fnullif(self, meta, args):
         return self.function_factory.create_function(args, FunctionType.NULLIF, meta)
-
+    
+    @v_args(meta=True)
+    def frecurse_edge(self, meta, args):
+        return self.function_factory.create_function(
+            args, FunctionType.RECURSE_EDGE, meta
+        )
+    
     @v_args(meta=True)
     def unnest(self, meta, args):
         return self.function_factory.create_function(args, FunctionType.UNNEST, meta)

--- a/trilogy/parsing/trilogy.lark
+++ b/trilogy/parsing/trilogy.lark
@@ -247,8 +247,10 @@
     fnot: "NOT"i expr
     fbool: "bool"i "(" expr ")"
     fnullif: "nullif"i "(" expr "," expr ")"
+    _FRECURSE_EDGE.1: "recurse_edge("i
+    frecurse_edge: _FRECURSE_EDGE expr "," expr ")"
 
-    _generic_functions: fcast |  concat  | fcoalesce | fnullif | fcase  | len | fnot | fbool
+    _generic_functions: fcast |  concat  | fcoalesce | fnullif | fcase  | len | fnot | fbool | frecurse_edge
 
     //constant
     CURRENT_DATE.1: /current_date\(\)/


### PR DESCRIPTION
## Description

Add basic recursion support via recurse_edge function.

This will iterate over left, right in a recursive self-join until a terminal value (a left without a right).

Big caveats:
On some engines, such as duckdb, providing circular graphs will result in an infinite loop.
Filters are not pushed down before the recursion in many cases,  which makes this expensive on large datasets.

```sql
import recursive;
# traverse parent-> id until you hit a null
auto first_parent <- recurse_edge(id, parent);"""

where
first_parent = 1    
select id, label
order by label asc;
```
## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
