### PR TITLE
[CI] Actually run the live BigQuery tests

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -103,6 +103,26 @@ jobs:
         if: matrix.run_llm_tests == true
         run: |
           python -m local_scripts.fuzzer
+      - name: Test against live BigQuery
+        # These need a dataset they may create and drop tables in, and without
+        # `TRILOGY_BIGQUERY_TEST_DATASET` every `bigquery_execution` test skips.
+        # They did skip, silently, on every run before this step existed — which
+        # is how a native-persist bug walked past the parity suite written to
+        # catch exactly it (#643). The dataset is named here rather than at job
+        # level so the steps above keep skipping them: this must stay one cell.
+        #
+        # One cell, because these exercise BigQuery's behaviour rather than the
+        # python version's, and each cell is ~7min of wall clock and real spend.
+        # Skipped for fork PRs, which have no credentials — same condition as
+        # the auth step, so the tests never run half-configured.
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        run: |
+          python -m pytest tests/ --cov=trilogy --cov-append -m bigquery_execution
+        env:
+          # Explicit rather than relying on the auth step's exported project:
+          # the whole point of this step is that it must not silently skip.
+          GOOGLE_CLOUD_PROJECT: preqldata
+          TRILOGY_BIGQUERY_TEST_DATASET: trilogy_integration
       - name: Test after installing rich
         run: |
           # install rich and rerun CLI tests. One invocation, not three: the -k


### PR DESCRIPTION
## They were not running

`tests/engine/bigquery` is gated on a dataset the credentials may create and drop tables in, read from `TRILOGY_BIGQUERY_TEST_DATASET`. CI authenticates to `preqldata` but has never set it — so `bq_write_dataset` skips, and all **22 `bigquery_execution` tests skip with it**, on every run since they were written. Silently, because a skip is not a failure.

```
SKIPPED [3] test_bigquery_partition_swap.py: TRILOGY_BIGQUERY_TEST_DATASET not set
...
13 skipped
```

This is not hypothetical. The native BigQuery partition swap shipped staging its rows under *concept* names rather than the target's *declared* ones (#643) — and `test_bigquery_partition_swap.py`, which exists specifically to prove the native and SQL write paths agree, never ran. Even locally it could not have caught it: its model declares `created_at: created_at`, so both names coincide. #643 fixes both the bug and that blind spot; this makes the suite actually execute.

## The change

One step, pointed at `preqldata.trilogy_integration`.

- **One cell** (ubuntu / 3.13), not the full 2×3 matrix. These exercise BigQuery's behaviour, not the python version's, so the other five cells re-prove the same result at ~7 min of wall clock and real BigQuery spend each. Same reasoning the fuzzer step already uses.
- **Dataset set on this step, not at job level.** That is load-bearing: the whole-tree `pytest tests/` steps above do not exclude the marker, so a job-level variable would run the live suite on all six cells — about 40 min added and six times the spend, against a job whose Windows cells already sit at ~42 min under a 45 min timeout.
- **Fork PRs excluded** on the same condition as the auth step, so the tests never run half-configured against absent credentials.
- **`GOOGLE_CLOUD_PROJECT` set explicitly** rather than leaning on the auth action's exported project. The entire point of this step is that it must not silently skip.

Table names are all uuid-suffixed, so concurrent runs against the shared dataset do not collide.

## Cost

Adds ~7 min to the ubuntu-3.13 cell only; the other five are unchanged. That cell is well under the 45 min timeout (the ~42 min figure in the workflow comment is Windows).

## Verified

Ran the exact marker locally against `preqldata.trilogy_integration`: **17 passed, 5 skipped**, no staging or parity tables left behind afterwards. The 5 skips need `TRILOGY_BIGQUERY_STAGING_URI` (a GCS bucket for staged python datasources) — a separate gap, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
