### PR TITLE
Fix stdlib sibling imports under non-filesystem resolvers

### DIFF
--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -465,3 +465,14 @@ order by id asc;
     assert row[1] == "fun"
     assert row[2] == "greatest"
     assert row[3] == "times"
+
+
+def test_stdlib_sibling_import_under_dict_resolver():
+    content = {
+        "lineitem": "import std.money;\nkey id int;\nproperty id.amount float::usd;"
+    }
+    env = Environment(
+        config=EnvironmentConfig(import_resolver=DictImportResolver(content=content))
+    )
+    env.parse("import lineitem;")
+    assert "usd" in env.data_types

--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -4,7 +4,7 @@ from trilogy.dialect.enums import Dialects
 from trilogy.executor import Executor
 from trilogy.parser import parse
 
-__version__ = "0.3.277"
+__version__ = "0.3.278"
 
 __all__ = [
     "parse",

--- a/trilogy/parsing/v2/hydration.py
+++ b/trilogy/parsing/v2/hydration.py
@@ -114,6 +114,7 @@ class HydrationContext:
     symbol_table: SymbolTable | None = None
     semantic_state: SemanticState | None = None
     in_flight_imports: set[str] | None = None
+    in_stdlib: bool = False
 
 
 class NativeHydrator:
@@ -142,8 +143,10 @@ class NativeHydrator:
                 if context.in_flight_imports is not None
                 else set()
             ),
+            in_stdlib=context.in_stdlib,
             semantic_state=self.semantic_state,
         )
+        self.in_stdlib = context.in_stdlib
         self.function_factory = FunctionFactory(self.environment)
         self.symbol_table: SymbolTable = (
             context.symbol_table
@@ -158,6 +161,7 @@ class NativeHydrator:
             symbol_table=self.symbol_table,
             semantic_state=self.semantic_state,
             source_text="",
+            in_stdlib=self.in_stdlib,
         )
 
     @property
@@ -211,6 +215,7 @@ class NativeHydrator:
             symbol_table=self.symbol_table,
             semantic_state=self.semantic_state,
             source_text=self.text_lookup.get(self.token_address, ""),
+            in_stdlib=self.in_stdlib,
         )
         try:
             self.plans = self.plan(document.forms)

--- a/trilogy/parsing/v2/import_service.py
+++ b/trilogy/parsing/v2/import_service.py
@@ -123,6 +123,9 @@ class ImportHydrationService:
     # Shared by reference across child ImportHydrationServices via
     # HydrationContext so cycle detection sees the full parse stack.
     in_flight_imports: set[str] = field(default_factory=set)
+    # True while parsing inside a stdlib file; propagated to child parses so
+    # nested sibling imports stay stdlib regardless of the import resolver.
+    in_stdlib: bool = False
     # Parser-local SemanticState. When a cycle is detected, the broken
     # alias is registered here so ConceptLookup can generate narrow
     # UndefinedConceptFull placeholders for datasource columns referencing
@@ -201,6 +204,7 @@ class ImportHydrationService:
                     text_lookup=self.text_lookup,
                     import_keys=key_path,
                     in_flight_imports=self.in_flight_imports,
+                    in_stdlib=request.is_stdlib or self.in_stdlib,
                 )
                 NativeHydrator(child_context).parse(document)
                 self.parsed_environments[env_cache_key] = new_env

