### PR TITLE
Fix partial-FK bridge dropped by subset-prune (measure fan-out)

### DIFF
--- a/tests/engine/test_enum_unions.py
+++ b/tests/engine/test_enum_unions.py
@@ -517,3 +517,110 @@ def test_shared_union_arms_collapse_to_single_union():
     assert sql.count('as "ds_a"') == 1, sql
     assert sql.count('as "ds_b"') == 1, sql
     assert sql.count('as "ds_c"') == 1, sql
+
+
+# An enum-partitioned fact where the FK that links a measure to its dimension is
+# carried directly on the fact for some channels (A, B) but, for channel C, lives
+# on a SIBLING table (`sale_c`) keyed by the same (oid, chan). Satisfying the C arm
+# of the fact union therefore requires MERGING `ret_c` (the measure) with `sale_c`
+# (the FK): its requested fields span two sources. A union projects only the
+# columns common to every branch, so `dim_id` (absent from `ret_c` alone) gets
+# dropped and the measure loses correlation to its dimension. Mirrors TPC-DS q05,
+# where a web return's return-site comes from web_sales, not web_returns.
+PREQL_UNION_ARM_SPANS_SOURCES = """
+key oid int;
+key chan enum<string>['A', 'B', 'C'];
+key dim_id int;
+property dim_id.dim_text string;
+property <oid, chan>.amt float;
+key k int;
+property k.v float;
+
+partial datasource ret_a (oid:oid, raw(''' 'A' '''):chan, aid:?dim_id, amt:amt)
+grain (oid, chan) complete where chan = 'A'
+query ''' select 1 as oid, 100 as aid, 11.0 as amt union all select 2 as oid, 200 as aid, 20.0 as amt ''';
+
+partial datasource ret_b (oid:oid, raw(''' 'B' '''):chan, bid:?dim_id, amt:amt)
+grain (oid, chan) complete where chan = 'B'
+query ''' select 3 as oid, 200 as bid, 30.0 as amt ''';
+
+partial datasource ret_c (oid:oid, raw(''' 'C' '''):chan, amt:amt)
+grain (oid, chan) complete where chan = 'C'
+query ''' select 4 as oid, 40.0 as amt union all select 5 as oid, 55.0 as amt ''';
+
+partial datasource sale_c (oid:oid, raw(''' 'C' '''):chan, cid:?dim_id)
+grain (oid, chan) complete where chan = 'C'
+query ''' select 4 as oid, 100 as cid union all select 5 as oid, 300 as cid ''';
+
+partial datasource dim_a (raw(''' 'A' '''):chan, did:dim_id, dtext:dim_text)
+grain (dim_id, chan) complete where chan = 'A'
+query ''' select 100 as did, 'p100' as dtext union all select 200 as did, 'p200' as dtext ''';
+
+partial datasource dim_b (raw(''' 'B' '''):chan, did:dim_id, dtext:dim_text)
+grain (dim_id, chan) complete where chan = 'B'
+query ''' select 100 as did, 'p100' as dtext union all select 200 as did, 'p200' as dtext ''';
+
+partial datasource dim_c (raw(''' 'C' '''):chan, did:dim_id, dtext:dim_text)
+grain (dim_id, chan) complete where chan = 'C'
+query ''' select 100 as did, 'p100' as dtext union all select 300 as did, 'p300' as dtext ''';
+
+datasource other (k:k, v:v) grain (k) query ''' select 1 as k, 7.0 as v ''';
+"""
+
+# p100: A/oid1 (11) + C/oid4 (40) = 51; p200: A/oid2 (20) + B/oid3 (30) = 50;
+# p300: C/oid5 (55). C's measure must correlate to its FK via sale_c.
+_EXPECTED_RETURNS = [("ep100", 51.0), ("ep200", 50.0), ("ep300", 55.0)]
+
+
+def test_enum_union_arm_spanning_multiple_sources_row_grain():
+    # The core defect, with no union/aggregate to obscure it: a plain row-grain
+    # select of (entity-via-partial-FK, measure). The measure union drops dim_id
+    # (ret_c lacks it) and joins the dimension on the enum key `chan` alone, so a
+    # measure pairs with EVERY entity sharing its channel — inventing (ent, amt)
+    # pairs that no row carries. The five real pairs (one per oid) are the only
+    # correct rows.
+    executor = Dialects.DUCK_DB.default_executor()
+    executor.execute_text(PREQL_UNION_ARM_SPANS_SOURCES)
+    results = executor.execute_text("""
+where dim_id is not null
+select concat('e', dim_text) as ent, amt as m order by ent, m;
+""")[0].fetchall()
+    assert [tuple(r) for r in results] == [
+        ("ep100", 11.0),
+        ("ep100", 40.0),
+        ("ep200", 20.0),
+        ("ep200", 30.0),
+        ("ep300", 55.0),
+    ]
+
+
+def test_enum_union_arm_spanning_multiple_sources_aggregated():
+    # Control: with an explicit aggregate the measure is sourced at dim_id grain,
+    # which pulls in the sale_c FK bridge, so this already resolves correctly.
+    executor = Dialects.DUCK_DB.default_executor()
+    executor.execute_text(PREQL_UNION_ARM_SPANS_SOURCES)
+    results = executor.execute_text("""
+where dim_id is not null
+select concat('e', dim_text) as ent, sum(amt) as total order by ent;
+""")[0].fetchall()
+    assert [tuple(r) for r in results] == _EXPECTED_RETURNS
+
+
+def test_enum_union_arm_spanning_multiple_sources_in_tvf():
+    # The same split arm inside a multi-arm union(...) TVF: the arm is resolved at
+    # row grain and does NOT carry the grain key (oid) in its output, so the
+    # planner has no grain-key bridge to pull `sale_c` in for the C branch. The
+    # measure union can then only join the dimension on the low-cardinality enum
+    # key (chan), and C's measure fans out / broadcasts (ep300 picks up all of C,
+    # ep100/ep200 inflate). The per-enum source search must instead recognize a
+    # mergeable set (ret_c |x| sale_c) so every branch provides dim_id.
+    executor = Dialects.DUCK_DB.default_executor()
+    executor.execute_text(PREQL_UNION_ARM_SPANS_SOURCES)
+    results = executor.execute_text("""
+with combined as union(
+  (select 'zzz' as ent, v as m where k = 1),
+  (where dim_id is not null select concat('e', dim_text) as ent, amt as m)
+) -> (entity, meas);
+select combined.entity, sum(combined.meas) as total order by combined.entity;
+""")[0].fetchall()
+    assert [tuple(r) for r in results] == _EXPECTED_RETURNS + [("zzz", 7.0)]

