### PR TITLE
[Feat] Extend Grouping Rollup Dialects

### DIFF
--- a/tests/engine/test_bigquery.py
+++ b/tests/engine/test_bigquery.py
@@ -1,13 +1,25 @@
 import sys
+from contextlib import contextmanager
 
 import pytest
 
 from trilogy import Dialects
-from trilogy.constants import Rendering
+from trilogy.constants import CONFIG, ParserBackend, Rendering
 from trilogy.core.models.core import ArrayType, DataType, ListWrapper
 from trilogy.core.models.environment import Environment
 from trilogy.dialect.bigquery import BigqueryDialect
 from trilogy.hooks.query_debugger import DebuggingHook
+
+
+@contextmanager
+def _using_backend(backend: ParserBackend):
+    prev = CONFIG.parser_backend
+    CONFIG.parser_backend = backend
+    try:
+        yield
+    finally:
+        CONFIG.parser_backend = prev
+
 
 UNSUPPORTED_TUPLE = (3, 14)
 
@@ -584,3 +596,96 @@ def test_aggregate_checksum():
     dialect = BigqueryDialect()
     result = dialect.aggregate_checksum("FARM_FINGERPRINT(CAST(`id` AS STRING))")
     assert result == "BIT_XOR(FARM_FINGERPRINT(CAST(`id` AS STRING)))"
+
+
+_GROUPING_SCHEMA = """
+key gm_a int;
+key gm_b int?;
+property <gm_a, gm_b>.gm_x int;
+datasource gm_data (
+    gm_a: gm_a,
+    gm_b: gm_b,
+    gm_x: gm_x
+)
+grain (gm_a, gm_b)
+query '''
+select 1 as gm_a, 1 as gm_b, 10 as gm_x
+union all
+select 1 as gm_a, 2 as gm_b, 20 as gm_x
+union all
+select 2 as gm_a, 1 as gm_b, 30 as gm_x
+union all
+select 2 as gm_a, 2 as gm_b, 40 as gm_x
+''';
+"""
+
+
+def _normalize_grouping_rows(rows):
+    def key(row):
+        return (row[0] is None, row[0], row[1] is None, row[1])
+
+    return sorted(((row[0], row[1], int(row[2])) for row in rows), key=key)
+
+
+def test_aggregate_grouping_modes_bigquery():
+    environment = Environment()
+    executor = Dialects.BIGQUERY.default_executor(
+        environment=environment, rendering=Rendering(parameters=False)
+    )
+    # Pest backend doesn't yet ship with the rollup/cube grammar in the
+    # installed wheel; force lark until it's regenerated.
+    with _using_backend(ParserBackend.LARK):
+        executor.parse_text(_GROUPING_SCHEMA)
+
+        rollup_sql = executor.generate_sql(
+            "select gm_a, gm_b, sum(gm_x) by rollup gm_a, gm_b as sx;"
+        )[-1]
+        cube_sql = executor.generate_sql(
+            "select gm_a, gm_b, sum(gm_x) by cube gm_a, gm_b as sx;"
+        )[-1]
+        grouping_sets_sql = executor.generate_sql(
+            "select gm_a, gm_b, sum(gm_x) by grouping sets (gm_a, gm_b), (gm_a), () as sx;"
+        )[-1]
+
+    assert "ROLLUP" in rollup_sql.upper(), rollup_sql
+    assert "CUBE" in cube_sql.upper(), cube_sql
+    assert "GROUPING SETS" in grouping_sets_sql.upper(), grouping_sets_sql
+
+    rollup_rows = _normalize_grouping_rows(
+        executor.execute_raw_sql(rollup_sql).fetchall()
+    )
+    assert rollup_rows == [
+        (1, 1, 10),
+        (1, 2, 20),
+        (1, None, 30),
+        (2, 1, 30),
+        (2, 2, 40),
+        (2, None, 70),
+        (None, None, 100),
+    ]
+
+    cube_rows = _normalize_grouping_rows(executor.execute_raw_sql(cube_sql).fetchall())
+    assert cube_rows == [
+        (1, 1, 10),
+        (1, 2, 20),
+        (1, None, 30),
+        (2, 1, 30),
+        (2, 2, 40),
+        (2, None, 70),
+        (None, 1, 40),
+        (None, 2, 60),
+        (None, None, 100),
+    ]
+
+    grouping_sets_rows = _normalize_grouping_rows(
+        executor.execute_raw_sql(grouping_sets_sql).fetchall()
+    )
+    assert grouping_sets_rows == [
+        (1, 1, 10),
+        (1, 2, 20),
+        (1, None, 30),
+        (2, 1, 30),
+        (2, 2, 40),
+        (2, None, 70),
+        (None, None, 100),
+    ]

