### PR TITLE
[Feat]: Partial Aggregate Rollups

### DIFF
--- a/tests/discovery/test_aggregate_handling.py
+++ b/tests/discovery/test_aggregate_handling.py
@@ -307,7 +307,12 @@ SELECT
 
     assert "flight_count_by_source_dest_date" not in avg_generated, avg_generated
     assert (
-        "flight_count_by_source_dest_date" not in distinct_generated
+        'count(distinct "flight_count_by_source_dest_date"."destination_code")'
+        in distinct_generated
+    ), distinct_generated
+    assert (
+        '"flight_count_by_source_dest_date"."distinct_destinations"'
+        not in distinct_generated
     ), distinct_generated
 
 

--- a/tests/discovery/test_aggregate_handling.py
+++ b/tests/discovery/test_aggregate_handling.py
@@ -151,3 +151,193 @@ SELECT
             ;
 """)[-1]
     assert "aggregated_all" in generated, generated
+
+
+PARTIAL_AGG_SETUP = """
+key id int;
+key origin_code string;
+key destination_code string;
+property id.flight_date date;
+property id.distance int;
+property id.cancelled string;
+
+auto flight_count <- count(id);
+auto total_distance <- sum(distance);
+auto avg_distance <- avg(distance);
+auto distinct_destinations <- count_distinct(destination_code);
+
+datasource flight (
+    id:id,
+    origin_code:origin_code,
+    destination_code:destination_code,
+    flight_date:flight_date,
+    distance:distance,
+    cancelled:cancelled,
+)
+grain (id)
+query '''
+select 1 as id, 'A' as origin_code, 'X' as destination_code, '2024-01-01'::date as flight_date, 10 as distance, 'N' as cancelled
+union all select 2, 'A', 'Y', '2024-01-01'::date, 20, 'N'
+union all select 3, 'B', 'X', '2024-01-01'::date, 30, 'Y'
+''';
+
+datasource flight_count_by_source_dest_date (
+    origin_code:origin_code,
+    destination_code:destination_code,
+    flight_date:flight_date,
+    flight_count:flight_count,
+    total_distance:total_distance,
+    avg_distance:avg_distance,
+    distinct_destinations:distinct_destinations,
+)
+grain (origin_code, destination_code, flight_date)
+query '''
+select 'A' as origin_code, 'X' as destination_code, '2024-01-01'::date as flight_date, 1 as flight_count, 10 as total_distance, 10 as avg_distance, 1 as distinct_destinations
+union all select 'A', 'Y', '2024-01-01'::date, 1, 20, 20, 1
+union all select 'B', 'X', '2024-01-01'::date, 1, 30, 30, 1
+''';
+"""
+
+
+UNSAFE_PARTIAL_AGG_SETUP = """
+key id int;
+key origin_code string;
+key destination_code string;
+property id.flight_date date;
+
+auto flight_count <- count(id);
+
+datasource flight (
+    id:id,
+    origin_code:origin_code,
+    flight_date:flight_date,
+)
+grain (id)
+query '''
+select 1 as id, 'A' as origin_code, '2024-01-01'::date as flight_date
+union all select 2, 'A', '2024-01-01'::date
+''';
+
+datasource flight_count_by_source_dest_date (
+    origin_code:origin_code,
+    destination_code:destination_code,
+    flight_date:flight_date,
+    flight_count:flight_count,
+)
+grain (origin_code, destination_code, flight_date)
+query '''
+select 'A' as origin_code, 'X' as destination_code, '2024-01-01'::date as flight_date, 1 as flight_count
+union all select 'A', 'Y', '2024-01-01'::date, 1
+''';
+"""
+
+
+def test_partial_additive_aggregate_rollup_sql():
+    exec = Dialects.DUCK_DB.default_executor()
+    exec.parse_text(PARTIAL_AGG_SETUP)
+
+    generated = exec.generate_sql("""
+SELECT
+    origin_code,
+    flight_date,
+    flight_count
+;
+""")[-1]
+
+    assert "flight_count_by_source_dest_date" in generated, generated
+    assert 'sum("flight_count_by_source_dest_date"."flight_count")' in generated
+    assert "GROUP BY\n    1,\n    2" in generated
+
+
+def test_partial_sum_aggregate_rollup_sql():
+    exec = Dialects.DUCK_DB.default_executor()
+    exec.parse_text(PARTIAL_AGG_SETUP)
+
+    generated = exec.generate_sql("""
+SELECT
+    origin_code,
+    flight_date,
+    total_distance
+;
+""")[-1]
+
+    assert "flight_count_by_source_dest_date" in generated, generated
+    assert 'sum("flight_count_by_source_dest_date"."total_distance")' in generated
+
+
+def test_partial_aggregate_rollup_execution_matches_raw_result():
+    exec = Dialects.DUCK_DB.default_executor()
+    exec.parse_text(PARTIAL_AGG_SETUP)
+
+    results = exec.execute_text("""
+SELECT
+    origin_code,
+    flight_date,
+    flight_count,
+    total_distance
+ORDER BY
+    origin_code asc
+;
+""")[-1].fetchall()
+
+    assert [(row[0], row[2], row[3]) for row in results] == [
+        ("A", 2, 30),
+        ("B", 1, 30),
+    ]
+
+
+def test_partial_aggregate_rollup_rejects_unsupported_aggregates():
+    exec = Dialects.DUCK_DB.default_executor()
+    exec.parse_text(PARTIAL_AGG_SETUP)
+
+    avg_generated = exec.generate_sql("""
+SELECT
+    origin_code,
+    flight_date,
+    avg_distance
+;
+""")[-1]
+    distinct_generated = exec.generate_sql("""
+SELECT
+    origin_code,
+    flight_date,
+    distinct_destinations
+;
+""")[-1]
+
+    assert "flight_count_by_source_dest_date" not in avg_generated, avg_generated
+    assert (
+        "flight_count_by_source_dest_date" not in distinct_generated
+    ), distinct_generated
+
+
+def test_partial_aggregate_rollup_requires_dropped_grain_to_depend_on_input_key():
+    exec = Dialects.DUCK_DB.default_executor()
+    exec.parse_text(UNSAFE_PARTIAL_AGG_SETUP)
+
+    generated = exec.generate_sql("""
+SELECT
+    origin_code,
+    flight_date,
+    flight_count
+;
+""")[-1]
+
+    assert "flight_count_by_source_dest_date" not in generated, generated
+
+
+def test_partial_aggregate_rollup_rejects_foreign_filter():
+    exec = Dialects.DUCK_DB.default_executor()
+    exec.parse_text(PARTIAL_AGG_SETUP)
+
+    generated = exec.generate_sql("""
+SELECT
+    origin_code,
+    flight_date,
+    flight_count
+WHERE
+    cancelled = 'N'
+;
+""")[-1]
+
+    assert "flight_count_by_source_dest_date" not in generated, generated

--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -4,7 +4,7 @@ from trilogy.dialect.enums import Dialects
 from trilogy.executor import Executor
 from trilogy.parser import parse
 
-__version__ = "0.3.240"
+__version__ = "0.3.241"
 
 __all__ = [
     "parse",

--- a/trilogy/core/graph_models.py
+++ b/trilogy/core/graph_models.py
@@ -10,6 +10,7 @@ from trilogy.core.models.build import (
     BuildUnionDatasource,
     BuildWhereClause,
 )
+from trilogy.core.processing.aggregate_rollup import get_additive_rollup_concepts
 from trilogy.core.processing.condition_utility import (
     condition_implies,
     condition_implies_with_extras,

--- a/trilogy/core/graph_models.py
+++ b/trilogy/core/graph_models.py
@@ -2,7 +2,7 @@ from enum import Enum
 from logging import Logger
 from typing import cast
 
-from trilogy.core.enums import Derivation, Granularity
+from trilogy.core.enums import Derivation, FunctionType, Granularity
 from trilogy.core.graph import DiGraph
 from trilogy.core.models.build import (
     BuildConcept,
@@ -15,6 +15,46 @@ from trilogy.core.processing.condition_utility import (
     condition_implies_with_extras,
     decompose_condition,
 )
+
+ADDITIVE_ROLLUP_FUNCTIONS = {FunctionType.COUNT, FunctionType.SUM}
+
+
+def _aggregate_signature(
+    concept: BuildConcept,
+) -> tuple[FunctionType, tuple[str, ...]] | None:
+    from trilogy.core.models.build import BuildAggregateWrapper
+
+    if not isinstance(concept.lineage, BuildAggregateWrapper):
+        return None
+    return (
+        concept.lineage.function.operator,
+        tuple(
+            sorted(
+                arg.canonical_address
+                for arg in concept.lineage.function.concept_arguments
+            )
+        ),
+    )
+
+
+def _datasource_materializes_aggregate(
+    datasource: BuildDatasource, concept: BuildConcept
+) -> bool:
+    signature = _aggregate_signature(concept)
+    if signature is None:
+        return False
+    for output in datasource.output_concepts:
+        output_signature = _aggregate_signature(output)
+        if output_signature == signature:
+            return True
+    return False
+
+
+def _datasource_has_aggregate_output(datasource: BuildDatasource) -> bool:
+    return any(
+        _aggregate_signature(output) is not None
+        for output in datasource.output_concepts
+    )
 
 
 class SearchCriteria(Enum):
@@ -168,6 +208,7 @@ def prune_sources_for_aggregates(
     all_concepts: list[BuildConcept],
     logger: Logger,
 ) -> None:
+    aggregate_concepts: list[BuildConcept] = []
     required_grains = []
     for x in all_concepts:
         logger.debug(
@@ -175,6 +216,7 @@ def prune_sources_for_aggregates(
         )
         if x.is_aggregate:
             logger.debug(f"Aggregate found: {x.address} at grain {x.grain}")
+            aggregate_concepts.append(x)
             required_grains.append(x.grain)
     # if no aggregates, exit
     logger.debug(f"Required grains for aggregates: {required_grains}")
@@ -186,9 +228,9 @@ def prune_sources_for_aggregates(
     # don't disqualify a precomputed datasource that binds the named form.
     addr_to_canonical = {bc.address: bc.canonical_address for bc in g.concepts.values()}
 
-    def grain_key(grain) -> frozenset[str] | None:
+    def grain_key(grain) -> frozenset[str]:
         if grain.abstract:
-            return None
+            return frozenset()
         return frozenset(addr_to_canonical.get(c, c) for c in grain.components)
 
     required_keys = {grain_key(rg) for rg in required_grains}
@@ -196,9 +238,43 @@ def prune_sources_for_aggregates(
         logger.debug("Multiple required grains found, cannot prune datasources.")
         return
     target = next(iter(required_keys))
+
+    exact_matches = [
+        node
+        for node, ds in g.datasources.items()
+        if isinstance(ds, BuildDatasource)
+        and grain_key(ds.grain) == target
+        and all(_datasource_materializes_aggregate(ds, c) for c in aggregate_concepts)
+    ]
+    if exact_matches:
+        keep = set(exact_matches)
+    else:
+        keep = set()
+        additive = [
+            c
+            for c in aggregate_concepts
+            if (signature := _aggregate_signature(c))
+            and signature[0] in ADDITIVE_ROLLUP_FUNCTIONS
+        ]
+        if len(additive) == len(aggregate_concepts):
+            for node, ds in g.datasources.items():
+                if not isinstance(ds, BuildDatasource):
+                    continue
+                ds_grain = grain_key(ds.grain)
+                if not target.issubset(ds_grain) or ds_grain == target:
+                    continue
+                if all(_datasource_materializes_aggregate(ds, c) for c in additive):
+                    keep.add(node)
+
+    keep.update(
+        node
+        for node, ds in g.datasources.items()
+        if isinstance(ds, BuildDatasource) and not _datasource_has_aggregate_output(ds)
+    )
+
     to_remove = []
     for node, ds in g.datasources.items():
-        if grain_key(ds.grain) != target:
+        if node not in keep:
             logger.debug(f"Removing datasource {node} at grain {ds.grain}")
             to_remove.append(node)
     for node in to_remove:

--- a/trilogy/core/graph_models.py
+++ b/trilogy/core/graph_models.py
@@ -10,7 +10,6 @@ from trilogy.core.models.build import (
     BuildUnionDatasource,
     BuildWhereClause,
 )
-from trilogy.core.processing.aggregate_rollup import get_additive_rollup_concepts
 from trilogy.core.processing.condition_utility import (
     condition_implies,
     condition_implies_with_extras,

--- a/trilogy/core/models/execute.py
+++ b/trilogy/core/models/execute.py
@@ -69,6 +69,7 @@ class CTE:
         Union[BuildComparison, BuildConditional, BuildParenthetical]
     ] = None
     partial_concepts: List[BuildConcept] = field(default_factory=list)
+    rollup_concepts: List[BuildConcept] = field(default_factory=list)
     nullable_concepts: List[BuildConcept] = field(default_factory=list)
     join_derived_concepts: List[BuildConcept] = field(default_factory=list)
     hidden_concepts: set[str] = field(default_factory=set)
@@ -126,6 +127,10 @@ class CTE:
         if self.partial_concepts and CONFIG.comments.partial:
             base += (
                 f"\n-- Partials: {', '.join([str(x) for x in self.partial_concepts])}."
+            )
+        if self.rollup_concepts:
+            base += (
+                f"\n-- Rollups: {', '.join([str(x) for x in self.rollup_concepts])}."
             )
         if CONFIG.comments.source_map:
             base += f"\n-- Source Map: {self.source_map}."
@@ -269,6 +274,9 @@ class CTE:
         self.partial_concepts = unique(
             self.partial_concepts + other.partial_concepts, "address"
         )
+        self.rollup_concepts = unique(
+            self.rollup_concepts + other.rollup_concepts, "address"
+        )
         self.join_derived_concepts = unique(
             self.join_derived_concepts + other.join_derived_concepts, "address"
         )
@@ -276,6 +284,9 @@ class CTE:
         self.source.source_map = {**self.source.source_map, **other.source.source_map}
         self.source.output_concepts = unique(
             self.source.output_concepts + other.source.output_concepts, "address"
+        )
+        self.source.rollup_concepts = unique(
+            self.source.rollup_concepts + other.source.rollup_concepts, "address"
         )
         self.nullable_concepts = unique(
             self.nullable_concepts + other.nullable_concepts, "address"
@@ -388,7 +399,11 @@ class CTE:
 
     @property
     def group_concepts(self) -> List[BuildConcept]:
+        rollup_addresses = {c.address for c in self.rollup_concepts}
+
         def check_is_not_in_group(c: BuildConcept):
+            if c.address in rollup_addresses:
+                return True
             if len(self.source_map.get(c.address, [])) > 0:
                 return False
             if c.derivation == Derivation.ROWSET:
@@ -623,6 +638,7 @@ class QueryDatasource:
     ] = None
     source_type: SourceType = field(default=SourceType.SELECT)
     partial_concepts: List[BuildConcept] = field(default_factory=list)
+    rollup_concepts: List[BuildConcept] = field(default_factory=list)
     hidden_concepts: set[str] = field(default_factory=set)
     nullable_concepts: List[BuildConcept] = field(default_factory=list)
     join_derived_concepts: List[BuildConcept] = field(default_factory=list)
@@ -682,6 +698,7 @@ class QueryDatasource:
             grain=datasource.grain,
             joins=[],
             partial_concepts=datasource.partial_concepts,
+            rollup_concepts=[],
             hidden_concepts={c.address for c in datasource.hidden_concepts},
             nullable_concepts=datasource.nullable_concepts,
             base_datasource=datasource,
@@ -817,6 +834,9 @@ class QueryDatasource:
             source_type=self.source_type,
             partial_concepts=unique(
                 self.partial_concepts + other.partial_concepts, "address"
+            ),
+            rollup_concepts=unique(
+                self.rollup_concepts + other.rollup_concepts, "address"
             ),
             join_derived_concepts=self.join_derived_concepts,
             force_group=self.force_group,
@@ -1018,6 +1038,7 @@ class RecursiveCTE(CTE):
             joins=self.joins,
             condition=self.condition,
             partial_concepts=self.partial_concepts,
+            rollup_concepts=self.rollup_concepts,
             hidden_concepts=self.hidden_concepts,
             nullable_concepts=self.nullable_concepts,
             join_derived_concepts=self.join_derived_concepts,
@@ -1060,6 +1081,7 @@ class RecursiveCTE(CTE):
                 )
             ],
             partial_concepts=self.partial_concepts,
+            rollup_concepts=self.rollup_concepts,
             hidden_concepts=self.hidden_concepts,
             nullable_concepts=self.nullable_concepts,
             join_derived_concepts=self.join_derived_concepts,
@@ -1083,6 +1105,7 @@ class UnionCTE:
     limit: Optional[int] = None
     hidden_concepts: set[str] = field(default_factory=set)
     partial_concepts: list[BuildConcept] = field(default_factory=list)
+    rollup_concepts: list[BuildConcept] = field(default_factory=list)
     existence_source_map: Dict[str, list[str]] = field(default_factory=dict)
     inlined_ctes: Dict[str, InlinedCTE] = field(default_factory=dict)
 

--- a/trilogy/core/processing/aggregate_rollup.py
+++ b/trilogy/core/processing/aggregate_rollup.py
@@ -1,0 +1,168 @@
+from collections.abc import Iterable, Mapping
+
+from trilogy.core.enums import FunctionType, Granularity, Purpose
+from trilogy.core.models.build import (
+    BuildAggregateWrapper,
+    BuildConcept,
+    BuildDatasource,
+    BuildGrain,
+    BuildWhereClause,
+)
+
+ADDITIVE_ROLLUP_FUNCTIONS = {FunctionType.COUNT, FunctionType.SUM}
+
+
+def _concept_lookup(
+    address: str, concepts_by_address: Mapping[str, BuildConcept]
+) -> BuildConcept | None:
+    return concepts_by_address.get(address)
+
+
+def _aggregate_inputs(concept: BuildConcept) -> list[BuildConcept]:
+    if not isinstance(concept.lineage, BuildAggregateWrapper):
+        return []
+    return list(concept.lineage.function.concept_arguments)
+
+
+def _is_additive_aggregate(concept: BuildConcept) -> bool:
+    return (
+        isinstance(concept.lineage, BuildAggregateWrapper)
+        and concept.lineage.function.operator in ADDITIVE_ROLLUP_FUNCTIONS
+    )
+
+
+def _aggregate_signature(
+    concept: BuildConcept,
+) -> tuple[FunctionType, tuple[str, ...]] | None:
+    if not isinstance(concept.lineage, BuildAggregateWrapper):
+        return None
+    return (
+        concept.lineage.function.operator,
+        tuple(
+            sorted(
+                arg.canonical_address
+                for arg in concept.lineage.function.concept_arguments
+            )
+        ),
+    )
+
+
+def _datasource_has_matching_additive_aggregate(
+    datasource: BuildDatasource, concept: BuildConcept
+) -> bool:
+    signature = _aggregate_signature(concept)
+    if signature is None:
+        return False
+    for output in datasource.output_concepts:
+        if not _is_additive_aggregate(output):
+            continue
+        if _aggregate_signature(output) == signature:
+            return True
+    return False
+
+
+def _base_keys(inputs: Iterable[BuildConcept]) -> set[str]:
+    keys: set[str] = set()
+    for concept in inputs:
+        if concept.purpose == Purpose.KEY:
+            keys.add(concept.address)
+        if concept.keys:
+            keys.update(concept.keys)
+        keys.update(concept.grain.components)
+    return keys
+
+
+def _datasource_proves_functional_dependency(
+    dropped: BuildConcept,
+    base_keys: set[str],
+    datasources: Iterable[BuildDatasource],
+) -> bool:
+    if not base_keys:
+        return False
+    for datasource in datasources:
+        output_addresses = {c.address for c in datasource.output_concepts}
+        if dropped.address not in output_addresses:
+            continue
+        if not base_keys.issubset(output_addresses):
+            continue
+        if datasource.grain.components.issubset(base_keys):
+            return True
+    return False
+
+
+def _safe_dropped_grain(
+    dropped: BuildConcept,
+    base_keys: set[str],
+    datasources: Iterable[BuildDatasource],
+) -> bool:
+    if dropped.granularity == Granularity.SINGLE_ROW:
+        return True
+    if dropped.address in base_keys:
+        return True
+    if dropped.keys and dropped.keys.issubset(base_keys):
+        return True
+    return _datasource_proves_functional_dependency(dropped, base_keys, datasources)
+
+
+def _conditions_supported(
+    datasource: BuildDatasource, conditions: BuildWhereClause | None
+) -> bool:
+    if not conditions:
+        return True
+    condition_addresses = {
+        c.canonical_address
+        for c in conditions.row_arguments
+        if c.granularity != Granularity.SINGLE_ROW
+    }
+    datasource_addresses = {c.canonical_address for c in datasource.output_concepts}
+    return condition_addresses.issubset(datasource_addresses)
+
+
+def get_additive_rollup_concepts(
+    datasource: BuildDatasource,
+    requested_concepts: list[BuildConcept],
+    concepts_by_address: Mapping[str, BuildConcept],
+    datasources: Iterable[BuildDatasource],
+    conditions: BuildWhereClause | None = None,
+) -> list[BuildConcept]:
+    if not _conditions_supported(datasource, conditions):
+        return []
+
+    target_grain = BuildGrain.from_concepts(requested_concepts)
+    if not target_grain.components:
+        return []
+    target_canonicals = [
+        concepts_by_address[component].canonical_address
+        for component in target_grain.components
+        if component in concepts_by_address
+    ]
+    if len(target_canonicals) != len(set(target_canonicals)):
+        return []
+    datasource_grain = datasource.grain
+    if datasource_grain.issubset(target_grain):
+        return []
+
+    dropped = datasource_grain - target_grain
+    dropped_concepts = [
+        _concept_lookup(address, concepts_by_address) for address in dropped.components
+    ]
+    if any(concept is None for concept in dropped_concepts):
+        return []
+
+    rollups: list[BuildConcept] = []
+    datasource_list = list(datasources)
+    for concept in requested_concepts:
+        if not concept.is_aggregate:
+            continue
+        if not _is_additive_aggregate(concept):
+            continue
+        if not _datasource_has_matching_additive_aggregate(datasource, concept):
+            continue
+        base_keys = _base_keys(_aggregate_inputs(concept))
+        if all(
+            _safe_dropped_grain(dropped_concept, base_keys, datasource_list)
+            for dropped_concept in dropped_concepts
+            if dropped_concept is not None
+        ):
+            rollups.append(concept)
+    return rollups

--- a/trilogy/core/processing/node_generators/group_node.py
+++ b/trilogy/core/processing/node_generators/group_node.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from trilogy.constants import logger
+from trilogy.core.enums import FunctionType
 from trilogy.core.internal import ALL_ROWS_CONCEPT
 from trilogy.core.models.build import (
     BuildAggregateWrapper,
@@ -56,6 +57,18 @@ def gen_group_node(
     parent_concepts: List[BuildConcept] = unique(
         resolve_function_parent_concepts(concept, environment=environment), "address"
     )
+    if isinstance(
+        concept.lineage, BuildAggregateWrapper
+    ) and concept.lineage.function.operator not in (
+        FunctionType.COUNT,
+        FunctionType.SUM,
+    ):
+        keyed_parents = [
+            environment.concepts[key]
+            for parent in parent_concepts
+            for key in (parent.keys or set())
+        ]
+        parent_concepts = unique(parent_concepts + keyed_parents, "address")
     logger.info(
         f"{padding(depth)}{LOGGER_PREFIX} parent concepts for {concept} {concept.lineage} are {[x.address for x in parent_concepts]} from group grain {concept.grain}"
     )
@@ -144,11 +157,48 @@ def gen_group_node(
                 logger.info(
                     f"{padding(depth)}{LOGGER_PREFIX} cannot include optional agg {possible_agg.address}; it has mismatched parent grain {comp_grain } vs local parent {get_aggregate_grain(concept, environment)}"
                 )
+    materialized_outputs = unique(
+        output_concepts
+        + [
+            c
+            for c in local_optional
+            if not isinstance(c.lineage, (BuildAggregateWrapper, BuildFunction))
+        ],
+        "address",
+    )
+    if len(materialized_outputs) > len(output_concepts):
+        materialized = history.gen_select_node(
+            materialized_outputs,
+            environment,
+            g,
+            depth + 1,
+            fail_if_not_found=False,
+            conditions=conditions,
+        )
+        if materialized:
+            logger.info(
+                f"{padding(depth)}{LOGGER_PREFIX} found materialized aggregate source for {concept.address}"
+            )
+            return materialized
     if parent_concepts:
         target_grain = BuildGrain.from_concepts(parent_concepts)
         logger.info(
             f"{padding(depth)}{LOGGER_PREFIX} fetching group node parents {LooseBuildConceptList(concepts=parent_concepts)} with expected grain {target_grain}"
         )
+        if grain_components:
+            materialized = history.gen_select_node(
+                unique(output_concepts, "address"),
+                environment,
+                g,
+                depth + 1,
+                fail_if_not_found=False,
+                conditions=conditions,
+            )
+            if materialized:
+                logger.info(
+                    f"{padding(depth)}{LOGGER_PREFIX} found materialized aggregate source for {concept.address}"
+                )
+                return materialized
         parent_concepts = unique(
             [x for x in parent_concepts if not x.name == ALL_ROWS_CONCEPT], "address"
         )

--- a/trilogy/core/processing/node_generators/group_node.py
+++ b/trilogy/core/processing/node_generators/group_node.py
@@ -63,16 +63,6 @@ def gen_group_node(
     parent_concepts: List[BuildConcept] = unique(
         resolve_function_parent_concepts(concept, environment=environment), "address"
     )
-    if (
-        isinstance(concept.lineage, BuildAggregateWrapper)
-        and concept.lineage.function.operator == FunctionType.COUNT_DISTINCT
-    ):
-        keyed_parents = [
-            environment.concepts[key]
-            for parent in parent_concepts
-            for key in (parent.keys or set())
-        ]
-        parent_concepts = unique(parent_concepts + keyed_parents, "address")
     logger.info(
         f"{padding(depth)}{LOGGER_PREFIX} parent concepts for {concept} {concept.lineage} are {[x.address for x in parent_concepts]} from group grain {concept.grain}"
     )

--- a/trilogy/core/processing/node_generators/group_node.py
+++ b/trilogy/core/processing/node_generators/group_node.py
@@ -23,6 +23,12 @@ from trilogy.utility import unique
 LOGGER_PREFIX = "[GEN_GROUP_NODE]"
 
 
+def _can_use_grouped_materialized_source(concept: BuildConcept) -> bool:
+    if not isinstance(concept.lineage, BuildAggregateWrapper):
+        return True
+    return concept.lineage.function.operator in (FunctionType.COUNT, FunctionType.SUM)
+
+
 def get_aggregate_grain(
     concept: BuildConcept, environment: BuildEnvironment
 ) -> BuildGrain:
@@ -57,11 +63,9 @@ def gen_group_node(
     parent_concepts: List[BuildConcept] = unique(
         resolve_function_parent_concepts(concept, environment=environment), "address"
     )
-    if isinstance(
-        concept.lineage, BuildAggregateWrapper
-    ) and concept.lineage.function.operator not in (
-        FunctionType.COUNT,
-        FunctionType.SUM,
+    if (
+        isinstance(concept.lineage, BuildAggregateWrapper)
+        and concept.lineage.function.operator == FunctionType.COUNT_DISTINCT
     ):
         keyed_parents = [
             environment.concepts[key]
@@ -166,7 +170,10 @@ def gen_group_node(
         ],
         "address",
     )
-    if len(materialized_outputs) > len(output_concepts):
+    can_use_grouped_materialized = _can_use_grouped_materialized_source(concept)
+    if can_use_grouped_materialized and len(materialized_outputs) > len(
+        output_concepts
+    ):
         materialized = history.gen_select_node(
             materialized_outputs,
             environment,
@@ -185,7 +192,7 @@ def gen_group_node(
         logger.info(
             f"{padding(depth)}{LOGGER_PREFIX} fetching group node parents {LooseBuildConceptList(concepts=parent_concepts)} with expected grain {target_grain}"
         )
-        if grain_components:
+        if can_use_grouped_materialized and grain_components:
             materialized = history.gen_select_node(
                 unique(output_concepts, "address"),
                 environment,

--- a/trilogy/core/processing/node_generators/select_merge_node.py
+++ b/trilogy/core/processing/node_generators/select_merge_node.py
@@ -31,6 +31,7 @@ from trilogy.core.models.build import (
     CanonicalBuildConceptList,
 )
 from trilogy.core.models.build_environment import BuildEnvironment
+from trilogy.core.processing.aggregate_rollup import get_additive_rollup_concepts
 from trilogy.core.processing.condition_utility import (
     condition_implies,
     decompose_condition,
@@ -386,6 +387,22 @@ def create_pruned_concept_graph(
     orig_g = g
     g = g.copy()
     union_options = get_union_sources(datasources, all_concepts)
+    concepts_by_address = {c.address: c for c in orig_g.concepts.values()}
+    for node_address, datasource in list(g.datasources.items()):
+        if not isinstance(datasource, BuildDatasource):
+            continue
+        for concept in get_additive_rollup_concepts(
+            datasource=datasource,
+            requested_concepts=all_concepts,
+            concepts_by_address=concepts_by_address,
+            datasources=datasources,
+            conditions=conditions,
+        ):
+            cnode = concept_to_node(concept)
+            g.concepts[cnode] = concept
+            g.add_node(cnode)
+            g.add_edge(node_address, cnode)
+            g.add_edge(cnode, node_address)
 
     for ds_list in union_options:
         node_address = "ds~" + "-".join([x.name for x in ds_list])
@@ -657,6 +674,21 @@ def create_datasource_node(
         force_group = any(
             x.granularity != Granularity.SINGLE_ROW for x in datasource.output_concepts
         )
+    rollup_concepts = (
+        get_additive_rollup_concepts(
+            datasource=datasource,
+            requested_concepts=all_concepts,
+            concepts_by_address=environment.concepts,
+            datasources=[
+                ds
+                for ds in environment.datasources.values()
+                if isinstance(ds, BuildDatasource)
+            ],
+            conditions=conditions,
+        )
+        if force_group
+        else []
+    )
     partial_concepts = [
         c.concept
         for c in datasource.columns
@@ -735,6 +767,7 @@ def create_datasource_node(
         partial_concepts=(
             [] if partial_is_full else [c for c in all_concepts if c in partial_lcl]
         ),
+        rollup_concepts=rollup_concepts,
         nullable_concepts=[c for c in all_concepts if c in nullable_lcl],
         accept_partial=accept_partial,
         datasource=datasource,

--- a/trilogy/core/processing/node_generators/select_merge_node.py
+++ b/trilogy/core/processing/node_generators/select_merge_node.py
@@ -689,17 +689,26 @@ def create_datasource_node(
         if force_group
         else []
     )
+    rollup_addresses = {c.address for c in rollup_concepts}
+    output_concepts = [
+        c
+        for c in all_concepts
+        if not c.is_aggregate
+        or c.address in rollup_addresses
+        or datasource_grain.issubset(c.grain)
+    ]
+    output_addresses = {c.address for c in output_concepts}
     partial_concepts = [
         c.concept
         for c in datasource.columns
-        if not c.is_complete and c.concept.address in all_concepts
+        if not c.is_complete and c.concept.address in output_addresses
     ]
 
     partial_lcl = CanonicalBuildConceptList(concepts=partial_concepts)
     nullable_concepts = [
         c.concept
         for c in datasource.columns
-        if c.is_nullable and c.concept.address in all_concepts
+        if c.is_nullable and c.concept.address in output_addresses
     ]
 
     nullable_lcl = CanonicalBuildConceptList(concepts=nullable_concepts)
@@ -746,6 +755,9 @@ def create_datasource_node(
     for x in all_concepts:
         if x not in all_inputs and x in canonical_all:
             all_inputs.append(x)
+    all_inputs = [
+        c for c in all_inputs if not c.is_aggregate or c.address in output_addresses
+    ]
 
     # additional single row check
     satisfies_conditions = not datasource_has_filter_sensitive_aggregate(
@@ -760,15 +772,15 @@ def create_datasource_node(
     )
     rval = SelectNode(
         input_concepts=all_inputs,
-        output_concepts=sorted(all_concepts, key=lambda x: x.address),
+        output_concepts=sorted(output_concepts, key=lambda x: x.address),
         environment=environment,
         parents=[],
         depth=depth,
         partial_concepts=(
-            [] if partial_is_full else [c for c in all_concepts if c in partial_lcl]
+            [] if partial_is_full else [c for c in output_concepts if c in partial_lcl]
         ),
         rollup_concepts=rollup_concepts,
-        nullable_concepts=[c for c in all_concepts if c in nullable_lcl],
+        nullable_concepts=[c for c in output_concepts if c in nullable_lcl],
         accept_partial=accept_partial,
         datasource=datasource,
         grain=datasource.grain,

--- a/trilogy/core/processing/node_generators/select_node.py
+++ b/trilogy/core/processing/node_generators/select_node.py
@@ -3,10 +3,12 @@ from trilogy.core.enums import Derivation
 from trilogy.core.exceptions import NoDatasourceException
 from trilogy.core.models.build import (
     BuildConcept,
+    BuildDatasource,
     BuildWhereClause,
     CanonicalBuildConceptList,
 )
 from trilogy.core.models.build_environment import BuildEnvironment
+from trilogy.core.processing.aggregate_rollup import get_additive_rollup_concepts
 from trilogy.core.processing.node_generators.select_merge_node import (
     gen_select_merge_node,
 )
@@ -64,6 +66,22 @@ def gen_select_node(
     fail_if_not_found: bool = True,
     conditions: BuildWhereClause | None = None,
 ) -> StrategyNode | None:
+    rollup_materialized = {
+        concept.canonical_address
+        for datasource in environment.datasources.values()
+        if isinstance(datasource, BuildDatasource)
+        for concept in get_additive_rollup_concepts(
+            datasource=datasource,
+            requested_concepts=concepts,
+            concepts_by_address=environment.concepts,
+            datasources=[
+                ds
+                for ds in environment.datasources.values()
+                if isinstance(ds, BuildDatasource)
+            ],
+            conditions=conditions,
+        )
+    }
     all_lcl = CanonicalBuildConceptList(concepts=concepts)
     # search all concepts here, including partial
     materialized_lcl = CanonicalBuildConceptList(
@@ -71,6 +89,7 @@ def gen_select_node(
             x
             for x in concepts
             if x.canonical_address in environment.materialized_canonical_concepts
+            or x.canonical_address in rollup_materialized
             or x.derivation == Derivation.CONSTANT
         ]
     )

--- a/trilogy/core/processing/nodes/base_node.py
+++ b/trilogy/core/processing/nodes/base_node.py
@@ -139,6 +139,7 @@ class StrategyNode:
         whole_grain: bool = False,
         parents: List["StrategyNode"] | None = None,
         partial_concepts: List[BuildConcept] | None = None,
+        rollup_concepts: List[BuildConcept] | None = None,
         nullable_concepts: List[BuildConcept] | None = None,
         depth: int = 0,
         conditions: (
@@ -193,6 +194,7 @@ class StrategyNode:
         self.partial_concepts: list[BuildConcept] = self.derive_partials(
             partial_concepts
         )
+        self.rollup_concepts = rollup_concepts or []
         self.validate_inputs()
         self.log = True
 
@@ -408,6 +410,7 @@ class StrategyNode:
             grain=grain,
             condition=self.conditions,
             partial_concepts=self.partial_concepts,
+            rollup_concepts=self.rollup_concepts,
             nullable_concepts=self.nullable_concepts,
             force_group=self.force_group,
             hidden_concepts=self.hidden_concepts,
@@ -438,6 +441,7 @@ class StrategyNode:
             whole_grain=self.whole_grain,
             parents=list(self.parents),
             partial_concepts=list(self.partial_concepts),
+            rollup_concepts=list(self.rollup_concepts),
             nullable_concepts=list(self.nullable_concepts),
             depth=self.depth,
             conditions=self.conditions,

--- a/trilogy/core/processing/nodes/group_node.py
+++ b/trilogy/core/processing/nodes/group_node.py
@@ -38,6 +38,7 @@ class GroupNode(StrategyNode):
         parents: List["StrategyNode"] | None = None,
         depth: int = 0,
         partial_concepts: Optional[List[BuildConcept]] = None,
+        rollup_concepts: Optional[List[BuildConcept]] = None,
         nullable_concepts: Optional[List[BuildConcept]] = None,
         force_group: bool | None = None,
         conditions: (
@@ -59,6 +60,7 @@ class GroupNode(StrategyNode):
             parents=parents,
             depth=depth,
             partial_concepts=partial_concepts,
+            rollup_concepts=rollup_concepts,
             nullable_concepts=nullable_concepts,
             force_group=force_group,
             conditions=conditions,
@@ -119,6 +121,12 @@ class GroupNode(StrategyNode):
             ),
             inherited_inputs=self.input_concepts + self.existence_concepts,
         )
+        rollup_addresses = {c.address for c in self.rollup_concepts}
+        input_addresses = {c.address for c in self.input_concepts}
+        for concept in self.output_concepts:
+            if concept.is_aggregate and concept.address not in rollup_addresses:
+                if concept.address not in input_addresses:
+                    source_map[concept.address] = set()
         nullable_addresses = find_nullable_concepts(
             source_map=source_map, joins=[], datasources=parent_sources
         )
@@ -139,6 +147,17 @@ class GroupNode(StrategyNode):
             ],
             "address",
         )
+        inherited_rollups = unique(
+            self.rollup_concepts
+            + [
+                c
+                for ps in parent_sources
+                if isinstance(ps, QueryDatasource)
+                for c in ps.rollup_concepts
+                if c.address in output_addresses
+            ],
+            "address",
+        )
         base = QueryDatasource(
             input_concepts=self.input_concepts,
             output_concepts=self.output_concepts,
@@ -148,6 +167,7 @@ class GroupNode(StrategyNode):
             joins=[],
             grain=target_grain,
             partial_concepts=inherited_partials,
+            rollup_concepts=inherited_rollups,
             nullable_concepts=nullable_concepts,
             hidden_concepts=self.hidden_concepts,
             condition=self.conditions,
@@ -180,6 +200,7 @@ class GroupNode(StrategyNode):
                 grain=target_grain,
                 nullable_concepts=base.nullable_concepts,
                 partial_concepts=self.partial_concepts,
+                rollup_concepts=self.rollup_concepts,
                 condition=self.conditions,
                 hidden_concepts=self.hidden_concepts,
                 ordering=self.ordering,
@@ -196,6 +217,7 @@ class GroupNode(StrategyNode):
             parents=self.parents,
             depth=self.depth,
             partial_concepts=list(self.partial_concepts),
+            rollup_concepts=list(self.rollup_concepts),
             nullable_concepts=list(self.nullable_concepts),
             force_group=self.force_group,
             conditions=self.conditions,

--- a/trilogy/core/processing/nodes/group_node.py
+++ b/trilogy/core/processing/nodes/group_node.py
@@ -125,7 +125,10 @@ class GroupNode(StrategyNode):
         input_addresses = {c.address for c in self.input_concepts}
         for concept in self.output_concepts:
             if concept.is_aggregate and concept.address not in rollup_addresses:
-                if concept.address not in input_addresses:
+                if (
+                    source_type == SourceType.GROUP
+                    or concept.address not in input_addresses
+                ):
                     source_map[concept.address] = set()
         nullable_addresses = find_nullable_concepts(
             source_map=source_map, joins=[], datasources=parent_sources

--- a/trilogy/core/processing/nodes/merge_node.py
+++ b/trilogy/core/processing/nodes/merge_node.py
@@ -111,6 +111,7 @@ class MergeNode(StrategyNode):
         join_concepts: Optional[List] = None,
         force_join_type: Optional[JoinType] = None,
         partial_concepts: Optional[List[BuildConcept]] = None,
+        rollup_concepts: Optional[List[BuildConcept]] = None,
         nullable_concepts: Optional[List[BuildConcept]] = None,
         force_group: bool | None = None,
         depth: int = 0,
@@ -134,6 +135,7 @@ class MergeNode(StrategyNode):
             parents=parents,
             depth=depth,
             partial_concepts=partial_concepts,
+            rollup_concepts=rollup_concepts,
             nullable_concepts=nullable_concepts,
             force_group=force_group,
             grain=grain,
@@ -373,6 +375,17 @@ class MergeNode(StrategyNode):
         nullable_concepts = find_nullable_concepts(
             source_map=source_map, joins=joins, datasources=final_datasets
         )
+        rollup_concepts = unique(
+            self.rollup_concepts
+            + [
+                c
+                for source in final_datasets
+                if isinstance(source, QueryDatasource)
+                for c in source.rollup_concepts
+                if c.address in {out.address for out in self.output_concepts}
+            ],
+            "address",
+        )
         if force_group:
 
             grain = BuildGrain.from_concepts(
@@ -393,6 +406,7 @@ class MergeNode(StrategyNode):
                 x for x in self.output_concepts if x.address in nullable_concepts
             ],
             partial_concepts=self.partial_concepts,
+            rollup_concepts=rollup_concepts,
             force_group=force_group,
             condition=self.conditions,
             hidden_concepts=self.hidden_concepts,
@@ -409,6 +423,7 @@ class MergeNode(StrategyNode):
             parents=self.parents,
             depth=self.depth,
             partial_concepts=list(self.partial_concepts),
+            rollup_concepts=list(self.rollup_concepts),
             force_group=self.force_group,
             grain=self.grain,
             conditions=self.conditions,

--- a/trilogy/core/processing/nodes/select_node_v2.py
+++ b/trilogy/core/processing/nodes/select_node_v2.py
@@ -38,6 +38,7 @@ class SelectNode(StrategyNode):
         parents: List["StrategyNode"] | None = None,
         depth: int = 0,
         partial_concepts: List[BuildConcept] | None = None,
+        rollup_concepts: List[BuildConcept] | None = None,
         nullable_concepts: List[BuildConcept] | None = None,
         accept_partial: bool = False,
         grain: Optional[BuildGrain] = None,
@@ -64,6 +65,7 @@ class SelectNode(StrategyNode):
             parents=parents,
             depth=depth,
             partial_concepts=partial_concepts,
+            rollup_concepts=rollup_concepts,
             nullable_concepts=nullable_concepts,
             force_group=force_group,
             grain=grain,
@@ -130,6 +132,7 @@ class SelectNode(StrategyNode):
             partial_concepts=[
                 c.concept for c in datasource.columns if not c.is_complete
             ],
+            rollup_concepts=self.rollup_concepts,
             nullable_concepts=[c.concept for c in datasource.columns if c.is_nullable],
             source_type=SourceType.DIRECT_SELECT,
             # we can skip rendering conditions
@@ -154,6 +157,7 @@ class SelectNode(StrategyNode):
             condition=self.conditions,
             joins=[],
             partial_concepts=[],
+            rollup_concepts=[],
             source_type=SourceType.CONSTANT,
             hidden_concepts=self.hidden_concepts,
             ordering=self.ordering,
@@ -218,6 +222,7 @@ class SelectNode(StrategyNode):
             parents=self.parents,
             whole_grain=self.whole_grain,
             partial_concepts=list(self.partial_concepts),
+            rollup_concepts=list(self.rollup_concepts),
             nullable_concepts=list(self.nullable_concepts),
             accept_partial=self.accept_partial,
             grain=self.grain,

--- a/trilogy/core/query_processor.py
+++ b/trilogy/core/query_processor.py
@@ -243,6 +243,7 @@ def datasource_to_query_datasource(datasource: BuildDatasource) -> QueryDatasour
         datasources=[datasource],
         joins=[],
         partial_concepts=[x.concept for x in datasource.columns if not x.is_complete],
+        rollup_concepts=[],
         base_datasource=datasource,
     )
 
@@ -332,6 +333,7 @@ def datasource_to_cte(
             ],
             grain=direct_parents[0].grain,
             order_by=query_datasource.ordering,
+            rollup_concepts=query_datasource.rollup_concepts,
         )
         return final
 
@@ -402,6 +404,7 @@ def datasource_to_cte(
         parent_ctes=parents,
         condition=query_datasource.condition,
         partial_concepts=query_datasource.partial_concepts,
+        rollup_concepts=query_datasource.rollup_concepts,
         nullable_concepts=query_datasource.nullable_concepts,
         join_derived_concepts=query_datasource.join_derived_concepts,
         hidden_concepts=query_datasource.hidden_concepts,

--- a/trilogy/dialect/base.py
+++ b/trilogy/dialect/base.py
@@ -707,6 +707,22 @@ class BaseDialect:
         logger.debug(
             f"{LOGGER_PREFIX} [{c.address}] Starting rendering loop on cte: {cte.name}"
         )
+        if cte.group_to_grain and c.address in {
+            concept.address for concept in cte.rollup_concepts
+        }:
+            rolled = safe_get_cte_value(
+                self.FUNCTION_MAP[FunctionType.COALESCE],
+                cte,
+                c,
+                self.QUOTE_CHARACTER,
+                self.render_expr,
+                self.used_map,
+            )
+            if not rolled:
+                rolled = INVALID_REFERENCE_STRING(
+                    f"Missing rollup source reference to {c.address}"
+                )
+            return self.FUNCTION_MAP[FunctionType.SUM]([rolled], [])
 
         # check if it's not inherited AND no pseudonyms are inherited
         if c.lineage and cte.source_map.get(c.address, []) == []:

--- a/trilogy/parsing/v2/pest_backend.py
+++ b/trilogy/parsing/v2/pest_backend.py
@@ -237,12 +237,7 @@ def parse_pest(text: str) -> SyntaxDocument:
     try:
         tree = parse_trilogy_syntax_tuple(text)
     except ValueError as e:
-        raw_error = str(e)
-        if "expected FILE_PATH or F_FILE_PATH" in raw_error:
-            from trilogy.parsing.v2.lark_backend import parse_lark
-
-            return parse_lark(text)
-        raise _diagnose_pest_error(text, raw_error) from e
+        raise _diagnose_pest_error(text, str(e)) from e
     line_starts = _compute_line_starts(text)
     syntax = _tuple_to_syntax(tree, text, line_starts)
     if not isinstance(syntax, SyntaxNode):

--- a/trilogy/parsing/v2/pest_backend.py
+++ b/trilogy/parsing/v2/pest_backend.py
@@ -237,7 +237,12 @@ def parse_pest(text: str) -> SyntaxDocument:
     try:
         tree = parse_trilogy_syntax_tuple(text)
     except ValueError as e:
-        raise _diagnose_pest_error(text, str(e)) from e
+        raw_error = str(e)
+        if "expected FILE_PATH or F_FILE_PATH" in raw_error:
+            from trilogy.parsing.v2.lark_backend import parse_lark
+
+            return parse_lark(text)
+        raise _diagnose_pest_error(text, raw_error) from e
     line_starts = _compute_line_starts(text)
     syntax = _tuple_to_syntax(tree, text, line_starts)
     if not isinstance(syntax, SyntaxNode):


### PR DESCRIPTION
## Description

There are situations where we can safely aggregate up counts/sums from partial intermediate aggregates. Add in an explicit mechanism to handle this case, where a partial count/sum can be re-aggregated via sum to derive a new aggregate.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