--- a/trilogy/parsing/v2/rules/import_rules.py
+++ b/trilogy/parsing/v2/rules/import_rules.py
@@ -54,13 +54,11 @@ def _resolve_import_path(
     if explicit_stdlib:
         target = join(STDLIB_ROOT, *path) + ".preql"
         token_lookup: Path | str = Path(target)
-    elif is_stdlib:
-        troot = Path(environment.working_path)
-        for _ in range(parent_dirs):
-            troot = troot.parent
-        target = join(troot, *path) + ".preql"
-        token_lookup = Path(target)
-    elif isinstance(environment.config.import_resolver, FileSystemImportResolver):
+    elif is_stdlib or isinstance(
+        environment.config.import_resolver, FileSystemImportResolver
+    ):
+        # Resolve against working_path: a stdlib sibling lives in the std dir,
+        # and a filesystem import lives relative to the importing file.
         troot = Path(environment.working_path)
         for _ in range(parent_dirs):
             troot = troot.parent

--- a/trilogy/parsing/v2/rules/import_rules.py
+++ b/trilogy/parsing/v2/rules/import_rules.py
@@ -27,6 +27,7 @@ STDLIB_ROOT = Path(__file__).parent.parent.parent.parent
 def _resolve_import_path(
     raw_args: list[str],
     environment: Environment,
+    in_stdlib: bool = False,
 ) -> tuple[str, str, str, str, Path | str, bool, int]:
     leading_dots = 0
     parsed_args: list[str] = []
@@ -44,10 +45,21 @@ def _resolve_import_path(
         cache_key = parsed_args[0]
     input_path = parsed_args[0]
     path = input_path.split(".")
-    is_stdlib = path[0] == "std"
-    if is_stdlib:
+    # A stdlib file's relative imports are themselves stdlib imports, so a bare
+    # sibling reference (``std/money.preql`` -> ``import currency;``) inherits
+    # stdlib context and resolves against the std dir even under a non-filesystem
+    # resolver. ``in_stdlib`` carries that context down from the parent parse.
+    explicit_stdlib = path[0] == "std"
+    is_stdlib = explicit_stdlib or in_stdlib
+    if explicit_stdlib:
         target = join(STDLIB_ROOT, *path) + ".preql"
         token_lookup: Path | str = Path(target)
+    elif is_stdlib:
+        troot = Path(environment.working_path)
+        for _ in range(parent_dirs):
+            troot = troot.parent
+        target = join(troot, *path) + ".preql"
+        token_lookup = Path(target)
     elif isinstance(environment.config.import_resolver, FileSystemImportResolver):
         troot = Path(environment.working_path)
         for _ in range(parent_dirs):
@@ -69,7 +81,7 @@ def import_statement(
 ) -> ImportRequest:
     args = [str(hydrate(child)) for child in node.children]
     alias, cache_key, input_path, target, token_lookup, is_stdlib, leading_dots = (
-        _resolve_import_path(args, context.environment)
+        _resolve_import_path(args, context.environment, context.in_stdlib)
     )
     return ImportRequest(
         alias=alias,
@@ -91,7 +103,7 @@ def selective_import_statement(
     concepts_list: list[str] = next(a for a in args if isinstance(a, list))
     path_args = [str(a) for a in args if not isinstance(a, list)]
     alias, cache_key, input_path, target, token_lookup, is_stdlib, leading_dots = (
-        _resolve_import_path(path_args, context.environment)
+        _resolve_import_path(path_args, context.environment, context.in_stdlib)
     )
     return ImportRequest(
         alias=alias,

--- a/trilogy/parsing/v2/rules_context.py
+++ b/trilogy/parsing/v2/rules_context.py
@@ -31,6 +31,9 @@ class RuleContext:
     symbol_table: SymbolTable
     semantic_state: SemanticState
     source_text: str = ""
+    # True while parsing inside a stdlib file, so its bare relative imports
+    # resolve as stdlib siblings. See import_rules._resolve_import_path.
+    in_stdlib: bool = False
     concepts: ConceptLookup = field(init=False, repr=False, compare=False)
     types: TypeLookup = field(init=False, repr=False, compare=False)
 


### PR DESCRIPTION
## Problem

When the parser descends into a standard-library file, it lost the "this is stdlib" context. A stdlib file that imports a **sibling stdlib file with a bare relative name** (e.g. `std/money.preql` → `import currency;`) had that nested import resolved against whatever import resolver the environment config carried, instead of against the bundled stdlib. With a `DictImportResolver` (what the studio backend uses), the nested import failed:

```
Unable to import 'lineitem', parsing error: Unable to import '.../trilogy/std/money.preql',
parsing error: Unable to import file currency, not resolvable from provided source files.
```

`std/money.preql` is currently the only stdlib file with a sibling import, but the bug is general — any future stdlib file importing a sibling would hit it.

### Reproduction

```python
from trilogy import Environment
from trilogy.core.models.environment import EnvironmentConfig, DictImportResolver

content = {"lineitem": "import std.money;\nkey id int;"}
env = Environment(config=EnvironmentConfig(import_resolver=DictImportResolver(content=content)))
env.parse("import lineitem;")  # raised ImportError before this fix
```

## Root cause

1. **stdlib detection was text-only and top-level only.** `_resolve_import_path` decided `is_stdlib = path[0] == "std"`, which is `True` for the top-level `import std.money;` but `False` for the nested `import currency;`.
2. **child parses inherited the parent resolver.** The child env's config still carried the `DictImportResolver`, so `import currency;` resolved against the client content dict and failed — even though the child env's `working_path` was already the std dir.

## Fix (Option A — propagate stdlib context)

The real invariant is "a stdlib file's relative imports are themselves stdlib imports." This threads an `in_stdlib` flag through `HydrationContext` → `ImportHydrationService` → `RuleContext`. In `_resolve_import_path`, a relative import is treated as stdlib when the parent parse is stdlib, and siblings resolve against `working_path` (the std dir) so they load from disk regardless of the configured resolver.

## Tests

- Added `test_stdlib_sibling_import_under_dict_resolver` regression test.
- Full import + parsing + geography suites pass (111 passed); ruff, mypy, black clean.

Also bumps the package version to `0.3.278`.

https://claude.ai/code/session_01FD7q9jhQ8J8ajLqbEsdPd4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FD7q9jhQ8J8ajLqbEsdPd4)_