### PR TITLE
fix(fmt): preserve nullable `?` suffix and fix function round-trips

### DIFF
--- a/tests/rendering/test_rendering.py
+++ b/tests/rendering/test_rendering.py
@@ -1648,3 +1648,43 @@ def test_column_assignment_in_datasource():
 grain (user_id)
 address dim_users;"""
     assert rendered == expected, f"Got:\n{rendered}\n\nExpected:\n{expected}"
+
+
+def test_render_nullable_typed_declaration_round_trip():
+    """`fmt` must keep the trailing `?` on typed key/property declarations —
+    dropping it silently flips a concept from nullable to non-nullable."""
+    src = """key kid int?;
+property kid.name string?;
+"""
+    env = Environment(working_path=".")
+    _, queries = env.parse(src)
+    rendered = Renderer(environment=env).render_statement_string(queries)
+    assert "key kid int?;" in rendered, rendered
+    assert "property kid.name string?;" in rendered, rendered
+
+    env2 = Environment(working_path=".")
+    env2.parse(rendered)
+    for addr in ("local.kid", "local.name"):
+        assert (Modifier.NULLABLE in env.concepts[addr].modifiers) == (
+            Modifier.NULLABLE in env2.concepts[addr].modifiers
+        )
+
+
+def test_render_date_trunc_round_trip():
+    """The `date_truncate` enum value isn't the parseable keyword; render the
+    canonical `date_trunc` so output round-trips."""
+    env = Environment(working_path=".")
+    _, queries = env.parse("auto t <- date_trunc('2020-01-01'::date, month);\n")
+    rendered = Renderer(environment=env).render_statement_string(queries)
+    assert "date_trunc(" in rendered, rendered
+    assert "date_truncate(" not in rendered, rendered
+    Environment(working_path=".").parse(rendered)
+
+
+def test_render_hash_round_trip():
+    """The hash algorithm is a bare keyword (md5/sha256/...), not a string."""
+    env = Environment(working_path=".")
+    _, queries = env.parse("const s <- 'x';\nauto h <- hash(s, sha256);\n")
+    rendered = Renderer(environment=env).render_statement_string(queries)
+    assert "hash(s, sha256)" in rendered, rendered
+    Environment(working_path=".").parse(rendered)

--- a/trilogy/parsing/render.py
+++ b/trilogy/parsing/render.py
@@ -128,6 +128,12 @@ def safe_address(address: str) -> str:
 
 DEFAULT_MAX_LINE_LENGTH = 100
 
+# FunctionType.value isn't always a keyword the parser accepts; map those to
+# their canonical parseable spelling so rendered output round-trips.
+_FUNCTION_NAME_OVERRIDES = {
+    FunctionType.DATE_TRUNCATE: "date_trunc",
+}
+
 
 def _purpose_keyword(purpose: Purpose) -> str:
     """Grammar keyword for a Purpose — ``unique property`` not ``unique_property``."""
@@ -767,10 +773,14 @@ class Renderer:
         ):
             ns_for_emit = ""
         if not concept.lineage:
+            # The grammar accepts a trailing ``?`` nullable marker on typed
+            # key/property declarations; drop it and the concept silently
+            # becomes non-nullable on reparse.
+            nullable = "?" if Modifier.NULLABLE in concept.modifiers else ""
             if key_prefix:
-                output = f"{purpose_kw} {key_prefix}{concept.name} {self.to_string(concept.datatype)};"
+                output = f"{purpose_kw} {key_prefix}{concept.name} {self.to_string(concept.datatype)}{nullable};"
             else:
-                output = f"{purpose_kw} {namespace}{concept.name} {self.to_string(concept.datatype)};"
+                output = f"{purpose_kw} {namespace}{concept.name} {self.to_string(concept.datatype)}{nullable};"
         else:
             # Any lineage-bearing concept renders as `auto`; the parser
             # re-infers purpose and keys. `property`/`metric` keywords
@@ -1166,11 +1176,22 @@ class Renderer:
             return f"struct(\n{inputs}\n{self.indent_context.current_indent})"
         if arg.operator == FunctionType.ALIAS:
             return f"{self.to_string(arg.arguments[0])}"
+        if arg.operator == FunctionType.HASH:
+            # The algorithm is a bare HASH_TYPE keyword (md5/sha1/...), not a
+            # string literal — quoting it breaks reparse.
+            with self.indented():
+                head = self.to_string(arg.arguments[0])
+            algo = arg.arguments[1]
+            algo_str = algo if isinstance(algo, str) else self.to_string(algo)
+            return self._render_call("hash", [head, algo_str])
         # Re-render args at +1 indent so multi-line atoms (e.g. wrapped
         # array literals) line up under the call's wrapped open-paren.
         with self.indented():
             indented_args = [self.to_string(c) for c in arg.arguments]
-        return self._render_call(arg.operator.value, indented_args)
+        # A few FunctionType values don't match a parseable keyword; the
+        # enum's ``date_truncate`` isn't the canonical ``date_trunc`` spelling.
+        name = _FUNCTION_NAME_OVERRIDES.get(arg.operator, arg.operator.value)
+        return self._render_call(name, indented_args)
 
     @to_string.register
     def _(self, arg: "OrderItem"):


### PR DESCRIPTION
The renderer dropped the trailing `?` nullable marker on typed
key/property declarations (e.g. `int?` -> `int`), silently flipping a
concept from nullable to non-nullable. Reparsing the formatted output
then failed validation with `inferred type X(NULLABLE) vs expected X`.
Add the marker back in the typed `ConceptDeclarationStatement` path.

Audit of function round-trips also turned up two non-round-tripping
emissions:

- `date_trunc` rendered as the enum value `date_truncate`, which the
  default pest parser rejects. Map it to the canonical `date_trunc`.
- `hash(x, md5)` rendered the algorithm as a quoted string `'md5'`, but
  the grammar wants a bare HASH_TYPE keyword. Emit it unquoted.

Add round-trip tests for all three.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XW8SskT2ujPAqSZWoDVSTb