--- a/tests/engine/test_dialects.py
+++ b/tests/engine/test_dialects.py
@@ -1,9 +1,99 @@
+from typing import Any, Generator, List, Optional
+
+import pytest
 from pytest import raises
 
-from trilogy import Dialects
+from trilogy import Dialects, Executor
+from trilogy.constants import Rendering
+from trilogy.core.models.environment import Environment
+from trilogy.engine import EngineConnection, ExecutionEngine, ResultProtocol
 
 
 def test_error_not_provided():
     for val in [Dialects.PRESTO, Dialects.TRINO, Dialects.SNOWFLAKE]:
         with raises(ValueError, match="Config must be provided"):
             val.default_engine()
+
+
+class _MockResult(ResultProtocol):
+    def fetchall(self) -> List[Any]:
+        return []
+
+    def keys(self) -> List[str]:
+        return []
+
+    def fetchone(self) -> Optional[Any]:
+        return None
+
+    def fetchmany(self, size: int) -> List[Any]:
+        return []
+
+    def __iter__(self) -> Generator[Any, None, None]:
+        return iter([])
+
+
+class _MockConnection(EngineConnection):
+    def execute(self, statement, parameters=None) -> ResultProtocol:
+        return _MockResult()
+
+
+class _MockEngine(ExecutionEngine):
+    def connect(self) -> EngineConnection:
+        return _MockConnection()
+
+
+GROUPING_DIALECTS = [
+    Dialects.POSTGRES,
+    Dialects.BIGQUERY,
+    Dialects.SNOWFLAKE,
+    Dialects.PRESTO,
+    Dialects.TRINO,
+    Dialects.CLICKHOUSE,
+    Dialects.SQL_SERVER,
+]
+
+_SCHEMA = """
+key a int;
+key b int;
+property <a, b>.x int;
+datasource test_data (
+    a: a,
+    b: b,
+    x: x
+)
+grain (a, b)
+address test_data;
+"""
+
+
+def _make_executor(dialect: Dialects) -> Executor:
+    return Executor(
+        dialect=dialect,
+        engine=_MockEngine(),
+        environment=Environment(),
+        rendering=Rendering(parameters=False),
+    )
+
+
+@pytest.mark.parametrize("dialect", GROUPING_DIALECTS)
+def test_aggregate_grouping_modes_render(dialect):
+    executor = _make_executor(dialect)
+    executor.parse_text(_SCHEMA)
+
+    rollup_sql = executor.generate_sql("select a, b, sum(x) by rollup a, b as sx;")[-1]
+    cube_sql = executor.generate_sql("select a, b, sum(x) by cube a, b as sx;")[-1]
+    grouping_sets_sql = executor.generate_sql(
+        "select a, b, sum(x) by grouping sets (a, b), (a), () as sx;"
+    )[-1]
+
+    assert "ROLLUP" in rollup_sql.upper(), rollup_sql
+    assert "CUBE" in cube_sql.upper(), cube_sql
+    assert "GROUPING SETS" in grouping_sets_sql.upper(), grouping_sets_sql
+
+
+def test_aggregate_grouping_modes_rejected_on_sqlite():
+    executor = _make_executor(Dialects.SQLITE)
+    executor.parse_text(_SCHEMA)
+
+    with raises(NotImplementedError, match="aggregate grouping mode"):
+        executor.generate_sql("select a, b, sum(x) by rollup a, b as sx;")

--- a/tests/engine/test_snowflake.py
+++ b/tests/engine/test_snowflake.py
@@ -1,9 +1,21 @@
 import re
+from contextlib import contextmanager
 from decimal import Decimal
 
 from trilogy import Dialects
-from trilogy.constants import Rendering
+from trilogy.constants import CONFIG, ParserBackend, Rendering
 from trilogy.core.models.environment import Environment
+from trilogy.dialect.config import SnowflakeConfig
+
+
+@contextmanager
+def _using_backend(backend: ParserBackend):
+    prev = CONFIG.parser_backend
+    CONFIG.parser_backend = backend
+    try:
+        yield
+    finally:
+        CONFIG.parser_backend = prev
 
 
 def test_render_query(snowflake_engine_parameterized):