--- a/tests/modeling/tpc_ds_duckdb/test_non_benchmark_queries.py
+++ b/tests/modeling/tpc_ds_duckdb/test_non_benchmark_queries.py
@@ -731,3 +731,48 @@ order by pivoted.daily_sales.week_seq nulls first;
     env = Environment(working_path=working_path)
     sql = Dialects.DUCK_DB.default_executor(environment=env).generate_sql(query)[-1]
     assert not _has_nested_aggregate(sql), sql
+
+def test_property_via_partial_fk_does_not_broadcast(engine_sf001):
+    # q05 shape: an entity label (`return_channel_dim_text_id`, a PROPERTY of the
+    # FK `return_channel_dim_id`) is selected at row grain alongside its return
+    # measure. The FK is PARTIAL on the returns grain (web_returns doesn't map it),
+    # so the planner sourced the FK from the dim datasource (where it's the grain
+    # key) instead of from the returns fact, then joined fact->dim on the only
+    # shared concept, `channel`. That channel-only join fans out: every catalog
+    # page in the channel pairs with the full channel return set, so an outer
+    # `sum(return_amount) by entity` broadcasts the channel total identically onto
+    # every entity. The FK must be sourced from the fact so the dim join keys on it.
+    query = """
+import all_sales as s;
+
+with combined as union(
+  (where s.date.date between '2000-08-23'::date and '2000-09-06'::date
+    and s.channel_dim_id is not null
+   select
+     case when s.channel = 'CATALOG' then 'catalog channel' else 'other' end as ch,
+     concat('catalog_page', s.channel_dim_text_id) as ent,
+     s.ext_sales_price as gs,
+     0::float as ret_amt),
+  (where s.return_date.date between '2000-08-23'::date and '2000-09-06'::date
+    and s.return_channel_dim_id is not null
+   select
+     case when s.channel = 'CATALOG' then 'catalog channel' else 'other' end as ch,
+     concat('catalog_page', s.return_channel_dim_text_id) as ent,
+     0::float as gs,
+     s.return_amount as ret_amt)
+) -> (channel_type, entity_id, gross_sales, return_amounts);
+
+select
+  combined.channel_type,
+  combined.entity_id,
+  sum(combined.gross_sales) as total_gross_sales,
+  sum(combined.return_amounts) as total_returns
+where combined.channel_type = 'catalog channel'
+order by total_returns desc
+limit 10;
+"""
+    rows = engine_sf001.execute_text(query)[0].fetchall()
+    totals = [round(r.total_returns, 2) for r in rows]
+    # A broadcast collapses every page onto the same channel total; correct
+    # per-page returns vary.
+    assert len(set(totals)) > 1, totals

