### PR TITLE
add `trilogy public` command for fetching public models

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,51 @@ This repo contains [pytrilogy](https://github.com/trilogy-data/pytrilogy), the r
 
 **Install**
 ```bash
-pip install pytrilogy[cli]
+pip install pytrilogy[cli,serve]
 ```
 
-**Create a file hello.preql**
+### End-to-end demo: public model → refresh → studio UI
 
-Trilogy supports reusable functions and constants. 
+Go from zero to a queryable, persisted model in four commands. We'll pull a
+public DuckDB model (boulder bike share stations, hosted parquet), add a
+derived persisted datasource, refresh it, then explore it in Studio.
+
+```bash
+# 1. Pull a public model (fetches all source .preql + setup.sql + trilogy.toml).
+trilogy public fetch bike_data ./bike-demo
+cd bike-demo
+
+# 2. Add a derived datasource that persists daily averages to a local table.
+cat > station_daily.preql <<'EOF'
+import boulder_data as boulder;
+
+auto day <- date_trunc(boulder.timestamp, day);
+
+persist station_daily into station_daily_stats from
+SELECT
+    boulder.id,
+    boulder.name,
+    day,
+    avg(boulder.bikes) -> avg_bikes,
+    avg(boulder.free) -> avg_free
+;
+EOF
+
+# 3. Refresh — runs setup.sql, builds station_daily_stats, tracks watermarks.
+trilogy refresh .
+
+# 4. Launch the Studio UI against the live model (opens your browser).
+trilogy serve .
+```
+
+Browse other available models with `trilogy public list` (filter with
+`--engine duckdb` or `--tag benchmark`). Every model in
+[trilogy-public-models](https://github.com/trilogy-data/trilogy-public-models)
+is pullable.
+
+### Minimal hello world
+
+Trilogy supports reusable functions and constants.
 
 ```sql
 const prime <- unnest([2, 3, 5, 7, 11, 13, 17, 19, 23, 29]);
@@ -315,6 +354,16 @@ trilogy run "key x int; datasource test_source(i:x) grain(x) address test; selec
 ```bash
 trilogy fmt <path to trilogy file>
 ```
+
+**Browse and pull public models:**
+```bash
+trilogy public list [--engine duckdb] [--tag benchmark]
+trilogy public fetch <model-name> [--path <dir>] [--no-examples]
+```
+
+Fetches model source files, setup scripts, and a ready-to-use `trilogy.toml`
+from [trilogy-public-models](https://github.com/trilogy-data/trilogy-public-models)
+into a local directory so you can immediately `refresh` and `serve` it.
 
 #### Backend Configuration
 

--- a/tests/scripts/test_public.py
+++ b/tests/scripts/test_public.py
@@ -1,0 +1,198 @@
+"""Tests for the `trilogy public` command."""
+
+import io
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from trilogy.scripts.trilogy import cli
+
+SAMPLE_INDEX = {
+    "count": 2,
+    "files": [
+        {
+            "name": "bike_data",
+            "filename": "bike_data.json",
+            "engine": "duckdb",
+            "description": "## CityBikes data",
+            "tags": ["duckdb"],
+        },
+        {
+            "name": "crypto",
+            "filename": "crypto.json",
+            "engine": "bigquery",
+            "description": "## Crypto dataset",
+            "tags": ["bigquery"],
+        },
+    ],
+}
+
+SAMPLE_MANIFEST = {
+    "name": "bike_data",
+    "engine": "duckdb",
+    "description": "## CityBikes data",
+    "tags": ["duckdb"],
+    "components": [
+        {
+            "alias": "boulder_data",
+            "name": "boulder_data",
+            "purpose": "source",
+            "type": "trilogy",
+            "url": (
+                "https://trilogy-data.github.io/trilogy-public-models/"
+                "trilogy_public_models/duckdb/bike_data/boulder_data.preql"
+            ),
+        },
+        {
+            "alias": "setup",
+            "name": "setup",
+            "purpose": "setup",
+            "type": "sql",
+            "url": (
+                "https://trilogy-data.github.io/trilogy-public-models/"
+                "trilogy_public_models/duckdb/bike_data/setup.sql"
+            ),
+        },
+        {
+            "name": "sample_dashboard",
+            "purpose": "example",
+            "type": "dashboard",
+            "url": (
+                "https://trilogy-data.github.io/trilogy-public-models/"
+                "examples/duckdb/bike_data/sample.json"
+            ),
+        },
+    ],
+}
+
+FILE_CONTENTS: dict[str, bytes] = {
+    "boulder_data.preql": b"key id string;\n",
+    "setup.sql": b"CREATE OR REPLACE TABLE t AS SELECT 1 as id;\n",
+    "sample.json": b'{"title": "demo"}\n',
+}
+
+
+def _fake_urlopen(url_or_req, *_args, **_kwargs):
+    url = url_or_req.full_url if hasattr(url_or_req, "full_url") else url_or_req
+    if url.endswith("/studio/index.json"):
+        payload = json.dumps(SAMPLE_INDEX).encode("utf-8")
+    elif url.endswith("/studio/bike_data.json"):
+        payload = json.dumps(SAMPLE_MANIFEST).encode("utf-8")
+    else:
+        filename = url.rsplit("/", 1)[-1]
+        if filename not in FILE_CONTENTS:
+            from urllib.error import HTTPError
+
+            raise HTTPError(url, 404, "Not Found", {}, None)
+        payload = FILE_CONTENTS[filename]
+    response = io.BytesIO(payload)
+    response.__enter__ = lambda self: self  # type: ignore[attr-defined]
+    response.__exit__ = lambda self, *a: None  # type: ignore[attr-defined]
+    return response
+
+
+@pytest.fixture
+def patched_urlopen():
+    with patch("trilogy.scripts.public.urlopen", side_effect=_fake_urlopen) as m:
+        yield m
+
+
+def test_public_list_duckdb(patched_urlopen):
+    runner = CliRunner()
+    result = runner.invoke(cli, ["public", "list", "--engine", "duckdb"])
+    assert result.exit_code == 0, result.output
+    assert "bike_data" in result.output
+    assert "crypto" not in result.output
+
+
+def test_public_list_no_match(patched_urlopen):
+    runner = CliRunner()
+    result = runner.invoke(cli, ["public", "list", "--engine", "nope"])
+    assert result.exit_code == 0
+    assert "No models matched" in result.output
+
+
+def test_public_fetch_bike_data(patched_urlopen):
+    runner = CliRunner()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        target = Path(tmpdir) / "out"
+        result = runner.invoke(
+            cli, ["public", "fetch", "bike_data", "--path", str(target)]
+        )
+        assert result.exit_code == 0, result.output
+        assert (target / "boulder_data.preql").exists()
+        assert (target / "setup.sql").exists()
+        assert (target / "examples" / "sample.json").exists()
+        assert (target / "README.md").read_text().startswith("## CityBikes data")
+        config = (target / "trilogy.toml").read_text()
+        assert 'dialect = "duck_db"' in config
+        assert '"setup.sql"' in config
+
+
+def test_public_fetch_no_examples(patched_urlopen):
+    runner = CliRunner()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        target = Path(tmpdir) / "out"
+        result = runner.invoke(
+            cli,
+            [
+                "public",
+                "fetch",
+                "bike_data",
+                "--path",
+                str(target),
+                "--no-examples",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert (target / "boulder_data.preql").exists()
+        assert not (target / "examples").exists()
+
+
+def test_public_fetch_missing_model(patched_urlopen):
+    runner = CliRunner()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        target = Path(tmpdir) / "out"
+        result = runner.invoke(
+            cli, ["public", "fetch", "nonexistent", "--path", str(target)]
+        )
+        assert result.exit_code == 1
+        assert "No public model" in result.output
+
+
+def test_public_fetch_rejects_non_empty_dir(patched_urlopen):
+    runner = CliRunner()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        target = Path(tmpdir) / "out"
+        target.mkdir()
+        (target / "existing.preql").write_text("select 1;")
+        result = runner.invoke(
+            cli, ["public", "fetch", "bike_data", "--path", str(target)]
+        )
+        assert result.exit_code == 1
+        assert "not empty" in result.output
+
+
+def test_public_fetch_force_overwrites(patched_urlopen):
+    runner = CliRunner()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        target = Path(tmpdir) / "out"
+        target.mkdir()
+        (target / "existing.preql").write_text("select 1;")
+        result = runner.invoke(
+            cli,
+            ["public", "fetch", "bike_data", "--path", str(target), "--force"],
+        )
+        assert result.exit_code == 0, result.output
+        assert (target / "boulder_data.preql").exists()
+
+
+def test_public_fetch_rejects_unsafe_name():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["public", "fetch", "../evil"])
+    assert result.exit_code == 1
+    assert "Invalid model name" in result.output

--- a/trilogy/scripts/agent_info.py
+++ b/trilogy/scripts/agent_info.py
@@ -175,6 +175,37 @@ trilogy ingest "orders,customers" duckdb --fks "orders.customer_id:customers.id"
 
 ---
 
+### trilogy public <subcommand> [options]
+
+Browse and pull Trilogy models published in
+[trilogy-public-models](https://github.com/trilogy-data/trilogy-public-models).
+
+**Subcommands:**
+- `list`: Print available models from the studio index.
+- `fetch <model>`: Download a model's source files into a local directory.
+
+**`trilogy public list` options:**
+- `--engine NAME`, `-e NAME`: Filter by engine (e.g. `duckdb`, `bigquery`).
+- `--tag NAME`, `-t NAME`: Filter by tag.
+
+**`trilogy public fetch <model>` options:**
+- `--path DIR`, `-p DIR`: Target directory (default `./<model>`).
+- `--no-examples`: Skip example scripts/dashboards.
+- `--force`, `-f`: Overwrite an existing non-empty target directory.
+
+Writes all components, a README.md from the model description, and a
+`trilogy.toml` with the engine dialect and any setup SQL preconfigured, so the
+directory is immediately usable with `trilogy refresh` / `trilogy serve`.
+
+**Example:**
+```bash
+trilogy public list --engine duckdb
+trilogy public fetch bike_data --path ./bike-demo
+cd bike-demo && trilogy refresh . && trilogy serve .
+```
+
+---
+
 ### trilogy serve <directory> [engine] [options]
 
 Start a FastAPI server to expose Trilogy models from a directory.

--- a/trilogy/scripts/click_utils.py
+++ b/trilogy/scripts/click_utils.py
@@ -32,8 +32,14 @@ class LazyGroup(click.Group):
                 module_path, attr, context_settings = self._lazy_subcommands[cmd_name]
                 module = importlib.import_module(module_path)
                 func = getattr(module, attr)
-                cmd = click.command(cmd_name, context_settings=context_settings)(func)
-                self._loaded_commands[cmd_name] = cmd
+                if isinstance(func, click.Command):
+                    func.name = cmd_name
+                    self._loaded_commands[cmd_name] = func
+                else:
+                    cmd = click.command(cmd_name, context_settings=context_settings)(
+                        func
+                    )
+                    self._loaded_commands[cmd_name] = cmd
             return self._loaded_commands[cmd_name]
         return super().get_command(ctx, cmd_name)
 

--- a/trilogy/scripts/public.py
+++ b/trilogy/scripts/public.py
@@ -1,0 +1,246 @@
+"""Public command for Trilogy CLI - fetch models from trilogy-public-models."""
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+import click
+
+from trilogy.scripts.display import (
+    print_error,
+    print_info,
+    print_success,
+    print_warning,
+)
+
+RAW_BASE = "https://raw.githubusercontent.com/trilogy-data/trilogy-public-models/main"
+PAGES_PREFIX = "https://trilogy-data.github.io/trilogy-public-models/"
+INDEX_URL = f"{RAW_BASE}/studio/index.json"
+STUDIO_BASE = f"{RAW_BASE}/studio"
+EXAMPLE_MARKER = "/examples/"
+
+
+@dataclass(frozen=True)
+class ModelEntry:
+    name: str
+    filename: str
+    engine: str
+    description: str
+    tags: tuple[str, ...]
+
+
+def _normalize_url(url: str) -> str:
+    """Rewrite github.io asset URLs to raw.githubusercontent.com for reliable fetches."""
+    if url.startswith(PAGES_PREFIX):
+        return RAW_BASE + "/" + url[len(PAGES_PREFIX) :]
+    return url
+
+
+def _http_get(url: str, timeout: float = 15.0) -> bytes:
+    req = Request(_normalize_url(url), headers={"User-Agent": "trilogy-cli"})
+    with urlopen(req, timeout=timeout) as resp:  # noqa: S310 - known HTTPS endpoint
+        return resp.read()
+
+
+def _fetch_index() -> list[ModelEntry]:
+    raw = _http_get(INDEX_URL)
+    data = json.loads(raw.decode("utf-8"))
+    entries: list[ModelEntry] = []
+    for item in data.get("files", []):
+        entries.append(
+            ModelEntry(
+                name=item["name"],
+                filename=item["filename"],
+                engine=item.get("engine", ""),
+                description=(item.get("description", "") or "").strip(),
+                tags=tuple(item.get("tags", [])),
+            )
+        )
+    entries.sort(key=lambda e: e.name)
+    return entries
+
+
+def _fetch_model_manifest(filename: str) -> dict[str, Any]:
+    url = f"{STUDIO_BASE}/{filename}"
+    return json.loads(_http_get(url).decode("utf-8"))
+
+
+def _short_description(text: str, width: int = 60) -> str:
+    for line in text.splitlines():
+        cleaned = line.lstrip("# ").strip()
+        if cleaned:
+            return cleaned if len(cleaned) <= width else cleaned[: width - 1] + "…"
+    return ""
+
+
+def _component_target(component: dict[str, Any], root: Path) -> Path:
+    url = component["url"]
+    parsed = urlparse(url)
+    filename = Path(parsed.path).name
+    if EXAMPLE_MARKER in parsed.path:
+        return root / "examples" / filename
+    return root / filename
+
+
+def _is_example(component: dict[str, Any]) -> bool:
+    return EXAMPLE_MARKER in urlparse(component["url"]).path
+
+
+@click.group()
+def public() -> None:
+    """Work with trilogy-public-models hosted at trilogy-data/trilogy-public-models."""
+
+
+@public.command("list")
+@click.option("--engine", "-e", type=str, default=None, help="Filter by engine.")
+@click.option("--tag", "-t", type=str, default=None, help="Filter by tag.")
+def list_cmd(engine: str | None, tag: str | None) -> None:
+    """List available public models from the studio index."""
+    try:
+        entries = _fetch_index()
+    except (HTTPError, URLError, TimeoutError) as exc:
+        print_error(f"Failed to fetch index: {exc}")
+        raise click.exceptions.Exit(1) from exc
+
+    if engine:
+        entries = [e for e in entries if e.engine == engine]
+    if tag:
+        entries = [e for e in entries if tag in e.tags]
+
+    if not entries:
+        print_warning("No models matched the filters.")
+        return
+
+    name_width = max(len(e.name) for e in entries)
+    engine_width = max(len(e.engine) for e in entries)
+    print_info(f"Found {len(entries)} model(s):")
+    for e in entries:
+        click.echo(
+            f"  {e.name.ljust(name_width)}  "
+            f"{e.engine.ljust(engine_width)}  "
+            f"{_short_description(e.description)}"
+        )
+    click.echo()
+    click.echo("Fetch a model with: trilogy public fetch <name> [--path <dir>]")
+
+
+_SAFE_NAME = re.compile(r"[^A-Za-z0-9._-]")
+
+
+@public.command("fetch")
+@click.argument("model", type=str)
+@click.option(
+    "--path",
+    "-p",
+    type=click.Path(file_okay=False, resolve_path=True),
+    default=None,
+    help="Target directory. Defaults to ./<model>.",
+)
+@click.option(
+    "--examples/--no-examples",
+    default=True,
+    help="Also download example scripts and dashboards (default: include).",
+)
+@click.option(
+    "--force",
+    "-f",
+    is_flag=True,
+    default=False,
+    help="Overwrite existing files if the target directory is not empty.",
+)
+def fetch_cmd(model: str, path: str | None, examples: bool, force: bool) -> None:
+    """Fetch a public model by name, writing its files locally.
+
+    Creates a directory containing all source files, setup scripts, and
+    (optionally) example assets. Afterwards you can `cd` into it and run
+    `trilogy refresh` / `trilogy serve` against the model.
+    """
+    if _SAFE_NAME.search(model):
+        print_error(f"Invalid model name: {model!r}")
+        raise click.exceptions.Exit(1)
+
+    try:
+        entries = _fetch_index()
+    except (HTTPError, URLError, TimeoutError) as exc:
+        print_error(f"Failed to fetch index: {exc}")
+        raise click.exceptions.Exit(1) from exc
+
+    entry = next((e for e in entries if e.name == model), None)
+    if entry is None:
+        print_error(f"No public model named {model!r}.")
+        click.echo("Available models: " + ", ".join(e.name for e in entries))
+        raise click.exceptions.Exit(1)
+
+    try:
+        manifest = _fetch_model_manifest(entry.filename)
+    except (HTTPError, URLError, TimeoutError) as exc:
+        print_error(f"Failed to fetch manifest for {model}: {exc}")
+        raise click.exceptions.Exit(1) from exc
+
+    target_root = Path(path) if path else Path.cwd() / model
+    if target_root.exists() and any(target_root.iterdir()) and not force:
+        print_error(
+            f"Target directory {target_root} is not empty. "
+            "Pass --force to overwrite, or choose another path."
+        )
+        raise click.exceptions.Exit(1)
+    target_root.mkdir(parents=True, exist_ok=True)
+
+    components = [
+        c
+        for c in manifest.get("components", [])
+        if c.get("type") in {"trilogy", "sql"}
+        or (examples and c.get("type") == "dashboard")
+    ]
+    if not examples:
+        components = [c for c in components if not _is_example(c)]
+
+    print_info(f"Fetching {entry.name} ({entry.engine}) into {target_root}")
+    written: list[Path] = []
+    for component in components:
+        dest = _component_target(component, target_root)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            payload = _http_get(component["url"])
+        except (HTTPError, URLError, TimeoutError) as exc:
+            print_warning(f"  skipped {component.get('name')}: {exc}")
+            continue
+        dest.write_bytes(payload)
+        written.append(dest)
+        rel = dest.relative_to(target_root)
+        click.echo(f"  wrote {rel}")
+
+    readme_path = target_root / "README.md"
+    if not readme_path.exists() and manifest.get("description"):
+        readme_path.write_text(manifest["description"] + "\n", encoding="utf-8")
+        written.append(readme_path)
+
+    toml_path = target_root / "trilogy.toml"
+    if not toml_path.exists():
+        dialect = "duck_db" if entry.engine == "duckdb" else entry.engine
+        setup_sql = [
+            str(p.relative_to(target_root).as_posix())
+            for p in written
+            if p.suffix == ".sql"
+        ]
+        lines = ["[engine]", f'dialect = "{dialect}"', ""]
+        if setup_sql:
+            lines += [
+                "[setup]",
+                "sql = [" + ", ".join(f'"{s}"' for s in setup_sql) + "]",
+                "",
+            ]
+        toml_path.write_text("\n".join(lines), encoding="utf-8")
+        written.append(toml_path)
+        click.echo("  wrote trilogy.toml")
+
+    print_success(f"Fetched {len(written)} file(s) for {entry.name}.")
+    click.echo("\nNext steps:")
+    click.echo(f"  cd {target_root}")
+    click.echo("  trilogy refresh .        # build any managed assets")
+    click.echo("  trilogy serve .          # open the studio UI")

--- a/trilogy/scripts/trilogy.py
+++ b/trilogy/scripts/trilogy.py
@@ -29,6 +29,7 @@ LAZY_SUBCOMMANDS: dict[str, tuple[str, str, dict | None]] = {
     "init": ("trilogy.scripts.init", "init", None),
     "integration": ("trilogy.scripts.testing", "integration", IGNORE_UNKNOWN),
     "plan": ("trilogy.scripts.plan", "plan", None),
+    "public": ("trilogy.scripts.public", "public", None),
     "refresh": ("trilogy.scripts.refresh", "refresh", IGNORE_UNKNOWN),
     "run": ("trilogy.scripts.run", "run", IGNORE_UNKNOWN),
     "serve": ("trilogy.scripts.serve", "serve", None),


### PR DESCRIPTION
Adds a new CLI subcommand group, `trilogy public`, that pulls from the
studio index in trilogy-data/trilogy-public-models:

- `trilogy public list [--engine] [--tag]` shows all available models.
- `trilogy public fetch <name> [--path] [--examples/--no-examples]`
  downloads all model components, writes a README.md from the model
  description, and generates a ready-to-use trilogy.toml with the
  engine dialect and any setup.sql pre-wired.

With this, the README demo flow becomes: `trilogy public fetch` →
`cd` into the new directory, add a derived datasource → `trilogy
refresh .` → `trilogy serve .` for the studio UI.

Also extends LazyGroup so pre-built click.Group attributes (like the
`public` group) can be registered directly as lazy subcommands, and
updates `trilogy agent-info` so agents discover the new command.