### PR TITLE
Alias Error Handling Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,20 @@ The Trilogy language is an experiment in better SQL for analytics - a streamline
 
 [pytrilogy](https://github.com/trilogy-data/pytrilogy) is the reference implementation, written in Python.
 
-Trilogy concretely solves these common problems in karge, SQL based analytics teams:
-- decoupling consumption code from specific physical assets
-- better testability and change management
-- reduced boilerplate and opportunity for OLAP style optimization at scale
+### What Trilogy Gives You
 
-Trilogy can be especially powerful as a frontend consumption language, since the decoupling from the physical layout makes dynamic and interactive dashboards backed by SQL tables much easier to create.
+- Speed - write faster, with concise, powerful syntax
+- Efficiency - write less SQL, and reuse what you do
+- Fearless refactoring
+- Testability
+- Easy to use for humans and LLMs
+
+Trilogy is epsecially targeted at data consumption, providing a rich metadata layer that makes visualizing Trilogy easy and expressive. 
 
 > [!TIP]
 > You can try Trilogy in a [open-source studio](https://trilogydata.dev/trilogy-studio-core/). More details on the language can be found on the [documentation](https://trilogydata.dev/).
 
-We recommend the studio as the fastest way to explore Trilogy. For deeper work and integration, `pytrilogy` can be run locally to parse and execute trilogy model [.preql] files using the `trilogy` CLI tool, or can be run in python by importing the `trilogy` package.
+Start in the studio to explore Trilogy. For deeper work and integration, `pytrilogy` can be run locally to parse and execute trilogy model [.preql] files using the `trilogy` CLI tool, or can be run in python by importing the `trilogy` package.
 
 Installation: `pip install pytrilogy`
 

--- a/tests/modeling/faa/test_faa.py
+++ b/tests/modeling/faa/test_faa.py
@@ -1,9 +1,11 @@
 from pathlib import Path
 
-from build.lib.trilogy.core.exceptions import InvalidSyntaxException
-from trilogy import Dialects, Environment
-from trilogy.hooks import DebuggingHook
 from pytest import raises
+
+from trilogy import Dialects, Environment
+from trilogy.core.exceptions import InvalidSyntaxException
+from trilogy.hooks import DebuggingHook
+
 
 def test_query_gen():
     """Make sure we inject another group by when conditions forced an evaluation with an early grain"""
@@ -41,13 +43,13 @@ def test_helpful_error():
 
     x = Dialects.DUCK_DB.default_executor(environment=x)
     with raises(InvalidSyntaxException) as e:
-        sql = x.generate_sql(
-        """import flight;
+        x.generate_sql(
+            """import flight;
         
 select
     max(dep_time.year_start) as max_year,
     min(dep_time.year_start) min_year;
     """
-
-    )
-    assert 'AS ' in str(e.value)
+        )
+    assert "AS " in str(e.value)
+    assert "\\n" not in e.value.args[0]

--- a/tests/modeling/tpc_ds_duckdb/zquery_timing_amd64-intel64_family_6_model_183_stepping_1_genuineintel-16.log
+++ b/tests/modeling/tpc_ds_duckdb/zquery_timing_amd64-intel64_family_6_model_183_stepping_1_genuineintel-16.log
@@ -1,104 +1,104 @@
 [query_01]
-parse_time = 0.264376
-exec_time = 0.07122
-comp_time = 1.717448
+parse_time = 0.786902
+exec_time = 0.148571
+comp_time = 0.290723
 
 [query_02]
-parse_time = 0.982141
-exec_time = 0.106507
-comp_time = 0.089327
+parse_time = 2.587683
+exec_time = 0.244556
+comp_time = 0.191288
 
 [query_03]
-parse_time = 0.131697
-exec_time = 0.031542
-comp_time = 0.029127
+parse_time = 0.323468
+exec_time = 0.069983
+comp_time = 0.064145
 
 [query_06]
-parse_time = 0.191989
-exec_time = 0.357506
-comp_time = 0.043298
+parse_time = 0.352008
+exec_time = 0.352117
+comp_time = 0.039057
 
 [query_07]
-parse_time = 0.138505
-exec_time = 0.111716
-comp_time = 0.082851
+parse_time = 0.156216
+exec_time = 0.114744
+comp_time = 0.087985
 
 [query_08]
-parse_time = 0.192607
-exec_time = 0.045344
-comp_time = 0.03962
+parse_time = 0.214083
+exec_time = 0.045727
+comp_time = 0.040701
 
 [query_10]
-parse_time = 0.896824
-exec_time = 0.126469
-comp_time = 0.274561
+parse_time = 0.955336
+exec_time = 0.119832
+comp_time = 0.27569
 
 [query_12]
-parse_time = 0.1465
-exec_time = 0.037445
-comp_time = 0.066389
+parse_time = 0.148251
+exec_time = 0.041032
+comp_time = 0.063357
 
 [query_15]
-parse_time = 0.140962
-exec_time = 0.017642
-comp_time = 0.162688
+parse_time = 0.127222
+exec_time = 0.015674
+comp_time = 0.151069
 
 [query_16]
-parse_time = 0.413332
-exec_time = 0.120816
-comp_time = 0.018744
+parse_time = 0.373159
+exec_time = 0.123721
+comp_time = 0.0221
 
 [query_20]
-parse_time = 0.134304
-exec_time = 0.092891
-comp_time = 0.088283
+parse_time = 0.144655
+exec_time = 0.096409
+comp_time = 0.089782
 
 [query_21]
-parse_time = 0.038103
-exec_time = 0.021087
-comp_time = 0.020655
+parse_time = 0.040143
+exec_time = 0.021057
+comp_time = 0.01997
 
 [query_24]
-parse_time = 0.612904
-exec_time = 0.315348
-comp_time = 0.247259
+parse_time = 0.667618
+exec_time = 0.345589
+comp_time = 0.220297
 
 [query_25]
-parse_time = 0.955656
-exec_time = 0.145071
-comp_time = 0.039846
+parse_time = 1.091556
+exec_time = 0.147788
+comp_time = 0.039802
 
 [query_26]
-parse_time = 0.128745
-exec_time = 0.069562
-comp_time = 0.063626
+parse_time = 0.136696
+exec_time = 0.068947
+comp_time = 0.058381
 
 [query_30]
-parse_time = 0.307691
-exec_time = 0.065254
-comp_time = 0.052758
+parse_time = 0.279021
+exec_time = 0.072404
+comp_time = 0.056151
 
 [query_32]
-parse_time = 0.154396
-exec_time = 0.053724
-comp_time = 0.004669
+parse_time = 0.160732
+exec_time = 0.052985
+comp_time = 0.005599
 
 [query_95]
-parse_time = 0.209918
-exec_time = 0.066615
-comp_time = 0.511377
+parse_time = 0.225865
+exec_time = 0.066409
+comp_time = 0.510185
 
 [query_97]
-parse_time = 1.201808
-exec_time = 0.271048
-comp_time = 0.068341
+parse_time = 1.236686
+exec_time = 0.317954
+comp_time = 0.070524
 
 [query_98]
-parse_time = 0.188962
-exec_time = 0.054657
-comp_time = 0.176256
+parse_time = 0.191718
+exec_time = 0.045138
+comp_time = 0.173033
 
 [query_99]
-parse_time = 0.168926
-exec_time = 0.111173
-comp_time = 0.069859
+parse_time = 0.163188
+exec_time = 0.108623
+comp_time = 0.066439

--- a/tests/test_parse_engine.py
+++ b/tests/test_parse_engine.py
@@ -96,6 +96,18 @@ order by a
         env.parse(TEXT2)
     assert ERROR_CODES[210] in str(e.value)
 
+    env = Environment()
+    TEXT2 = """
+const a <- 1;
+
+select
+    a,
+order by a;
+    """
+    with raises(InvalidSyntaxException) as e:
+        env.parse(TEXT2)
+    assert ERROR_CODES[210] in str(e.value)
+
 
 def test_alias_error():
     env = Environment()
@@ -106,6 +118,21 @@ def test_alias_error():
         a+2 fun,
     ;
     """
+    with raises(InvalidSyntaxException) as e:
+        env.parse(TEXT2)
+    assert ERROR_CODES[201] in str(e.value), e.value
+
+
+    env.parse_text(
+        
+    )
+
+    TEXT = """
+select
+    max(dep_time.year_start) as max_year,
+    min(dep_time.year_start) min_year;"""
+
+
     with raises(InvalidSyntaxException) as e:
         env.parse(TEXT2)
     assert ERROR_CODES[201] in str(e.value), e.value

--- a/tests/test_parse_engine.py
+++ b/tests/test_parse_engine.py
@@ -121,18 +121,3 @@ def test_alias_error():
     with raises(InvalidSyntaxException) as e:
         env.parse(TEXT2)
     assert ERROR_CODES[201] in str(e.value), e.value
-
-
-    env.parse_text(
-        
-    )
-
-    TEXT = """
-select
-    max(dep_time.year_start) as max_year,
-    min(dep_time.year_start) min_year;"""
-
-
-    with raises(InvalidSyntaxException) as e:
-        env.parse(TEXT2)
-    assert ERROR_CODES[201] in str(e.value), e.value

--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -4,6 +4,6 @@ from trilogy.dialect.enums import Dialects
 from trilogy.executor import Executor
 from trilogy.parser import parse
 
-__version__ = "0.0.3.77"
+__version__ = "0.0.3.78"
 
 __all__ = ["parse", "Executor", "Dialects", "Environment", "CONFIG"]

--- a/trilogy/parsing/parse_engine.py
+++ b/trilogy/parsing/parse_engine.py
@@ -2172,7 +2172,7 @@ def parse_text(
             # recovery attempt for aliasing
             try:
                 e.interactive_parser.feed_token(Token("AS", "AS"))
-                e.interactive_parser.feed_token(e.token)
+                e.interactive_parser.feed_token(Token("IDENTIFIER", e.token.value))
                 raise InvalidSyntaxException(
                     f"Syntax [{ERROR_CODES[201]}]:"
                     + ERROR_CODES[201]


### PR DESCRIPTION
## Description

Alias error context injection didn't trigger properly if the next token wasn't parsed as an identifier; instead in recovery inject in a new token with the actual token value to handle more cases.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
