### PR TITLE
DuckDB regexp_extract fixes

### DIFF
--- a/tests/engine/test_duckdb.py
+++ b/tests/engine/test_duckdb.py
@@ -1485,3 +1485,30 @@ select
     results = default_duckdb_engine.execute_text(test)[0].fetchall()
     assert len(results) == 1
     assert results[0].map == {1: 2, 3: 4}
+
+
+def test_regexp(default_duckdb_engine: Executor):
+
+    from trilogy.hooks import DebuggingHook
+
+    DebuggingHook()
+    test = """
+
+const values <- unnest(['apple', 'banana', 'cherry', 'date']);
+
+select 
+
+    regexp_contains(values, '^a.*') as starts_with_a,
+    regexp_extract(values, '^a(.*)') as after_a,
+    regexp_extract(values, '^a(.*)', 1) as after_a_explicit,
+    regexp_extract(values, '^a.*') as no_capture
+order by 
+    starts_with_a asc;
+    """
+
+    results = default_duckdb_engine.execute_text(test)[0].fetchall()
+    assert len(results) == 2
+    assert results[1].starts_with_a is True
+    assert results[1].after_a == "pple"
+    assert results[1].after_a_explicit == "pple"
+    assert results[1].no_capture == "apple"

--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -4,6 +4,6 @@ from trilogy.dialect.enums import Dialects
 from trilogy.executor import Executor
 from trilogy.parser import parse
 
-__version__ = "0.0.3.69"
+__version__ = "0.0.3.70"
 
 __all__ = ["parse", "Executor", "Dialects", "Environment", "CONFIG"]

--- a/trilogy/core/functions.py
+++ b/trilogy/core/functions.py
@@ -370,10 +370,10 @@ FUNCTION_REGISTRY: dict[FunctionType, FunctionConfig] = {
         arg_count=2,
     ),
     FunctionType.REGEXP_EXTRACT: FunctionConfig(
-        valid_inputs={DataType.STRING},
+        valid_inputs=[{DataType.STRING}, {DataType.STRING}, {DataType.INTEGER}],
         output_purpose=Purpose.PROPERTY,
         output_type=DataType.STRING,
-        arg_count=2,
+        arg_count=3,
     ),
     FunctionType.REGEXP_REPLACE: FunctionConfig(
         valid_inputs={DataType.STRING},

--- a/trilogy/dialect/duckdb.py
+++ b/trilogy/dialect/duckdb.py
@@ -1,3 +1,4 @@
+import re
 from typing import Any, Callable, Mapping
 
 from jinja2 import Template
@@ -7,6 +8,18 @@ from trilogy.core.models.core import DataType
 from trilogy.dialect.base import BaseDialect
 
 WINDOW_FUNCTION_MAP: Mapping[WindowType, Callable[[Any, Any, Any], str]] = {}
+
+
+def generate_regex_extract(x: list[str | int]) -> tuple[str, str, int]:
+    if x[2] == "-1":
+        regex = re.compile(x[1])
+        print(f"Regex: {regex}" f" Groups: {regex.groups} Match: {regex.match('test')}")
+        if regex.groups == 0:
+            search = 0
+        else:
+            search = 1
+        return f"REGEXP_EXTRACT({x[0]},{x[1]},{search})"
+    return f"REGEXP_EXTRACT({x[0]},{x[1]},{x[2]})"
 
 
 FUNCTION_MAP = {
@@ -37,6 +50,9 @@ FUNCTION_MAP = {
     FunctionType.DATETIME_LITERAL: lambda x: f"datetime '{x}'",
     # string
     FunctionType.CONTAINS: lambda x: f"CONTAINS(LOWER({x[0]}), LOWER({x[1]}))",
+    # regexp
+    FunctionType.REGEXP_CONTAINS: lambda x: f"REGEXP_MATCHES({x[0]},{x[1]})",
+    FunctionType.REGEXP_EXTRACT: lambda x: generate_regex_extract(x),
 }
 
 # if an aggregate function is called on a source that is at the same grain as the aggregate

--- a/trilogy/dialect/duckdb.py
+++ b/trilogy/dialect/duckdb.py
@@ -9,9 +9,11 @@ from trilogy.dialect.base import BaseDialect
 
 WINDOW_FUNCTION_MAP: Mapping[WindowType, Callable[[Any, Any, Any], str]] = {}
 
+SENTINAL_AUTO_CAPTURE_GROUP_VALUE = "-1"
 
-def generate_regex_extract(x: list[str | int]) -> tuple[str, str, int]:
-    if x[2] == "-1":
+
+def generate_regex_extract(x: list[str]) -> str:
+    if str(x[2]) == SENTINAL_AUTO_CAPTURE_GROUP_VALUE:
         regex = re.compile(x[1])
         print(f"Regex: {regex}" f" Groups: {regex.groups} Match: {regex.match('test')}")
         if regex.groups == 0:

--- a/trilogy/dialect/duckdb.py
+++ b/trilogy/dialect/duckdb.py
@@ -15,7 +15,6 @@ SENTINAL_AUTO_CAPTURE_GROUP_VALUE = "-1"
 def generate_regex_extract(x: list[str]) -> str:
     if str(x[2]) == SENTINAL_AUTO_CAPTURE_GROUP_VALUE:
         regex = re.compile(x[1])
-        print(f"Regex: {regex}" f" Groups: {regex.groups} Match: {regex.match('test')}")
         if regex.groups == 0:
             search = 0
         else:

--- a/trilogy/parsing/parse_engine.py
+++ b/trilogy/parsing/parse_engine.py
@@ -1802,6 +1802,9 @@ class ParseToObjects(Transformer):
 
     @v_args(meta=True)
     def fregexp_extract(self, meta, args):
+        if len(args) == 2:
+            # this is a magic value to represent the default behavior
+            args.append(-1)
         return self.function_factory.create_function(
             args, FunctionType.REGEXP_EXTRACT, meta
         )

--- a/trilogy/parsing/trilogy.lark
+++ b/trilogy/parsing/trilogy.lark
@@ -279,7 +279,7 @@
     _SUBSTRING.1: "substring("i
     fsubstring: _SUBSTRING expr "," expr "," expr ")"
     _REGEXP_EXTRACT.1: "regexp_extract("
-    fregexp_extract: _REGEXP_EXTRACT expr "," expr ")"
+    fregexp_extract: _REGEXP_EXTRACT expr "," expr ("," int_lit)? ")"
     _REGEXP_CONTAINS.1: "regexp_contains("
     fregexp_contains: _REGEXP_CONTAINS expr "," expr  ")"
     _REGEXP_REPLACE.1: "regexp_replace("


### PR DESCRIPTION
## Description

Copy BQ default behavior for now - if a regexp_extract has no capture group, return the whole regex on match. Support setting an explicit capture group as well. 

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