--- a/trilogy/core/processing/node_generators/select_helpers/source_scoring.py
+++ b/trilogy/core/processing/node_generators/select_helpers/source_scoring.py
@@ -340,9 +340,16 @@ def resolve_subgraphs(
         ds: {n for n in subgraphs[ds] if n in concepts} for ds in datasources
     }
 
-    def _bridge_targets(ds: str) -> set[str]:
+    def _bridge_edges(ds: str) -> set[tuple[str, str]]:
+        # (other datasource, the join-key node shared with it). Keyed by join key,
+        # not just by target: an FK bridge reaches a fact via a fine key (oid)
+        # while a dimension peer reaches the same fact only via a coarse enum key
+        # (channel). Comparing whole targets treats those as equivalent and drops
+        # the FK bridge; comparing (target, key) edges keeps the distinction.
         mine = ds_join_nodes[ds]
-        return {o for o in datasources if o != ds and (mine & ds_join_nodes[o])}
+        return {
+            (o, n) for o in datasources if o != ds for n in (mine & ds_join_nodes[o])
+        }
 
     # Datasources that uniquely provide some requested concept — pruning a join
     # path to one of these would lose data, so a bridge to it is load-bearing.
@@ -385,10 +392,15 @@ def resolve_subgraphs(
                 # fans the result out, so keep it. A bridge to a datasource that
                 # is redundant elsewhere is NOT protected (it would re-introduce
                 # an ambiguous alternative path).
-                key_only_bridges = (
-                    _bridge_targets(key) - _bridge_targets(other_key) - {other_key}
-                )
-                if key_only_bridges & sole_providers:
+                other_edges = _bridge_edges(other_key)
+                key_only_bridges = {
+                    o
+                    for (o, n) in _bridge_edges(key)
+                    if o != other_key
+                    and o in sole_providers
+                    and (o, n) not in other_edges
+                }
+                if key_only_bridges:
                     continue
                 if len(value) < len(other_value):
                     is_subset = True


### PR DESCRIPTION
## Problem

A plain row-grain select of `(entity-via-partial-FK, measure)` — e.g. the returns arm of a multi-channel `union(...)` — silently **fanned out**: a measure paired with every entity sharing its channel, inventing `(entity, measure)` rows that no source row carries (TPC-DS q05 broadcast shape).

## Root cause

`resolve_subgraphs` (source scoring) dropped the **FK-union** datasource as a "subset" of the **dimension union**. The FK union is the only source carrying the fine foreign key (`oid -> dim_id`) that links the measure union (keyed on `oid`) to the dimension (keyed on `dim_id`). With it pruned, the measure could only join the dimension on the coarse shared enum key (`channel`) → fan-out.

The existing bridge protection compared **whole targets**, which masked the difference: the dimension peer also "touches" the measure union, but only via the coarse key. So the fine bridge looked redundant. This is the "global-merge form still open" of the earlier q72 bridge-prune fix.

## Fix

Make the bridge protection **key-aware** — compare `(target, join-key)` edges instead of bare targets. The FK union's `(measure-union, oid)` edge isn't covered by the dimension union (which only has `(measure-union, channel)`), so it's correctly kept as a load-bearing bridge.

~18 lines in `source_scoring.py`. No model or union-machinery changes.

## Validation

- New unit tests: `tests/engine/test_enum_unions.py` — the split arm row-grain (core bug), inside a `union(...)` TVF, and an aggregated control.
- End-to-end TPC-DS regression test in `test_non_benchmark_queries.py`.
- Full TPC-DS benchmark **106/106 pass**; scoring/union/optimization/discovery/modeling suites green; lint/mypy/black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)