@@ -330,3 +342,112 @@ def test_array_agg():
     results = list(test_executor.execute_text(test_select)[0].fetchall())
     assert len(results) == 1
     assert results[0] == ([1, 2, 3, 3, 4, 5],)  # aggregated_values
+
+
+_GROUPING_SCHEMA = """
+key gm_a int;
+key gm_b int?;
+property <gm_a, gm_b>.gm_x int;
+datasource gm_data (
+    gm_a: gm_a,
+    gm_b: gm_b,
+    gm_x: gm_x
+)
+grain (gm_a, gm_b)
+query '''
+select 1 as gm_a, 1 as gm_b, 10 as gm_x
+union all
+select 1 as gm_a, 2 as gm_b, 20 as gm_x
+union all
+select 2 as gm_a, 1 as gm_b, 30 as gm_x
+union all
+select 2 as gm_a, 2 as gm_b, 40 as gm_x
+''';
+"""
+
+
+def _normalize_grouping_rows(rows):
+    def key(row):
+        return (row[0] is None, row[0], row[1] is None, row[1])
+
+    return sorted(
+        ((row[0], row[1], int(row[2]) if row[2] is not None else None) for row in rows),
+        key=key,
+    )
+
+
+def test_aggregate_grouping_modes_snowflake(fakesnow_happening):
+    executor = Dialects.SNOWFLAKE.default_executor(
+        environment=Environment(),
+        conf=SnowflakeConfig(
+            account="account",
+            username="user",
+            password="password",
+            database="test_grouping",
+            schema="public",
+        ),
+        rendering=Rendering(parameters=False),
+    )
+    executor.execute_raw_sql("CREATE DATABASE IF NOT EXISTS test_grouping")
+    executor.execute_raw_sql("USE DATABASE test_grouping")
+    executor.execute_raw_sql("CREATE SCHEMA IF NOT EXISTS public")
+    executor.execute_raw_sql("USE SCHEMA public")
+    # Pest backend doesn't yet ship with the rollup/cube grammar in the
+    # installed wheel; force lark until it's regenerated.
+    with _using_backend(ParserBackend.LARK):
+        executor.parse_text(_GROUPING_SCHEMA)
+
+        rollup_sql = executor.generate_sql(
+            "select gm_a, gm_b, sum(gm_x) by rollup gm_a, gm_b as sx;"
+        )[-1]
+        cube_sql = executor.generate_sql(
+            "select gm_a, gm_b, sum(gm_x) by cube gm_a, gm_b as sx;"
+        )[-1]
+        grouping_sets_sql = executor.generate_sql(
+            "select gm_a, gm_b, sum(gm_x) by grouping sets (gm_a, gm_b), (gm_a), () as sx;"
+        )[-1]
+
+        assert "ROLLUP" in rollup_sql.upper(), rollup_sql
+        assert "CUBE" in cube_sql.upper(), cube_sql
+        assert "GROUPING SETS" in grouping_sets_sql.upper(), grouping_sets_sql
+
+        rollup_rows = _normalize_grouping_rows(
+            executor.execute_raw_sql(rollup_sql).fetchall()
+        )
+        assert rollup_rows == [
+            (1, 1, 10),
+            (1, 2, 20),
+            (1, None, 30),
+            (2, 1, 30),
+            (2, 2, 40),
+            (2, None, 70),
+            (None, None, 100),
+        ]
+
+        cube_rows = _normalize_grouping_rows(
+            executor.execute_raw_sql(cube_sql).fetchall()
+        )
+        assert cube_rows == [
+            (1, 1, 10),
+            (1, 2, 20),
+            (1, None, 30),
+            (2, 1, 30),
+            (2, 2, 40),
+            (2, None, 70),
+            (None, 1, 40),
+            (None, 2, 60),
+            (None, None, 100),
+        ]
+
+        grouping_sets_rows = _normalize_grouping_rows(
+            executor.execute_raw_sql(grouping_sets_sql).fetchall()
+        )
+        assert grouping_sets_rows == [
+            (1, 1, 10),
+            (1, 2, 20),
+            (1, None, 30),
+            (2, 1, 30),
+            (2, 2, 40),
+            (2, None, 70),
+            (None, None, 100),
+        ]

--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -4,7 +4,7 @@ from trilogy.dialect.enums import Dialects
 from trilogy.executor import Executor
 from trilogy.parser import parse
 
-__version__ = "0.3.257"
+__version__ = "0.3.258"
 
 __all__ = [
     "parse",

--- a/trilogy/dialect/bigquery.py
+++ b/trilogy/dialect/bigquery.py
@@ -229,6 +229,7 @@ class BigqueryDialect(BaseDialect):
     CREATE_TABLE_SQL_TEMPLATE = BQ_CREATE_TABLE_SQL_TEMPLATE
     UNNEST_MODE = UnnestMode.CROSS_JOIN_UNNEST
     DATATYPE_MAP = DATATYPE_MAP
+    SUPPORTS_AGGREGATE_GROUPING_MODES = True
 
     def hash_column_value(self, column_name: str) -> str:
         return f"FARM_FINGERPRINT(CAST({safe_quote(column_name, self.QUOTE_CHARACTER)} AS STRING))"

--- a/trilogy/dialect/clickhouse.py
+++ b/trilogy/dialect/clickhouse.py
@@ -215,6 +215,7 @@ class ClickhouseDialect(BaseDialect):
     # CH doesn't accept arrayJoin as a FROM-clause table function; DIRECT mode
     # emits `SELECT arrayJoin(...) AS alias` with no FROM, which CH supports.
     UNNEST_MODE = UnnestMode.DIRECT
+    SUPPORTS_AGGREGATE_GROUPING_MODES = True
     TABLE_NOT_FOUND_PATTERN = "Table .* doesn't exist"
     COLUMN_NOT_FOUND_PATTERN = "Unknown identifier"
 

--- a/trilogy/dialect/postgres.py
+++ b/trilogy/dialect/postgres.py
@@ -82,6 +82,7 @@ class PostgresDialect(BaseDialect):
     }
     QUOTE_CHARACTER = '"'
     SQL_TEMPLATE = PG_SQL_TEMPLATE
+    SUPPORTS_AGGREGATE_GROUPING_MODES = True
 
     def get_table_primary_keys(
         self, executor, table_name: str, schema: str | None = None

--- a/trilogy/dialect/presto.py
+++ b/trilogy/dialect/presto.py
@@ -88,6 +88,7 @@ class PrestoDialect(BaseDialect):
     }
     UNNEST_MODE = UnnestMode.PRESTO
     GROUP_MODE = GroupMode.BY_INDEX
+    SUPPORTS_AGGREGATE_GROUPING_MODES = True
     ALIAS_ORDER_REFERENCING_ALLOWED = (
         False  # some complex presto functions don't support aliasing
     )

--- a/trilogy/dialect/snowflake.py
+++ b/trilogy/dialect/snowflake.py
@@ -91,6 +91,7 @@ class SnowflakeDialect(BaseDialect):
     QUOTE_CHARACTER = '"'
     SQL_TEMPLATE = SNOWFLAKE_SQL_TEMPLATE
     UNNEST_MODE = UnnestMode.SNOWFLAKE
+    SUPPORTS_AGGREGATE_GROUPING_MODES = True
     TABLE_NOT_FOUND_PATTERN = "does not exist"
     COLUMN_NOT_FOUND_PATTERN = "invalid identifier"
 

--- a/trilogy/dialect/sql_server.py
+++ b/trilogy/dialect/sql_server.py
@@ -74,6 +74,7 @@ class SqlServerDialect(BaseDialect):
     }
     QUOTE_CHARACTER = '"'
     SQL_TEMPLATE = TSQL_TEMPLATE
+    SUPPORTS_AGGREGATE_GROUPING_MODES = True
 
     def get_table_schema(
         self, executor, table_name: str, schema: str | None = None


### PR DESCRIPTION
## Description

Pretty mechanical; default syntax works, was just conservative in first diff. 

This PR adds support for aggregate grouping modes (ROLLUP, CUBE, GROUPING SETS) across multiple SQL dialects. The change introduces a new `SUPPORTS_AGGREGATE_GROUPING_MODES` flag to dialect classes.

### Changes Made

1. **Dialect Updates**: Added `SUPPORTS_AGGREGATE_GROUPING_MODES = True` to the following dialects:
   - PostgreSQL
   - BigQuery
   - Snowflake
   - Presto
   - Trino (via Presto)
   - ClickHouse
   - SQL Server

## Type of Change

- [x] New Feature
- [ ] Bug Fix
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
- [x] Functionality is properly isolated to dialect implementations

