### PR TITLE
[Bug/Feat] Window-over-window CTE split, chart rendering + agent syntax examples

### DIFF
--- a/crates/trilogy-io/Cargo.toml
+++ b/crates/trilogy-io/Cargo.toml
@@ -2,7 +2,7 @@
 name = "trilogy-io"
 # Synced from the python __init__ by the same release flow as trilogy-parser;
 # a published crate version always corresponds to a real pytrilogy release.
-version = "0.3.336"
+version = "0.3.337"
 edition = "2021"
 description = "Write a program that is a Trilogy data source: Arrow out, contract flags in."
 license = "MIT"

--- a/tests/ai/test_syntax_examples.py
+++ b/tests/ai/test_syntax_examples.py
@@ -148,6 +148,20 @@ def test_syntax_example_compiles_and_runs(name, executor, model_dir):
         executor.execute_raw_sql(sql)
 
 
+def test_chart_example_renders_every_chart(executor, model_dir):
+    """The chart example is only useful if its statements actually DRAW - SQL
+    generation alone would not catch an unrenderable role/type combination."""
+    pytest.importorskip("altair")
+    from trilogy.dialect.results import ChartResult
+
+    executor.environment = Environment(working_path=model_dir)
+    body = SYNTAX_EXAMPLES["chart"].body
+    charts = [r for r in executor.execute_text(body) if isinstance(r, ChartResult)]
+    assert len(charts) == 9
+    for result in charts:
+        assert result.chart.to_dict()["$schema"]
+
+
 def test_example_index_lists_every_example():
     from trilogy.ai.syntax_examples import example_index
 

--- a/tests/charts/test_altair_rendering.py
+++ b/tests/charts/test_altair_rendering.py
@@ -138,8 +138,8 @@ def test_altair_empty_layers_returns_none():
 
 
 def test_altair_unimplemented_chart_type_raises():
-    statement = _statement(ChartType.HEATMAP, ["x"], ["y"])
-    with pytest.raises(NotImplementedError):
+    statement = _statement(ChartType.TREEMAP, ["x"], ["y"])
+    with pytest.raises(NotImplementedError, match="Supported types:"):
         AltairRenderer().render(statement, _data())
 
 

--- a/tests/charts/test_chart_type_rendering.py
+++ b/tests/charts/test_chart_type_rendering.py
@@ -1,0 +1,151 @@
+"""Chart types beyond the x/y marks: donut, heatmap and boxplot, plus the
+refusal that names what IS supported. These build off the real executor because
+the builders read declared datatypes off the layer's query, not pandas dtypes."""
+
+import pytest
+
+pytest.importorskip("altair")
+
+from trilogy import Executor
+from trilogy.dialect.enums import Dialects
+from trilogy.dialect.results import ChartResult
+
+_SETUP = """
+key id int;
+property id.category string;
+property id.region string;
+property id.value int;
+property id.note string;
+
+datasource chart_data (
+    id: id,
+    cat: category,
+    reg: region,
+    val: value,
+    note: note
+)
+grain (id)
+query '''
+select 1 as id, 'A' as cat, 'east' as reg, 10 as val, 'low' as note
+union all select 2, 'A', 'west', 20, 'mid'
+union all select 3, 'B', 'east', 30, 'high'
+union all select 4, 'B', 'west', 40, 'top'
+''';
+"""
+
+
+def _chart(text: str):
+    ex = Executor(dialect=Dialects.DUCK_DB, engine=Dialects.DUCK_DB.default_engine())
+    results = [r for r in ex.execute_text(_SETUP + text) if isinstance(r, ChartResult)]
+    return results[0].chart
+
+
+def test_donut_sizes_slices_by_the_numeric_binding():
+    spec = _chart(
+        "chart layer donut ( x_axis <- category, y_axis <- sum(value) as total );"
+    ).to_dict()
+    assert spec["mark"]["type"] == "arc"
+    assert spec["mark"]["innerRadius"] > 0
+    assert spec["encoding"]["theta"]["field"] == "total"
+    assert spec["encoding"]["color"]["field"] == "category"
+    assert spec["encoding"]["order"]["sort"] == "descending"
+
+
+def test_donut_accepts_the_color_shaped_spelling():
+    spec = _chart(
+        "chart layer donut ( x_axis <- sum(value) as total, color <- category );"
+    ).to_dict()
+    assert spec["encoding"]["theta"]["field"] == "total"
+    assert spec["encoding"]["color"]["field"] == "category"
+
+
+def test_donut_without_a_numeric_binding_raises():
+    with pytest.raises(ValueError, match="numeric x_axis or y_axis"):
+        _chart("chart layer donut ( x_axis <- category, y_axis <- note );")
+
+
+def test_donut_without_a_category_raises():
+    with pytest.raises(ValueError, match="name the slices"):
+        _chart("chart layer donut ( y_axis <- sum(value) as total );")
+
+
+def test_donut_rejects_annotation():
+    with pytest.raises(ValueError, match="'annotation' role is not supported"):
+        _chart(
+            "chart layer donut ( x_axis <- category, y_axis <- sum(value) as total,"
+            " annotation <- note );"
+        )
+
+
+def test_heatmap_bands_both_axes_and_colors_by_the_measure():
+    spec = _chart(
+        "chart layer heatmap ( x_axis <- region, y_axis <- category,"
+        " color <- sum(value) as total );"
+    ).to_dict()
+    assert spec["mark"]["type"] == "rect"
+    assert spec["encoding"]["x"]["type"] == "nominal"
+    assert spec["encoding"]["y"]["type"] == "nominal"
+    assert spec["encoding"]["color"]["field"] == "total"
+
+
+def test_heatmap_bands_a_numeric_axis_as_ordinal():
+    spec = _chart(
+        "chart layer heatmap ( x_axis <- id, y_axis <- category,"
+        " color <- sum(value) as total );"
+    ).to_dict()
+    assert spec["encoding"]["x"]["type"] == "ordinal"
+
+
+def test_heatmap_without_color_raises():
+    with pytest.raises(ValueError, match="needs a `color` binding"):
+        _chart("chart layer heatmap ( x_axis <- region, y_axis <- category );")
+
+
+def test_heatmap_annotation_labels_cells():
+    spec = _chart(
+        "chart layer heatmap ( x_axis <- region, y_axis <- category,"
+        " color <- sum(value) as total, annotation <- count(id) as rows );"
+    ).to_dict()
+    assert [layer["mark"]["type"] for layer in spec["layer"]] == ["rect", "text"]
+
+
+def test_boxplot_summarizes_the_value_axis_per_category():
+    spec = _chart(
+        "chart layer boxplot ( x_axis <- category, y_axis <- value )"
+        " from select --id, category, value;"
+    ).to_dict()
+    assert spec["mark"]["type"] == "boxplot"
+    assert spec["encoding"]["x"]["type"] == "nominal"
+    assert spec["encoding"]["y"]["type"] == "quantitative"
+
+
+def test_boxplot_rejects_annotation():
+    with pytest.raises(ValueError, match="'annotation' role is not supported"):
+        _chart(
+            "chart layer boxplot ( x_axis <- category, y_axis <- value,"
+            " annotation <- note );"
+        )
+
+
+def test_unimplemented_type_names_the_supported_set():
+    with pytest.raises(NotImplementedError) as err:
+        _chart(
+            "chart layer treemap ( x_axis <- category, y_axis <- sum(value) as total );"
+        )
+    message = str(err.value)
+    assert "treemap" in message
+    for supported in ("bar", "barh", "line", "point", "area", "headline"):
+        assert supported in message
+
+
+def test_donut_hex_trait_colors_the_slices():
+    spec = _chart(
+        "import std.color;\n"
+        "chart layer donut ( x_axis <- total, color <- category )"
+        " from select category, sum(value) as total,"
+        " case when category = 'A' then '#ff0000' else '#00ff00' end::hex as shade;"
+    ).to_dict()
+    assert spec["encoding"]["color"]["scale"] == {
+        "domain": ["A", "B"],
+        "range": ["#ff0000", "#00ff00"],
+    }

--- a/tests/test_window_over_window_cte_split.py
+++ b/tests/test_window_over_window_cte_split.py
@@ -1,0 +1,27 @@
+from trilogy import Dialects, Environment
+
+MODEL = """
+key tree_id int;
+property tree_id.species string;
+
+datasource trees (
+    tree_id: tree_id,
+    species: species,
+) grain (tree_id) address trees;
+
+auto dominance_rank <- rank(species) over (order by count(tree_id) by species desc, species asc);
+auto cumulative <- (sum count(tree_id) by species order by dominance_rank asc);
+"""
+
+
+def test_window_ordered_by_sibling_window_splits_ctes():
+    env = Environment()
+    env.parse(MODEL)
+    executor = Dialects.DUCK_DB.default_executor(environment=env)
+    executor.execute_raw_sql(
+        "create table trees as select * from (values (1,'a'),(2,'a'),(3,'b')) t(tree_id, species)"
+    )
+    sql = executor.generate_sql("select species, dominance_rank, cumulative;")[-1]
+    assert "over (order by rank()" not in sql, sql
+    rows = executor.execute_raw_sql(sql).fetchall()
+    assert rows == [("a", 1, 2), ("b", 2, 3)], rows

--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from trilogy.executor import Executor
     from trilogy.parser import parse
 
-__version__ = "0.3.336"
+__version__ = "0.3.337"
 
 __all__ = [
     "CONFIG",

--- a/trilogy/ai/syntax_examples.py
+++ b/trilogy/ai/syntax_examples.py
@@ -161,6 +161,124 @@ limit 100;
 """,
     ),
     SyntaxExample(
+        name="chart",
+        title="Chart statement - layers, roles, settings and reference lines",
+        summary=(
+            "drawing a result rather than tabulating it: `chart layer <type> "
+            "( <role> <- <expr> as <name>, ... )` is a STATEMENT that wraps its "
+            "own query - the bindings ARE the select; layers, roles, scales, "
+            "reference lines and `from <select>`"
+        ),
+        body="""# `chart` is a top-level statement, like `select` - it wraps a query AND says
+# how to draw it. It renders wherever results render: a trilogy code block in a
+# `trilogy render` report, a studio cell, terminal output, and
+# `copy into png|svg|html|pdf '<path>' from chart ...` for a standalone image.
+import enrollments as enroll;
+
+# --- 1. Minimal form --------------------------------------------------------
+# `layer <type> ( <role> <- <expr> [as <name>], ... )`. The bindings ARE the
+# select: grouping is automatic by the non-aggregated ones, exactly as in a
+# query. NEVER write a separate `select` for a chart.
+chart layer bar ( x_axis <- enroll.department, y_axis <- sum(enroll.credits) as credits );
+
+# A COMPUTED binding must be aliased: `y_axis <- sum(enroll.credits) as credits`.
+# A bare concept reference needs no alias (`x_axis <- enroll.department`) but may
+# take one as a display label. `y_axis <- sum(...)` with no `as` is a parse error.
+#
+# GRAIN: every binding is a select column, so binding a FINER concept to any
+# role (color, group, annotation, ...) refines the grain and splits the marks -
+# exactly as adding that column to a select would. Aggregate annotations at the
+# mark's own grain (`count(enroll.id) as ...`) instead of binding a detail field.
+
+# --- 2. Every part of the statement -----------------------------------------
+# Components may appear in any order after `chart`; at least one `layer` is
+# required, and multiple `layer`s compose into one overlaid chart.
+chart
+  set show_title                            # title from the value-axis label
+  set hide_legend
+  set scale_y: log                          # scale_x | scale_y : linear | log | sqrt
+  layer bar (
+    x_axis <- enroll.department,
+    y_axis <- sum(enroll.credits) as credits,
+    color <- enroll.completed,              # one legend series per value
+    annotation <- count(enroll.id) as enrollments   # text label on each mark
+  )
+  order by credits desc                     # category order follows ORDER BY
+  limit 10                                  # (ascending when there is no ORDER BY)
+  place hline at 5 as target;               # reference rule; `place vline at ...`
+                                            # too. `at` takes a literal; `as <label>`
+                                            # is optional
+
+# --- 3. `from <select>` - when the bindings cannot express the query ---------
+# Bindings alone have no `where` / `having` / hidden columns. Add `from` plus a
+# COMPLETE select, which carries its own clauses in the usual order:
+chart layer line (
+    x_axis <- enroll.year,
+    y_axis <- completions,
+    color <- enroll.department
+  )
+  from
+  where enroll.year >= 2016
+  select
+    enroll.year,
+    enroll.department,
+    count(enroll.id ? enroll.completed = true) as completions
+  order by enroll.year asc;
+# With `from select`, EVERY binding must be a bare reference to one of the
+# select's outputs - put transformations inside the select - and layer-level
+# `order by` / `limit` are rejected: they belong to the select.
+
+# --- 4. Types ---------------------------------------------------------------
+#   bar       vertical bars: x_axis = category, y_axis = measure
+#   barh      horizontal bars: x_axis = MEASURE, y_axis = category (roles swap)
+#   line      x_axis = the ordered axis (date/year), y_axis = measure
+#   point     scatter; `size <- <measure>` scales the marks
+#   area      line, filled
+#   headline  big KPI number - needs only `x_axis <- <measure> as <name>`
+#   donut     the numeric binding sizes the slices; the other positional one -
+#             or `color` - names them. No annotations.
+#   heatmap   x_axis and y_axis are BOTH categories, `color` is the measure
+#   boxplot   x_axis = category, y_axis = the distribution being summarized
+# `treemap` parses but no renderer implements it; the error names what does.
+chart layer barh ( x_axis <- sum(enroll.credits) as credits, y_axis <- enroll.department );
+chart layer headline ( x_axis <- count(enroll.student_id) as students );
+chart layer donut ( x_axis <- enroll.department, y_axis <- sum(enroll.credits) as credits );
+chart layer heatmap (
+    x_axis <- enroll.year,
+    y_axis <- enroll.department,
+    color <- sum(enroll.credits) as credits
+);
+# A boxplot summarizes RAW rows, so its select has to carry the fact's row grain
+# - hidden with `--` - or output dedup collapses the distribution to the set of
+# distinct values.
+chart layer boxplot ( x_axis <- enroll.department, y_axis <- enroll.credits )
+  from select --enroll.id, enroll.department, enroll.credits;
+
+# --- 5. Roles ---------------------------------------------------------------
+#   x_axis, y_axis          position
+#   color                   one series per value, WITH a legend
+#   size                    mark size (point)
+#   group                   side-by-side bars, or a per-series split on
+#                           line/point/area - no legend
+#   x_trellis / y_trellis   small multiples (columns / rows)
+#   annotation              per-mark text label
+#   geo                     reserved - parses, then raises
+# Each role may be bound at most once per layer; an unknown role name is a parse
+# error. Trellis roles cannot combine with multiple layers, placements, or
+# annotations (Vega-Lite forbids facets inside layered charts).
+chart layer bar (
+    x_axis <- enroll.year,
+    y_axis <- sum(enroll.credits) as credits,
+    group <- enroll.department              # side-by-side bars, no legend
+);
+
+# EXPLICIT SERIES COLORS: select a `string::hex` column (the trait comes from
+# `import std.color;`) alongside a `color` binding and each color value takes the
+# hex code found on its rows (missing -> gray); bind the hex column itself to
+# `color` to use the codes directly.
+""",
+    ),
+    SyntaxExample(
         name="filtered-aggregate",
         title="Filtered aggregate - aggregate only the rows matching a condition",
         summary=(

--- a/trilogy/core/processing/v4_helper/group_rules.py
+++ b/trilogy/core/processing/v4_helper/group_rules.py
@@ -273,13 +273,13 @@ def _fold_distinct_rewritable_buckets(
     return distinct_by_key
 
 
-def _aggregate_lineage_layers(
+def _lineage_layers(
     members: list[NodeItem],
     concept_graph: nx.DiGraph,
     concept_edges: EdgeMap,
 ) -> list[list[NodeItem]]:
-    """Split same-key aggregate members into build layers so no bucket holds
-    both an aggregate and a lineage CONSUMER of it.
+    """Split same-key members into build layers so no bucket holds both a
+    member and a lineage CONSUMER of it.
 
     Two aggregates at one output grain normally co-source when their arguments
     need the same row grain. But `count(line ? owc > 1) by order_id` where
@@ -356,7 +356,7 @@ def _partition_standard_aggregates(
     buckets: list[GroupBucket] = []
     for key, members in entries.items():
         label, depth_label, grain, input_grain, populations = key
-        layers = _aggregate_lineage_layers(members, concept_graph, concept_edges)
+        layers = _lineage_layers(members, concept_graph, concept_edges)
         for layer_index, layer in enumerate(layers):
             bucket = _bucket_for(
                 depth_label, layer[0][1].derivation, grain, label=label
@@ -989,6 +989,51 @@ def _partition_by_signature_and_grain(
     return buckets
 
 
+def partition_windows(
+    items: list[NodeItem],
+    concept_graph: nx.DiGraph,
+    concept_edges: EdgeMap,
+    concept_attrs: dict[str, ConceptAttrs],
+    primary_group: dict[str, str],
+    ensure_assigned: EnsureAssignedFn,
+    output_addresses: frozenset[str] = frozenset(),
+) -> list[GroupBucket]:
+    """Same-grain windows co-source, except when one reads another's output.
+    SQL forbids a window function inside another window's OVER clause
+    (`sum(x) over (order by rank() over (...))` is a parser error), so a window
+    whose partition/order lineage includes a sibling window needs its own CTE
+    over the producer's. Layering is the aggregate rule's producer/consumer
+    split applied to the default depth+grain partition."""
+    buckets: list[GroupBucket] = []
+    by_key: dict[
+        tuple[str, DepthLabel, frozenset[str], AggregateGroupingMode | None],
+        list[NodeItem],
+    ] = defaultdict(list)
+    for node, data in items:
+        by_key[
+            (data.label, data.depth_label, data.grain_components, data.grouping_mode)
+        ].append((node, data))
+    for (label, depth_label, grain, grouping_mode), members in by_key.items():
+        for index, layer in enumerate(
+            _lineage_layers(members, concept_graph, concept_edges)
+        ):
+            if not layer:
+                continue
+            bucket = _bucket_for(
+                depth_label, layer[0][1].derivation, grain, label=label
+            )
+            # Layer 0 keeps the historical (undiscriminated) group id so the
+            # single-layer case -- every query without window-over-window -- is
+            # byte-identical to the default rule.
+            _apply_grouping_mode(
+                bucket, grouping_mode, *(() if index == 0 else (f"wlayer:{index}",))
+            )
+            for node, data in layer:
+                _add_member(bucket, node, data)
+            buckets.append(bucket)
+    return buckets
+
+
 def partition_basics_by_signature(
     items: list[NodeItem],
     concept_graph: nx.DiGraph,
@@ -1203,6 +1248,7 @@ GROUPING_RULES: dict[Derivation, PartitionFn] = {
     Derivation.ROWSET: partition_rowsets,
     Derivation.AGGREGATE: partition_aggregates,
     Derivation.CONSTANT: partition_constants,
+    Derivation.WINDOW: partition_windows,
 }
 
 DEFAULT_RULE: PartitionFn = partition_by_depth_and_grain

--- a/trilogy/rendering/altair_renderer.py
+++ b/trilogy/rendering/altair_renderer.py
@@ -148,11 +148,16 @@ class AltairRenderer(BaseRenderer):
             ChartType.POINT: self._point,
             ChartType.AREA: self._area,
             ChartType.HEADLINE: self._headline,
+            ChartType.DONUT: self._donut,
+            ChartType.HEATMAP: self._heatmap,
+            ChartType.BOXPLOT: self._boxplot,
         }
         build = builders.get(layer.layer_type)
         if build is None:
+            supported = ", ".join(sorted(t.value for t in builders))
             raise NotImplementedError(
-                f"Chart type '{layer.layer_type.value}' not yet implemented"
+                f"Chart type '{layer.layer_type.value}' is not implemented in the"
+                f" Altair renderer. Supported types: {supported}."
             )
         return build(df, layer, scales)
 
@@ -228,7 +233,7 @@ class AltairRenderer(BaseRenderer):
         self,
         layer: ProcessedChartLayer,
         data: Any = None,
-        category_axis: str | None = None,
+        category_axes: tuple[str, ...] = (),
         scales: tuple[ScaleType | None, ScaleType | None] = (None, None),
     ) -> dict[str, Any]:
         # Bar order follows the query's ORDER BY when it has one; without one,
@@ -254,7 +259,7 @@ class AltairRenderer(BaseRenderer):
                 # date parts want bare integer ticks.
                 axis_kwargs["format"] = "d"
                 axis_kwargs["tickMinStep"] = 1
-            if channel == category_axis:
+            if channel in category_axes:
                 sort = None if ordered else "ascending"
                 # A bar's category axis is discrete: encode as ordinal so bars
                 # band to the step at any density. A continuous scale gives
@@ -287,7 +292,7 @@ class AltairRenderer(BaseRenderer):
             encoding["color"] = alt.Color(
                 layer.color_field,
                 title=self._field_title(layer, layer.color_field),
-                scale=self._hex_color_scale(layer, data),
+                scale=self._hex_color_scale(layer, data, layer.color_field),
             )
         if layer.size_field:
             encoding["size"] = alt.Size(
@@ -326,12 +331,14 @@ class AltairRenderer(BaseRenderer):
 
     _HEX_FALLBACK = "#999999"
 
-    def _hex_color_scale(self, layer: ProcessedChartLayer, data: Any) -> Any:
+    def _hex_color_scale(
+        self, layer: ProcessedChartLayer, data: Any, field: str | None
+    ) -> Any:
         """Explicit category→color mapping when the query outputs a `::hex`
         column alongside the color field: each color-field member maps to the
         hex code found on its rows, so authors control series colors from data.
         """
-        if layer.query is None or data is None or layer.color_field not in data:
+        if layer.query is None or data is None or field is None or field not in data:
             return alt.Undefined
         hex_field = next(
             (
@@ -344,10 +351,10 @@ class AltairRenderer(BaseRenderer):
         if hex_field is None:
             return alt.Undefined
         lookup: dict[Any, str] = {}
-        for category, hex_value in zip(data[layer.color_field], data[hex_field]):
+        for category, hex_value in zip(data[field], data[hex_field]):
             if pd.notna(hex_value):
                 lookup.setdefault(category, str(hex_value))
-        domain = sorted(data[layer.color_field].dropna().unique().tolist(), key=str)
+        domain = sorted(data[field].dropna().unique().tolist(), key=str)
         return alt.Scale(
             domain=domain,
             range=[lookup.get(category, self._HEX_FALLBACK) for category in domain],
@@ -389,9 +396,9 @@ class AltairRenderer(BaseRenderer):
     ) -> Any:
         # barh maps here too: axes are literal, so binding a quantitative field
         # to x_axis yields horizontal bars without any axis swap.
-        category_axis = "y" if layer.layer_type == ChartType.BARH else "x"
+        category_axes = ("y",) if layer.layer_type == ChartType.BARH else ("x",)
         encoding = self._encode(
-            layer, data=data, category_axis=category_axis, scales=scales
+            layer, data=data, category_axes=category_axes, scales=scales
         )
         chart = alt.Chart(data).mark_bar().encode(**encoding)
         return self._with_annotation(chart, data, layer, encoding)
@@ -449,6 +456,97 @@ class AltairRenderer(BaseRenderer):
         encoding = self._encode(layer, data=data, scales=scales)
         chart = alt.Chart(data).mark_area().encode(order=order, **encoding)
         return self._with_annotation(chart, data, layer, encoding)
+
+    @staticmethod
+    def _reject_annotation(layer: ProcessedChartLayer) -> None:
+        if layer.annotation_field:
+            raise ValueError(
+                "The 'annotation' role is not supported on"
+                f" {layer.layer_type.value} layers; the mark has no per-row"
+                " position to hang a label on."
+            )
+
+    def _donut_fields(self, layer: ProcessedChartLayer) -> tuple[str, str]:
+        """(angle, slice) fields. The numeric binding sizes the slices; the
+        other positional binding - or `color` - names them, so both the
+        bar-shaped and the color-shaped spelling of a donut work."""
+        positional = [
+            fields[0] for fields in (layer.y_fields, layer.x_fields) if fields
+        ]
+        angle = next(
+            (f for f in positional if self._field_type(layer, f) == "quantitative"),
+            None,
+        )
+        if angle is None:
+            raise ValueError(
+                "A donut chart needs a numeric x_axis or y_axis binding to size"
+                " the slices."
+            )
+        slices = layer.color_field or next((f for f in positional if f != angle), None)
+        if slices is None:
+            raise ValueError(
+                "A donut chart needs a second binding - the other axis, or"
+                " `color` - to name the slices."
+            )
+        return angle, slices
+
+    def _donut(
+        self,
+        data: Any,
+        layer: ProcessedChartLayer,
+        scales: tuple[ScaleType | None, ScaleType | None] = (None, None),
+    ) -> Any:
+        """Arc chart. `set scale_x|scale_y` does not apply - an angle has no
+        axis to rescale."""
+        self._reject_annotation(layer)
+        angle, slices = self._donut_fields(layer)
+        return (
+            alt.Chart(data)
+            .mark_arc(innerRadius=50, outerRadius=120, strokeWidth=2)
+            .encode(
+                theta=alt.Theta(
+                    angle, type="quantitative", title=self._field_title(layer, angle)
+                ),
+                color=alt.Color(
+                    slices,
+                    type="nominal",
+                    title=self._field_title(layer, slices),
+                    scale=self._hex_color_scale(layer, data, slices),
+                ),
+                order=alt.Order(angle, sort="descending"),
+            )
+        )
+
+    def _heatmap(
+        self,
+        data: Any,
+        layer: ProcessedChartLayer,
+        scales: tuple[ScaleType | None, ScaleType | None] = (None, None),
+    ) -> Any:
+        """Rect grid: BOTH axes are discrete and `color` carries the measure."""
+        if not layer.color_field:
+            raise ValueError(
+                "A heatmap needs a `color` binding for the measure that fills"
+                " each cell."
+            )
+        encoding = self._encode(
+            layer, data=data, category_axes=("x", "y"), scales=scales
+        )
+        chart = alt.Chart(data).mark_rect().encode(**encoding)
+        return self._with_annotation(chart, data, layer, encoding)
+
+    def _boxplot(
+        self,
+        data: Any,
+        layer: ProcessedChartLayer,
+        scales: tuple[ScaleType | None, ScaleType | None] = (None, None),
+    ) -> Any:
+        """Distribution of the value axis per category. The layer's select has
+        to carry the fact's row grain (hidden with `--`) or output dedup
+        collapses the very duplicates the box summarizes."""
+        self._reject_annotation(layer)
+        encoding = self._encode(layer, data=data, category_axes=("x",), scales=scales)
+        return alt.Chart(data).mark_boxplot().encode(**encoding)
 
     def _headline(
         self,

--- a/trilogy/rendering/terminal_renderer.py
+++ b/trilogy/rendering/terminal_renderer.py
@@ -78,8 +78,10 @@ class TerminalRenderer(BaseRenderer):
         for idx, (layer, data) in enumerate(layers):
             build = builders.get(layer.layer_type)
             if build is None:
+                supported = ", ".join(sorted(t.value for t in builders))
                 return (
-                    f"Chart type '{layer.layer_type.value}' not supported in terminal"
+                    f"Chart type '{layer.layer_type.value}' is not supported in the"
+                    f" terminal renderer. Supported types: {supported}."
                 )
             if use_subplots:
                 plt.subplot(idx + 1, 1)

--- a/trilogy/scripts/agent_info_docs/content.py
+++ b/trilogy/scripts/agent_info_docs/content.py
@@ -833,7 +833,11 @@ chart
 ```
 
 - **Chart types**: `bar`, `barh` (horizontal), `line`, `point`, `area`,
-  `headline` (big KPI number; binds `x_axis` only).
+  `headline` (big KPI number; binds `x_axis` only), `donut` (the numeric
+  binding sizes the slices, the other one - or `color` - names them),
+  `heatmap` (both axes categorical, `color` carries the measure), `boxplot`
+  (distribution of the value axis per category; the select must carry the row
+  grain or dedup collapses it). `treemap` parses but has no renderer.
 - **Roles**: `x_axis`, `y_axis`, `color`, `size` (point size), `group`
   (side-by-side bars, or per-series split on line/point/area), `x_trellis` /
   `y_trellis` (small-multiple columns/rows), `annotation` (text label per

--- a/trilogy/scripts/dependency/Cargo.toml
+++ b/trilogy/scripts/dependency/Cargo.toml
@@ -4,7 +4,7 @@ name = "trilogy-parser"
 # crates.io releases ride the same stream (see pythonpublish.yml), so a
 # published crate version always corresponds to the pytrilogy release
 # whose grammar it carries.
-version = "0.3.336"
+version = "0.3.337"
 edition = "2021"
 description = "Parser and import/datasource dependency resolver for the Trilogy language"
 license = "MIT"


### PR DESCRIPTION
## Window-over-window CTE split (bug)

A window whose partition/order lineage reads a **sibling window at the same grain** was bucketed into a single node by the default depth+grain partition rule, so the renderer emitted a window function inside another window's `OVER` clause:

```sql
sum(x) over (order by rank() over (order by ...) asc)
```

Every engine rejects this — on DuckDB: `Parser Error: window functions are not allowed in window definitions`.

Minimal reproducer (a cumulative share ordered by a dominance rank):

```
auto dominance_rank <- rank(species) over (order by count(tree_id) by species desc, species asc);
auto cumulative <- (sum count(tree_id) by species order by dominance_rank asc);

select species, dominance_rank, cumulative;
```

**Regressed in 0.3.316** (`[Feat]: V4 As Engine Default (#602)`); bisected against PyPI releases — 0.3.305–0.3.315 planned the two windows as separate CTEs and returned rows, 0.3.316–0.3.336 fail to parse.

### Root cause

`GROUPING_RULES` gave `AGGREGATE` a producer/consumer split (`_aggregate_lineage_layers`) so one CTE never both computes and consumes a value. `WINDOW` had no entry and fell through to `DEFAULT_RULE` (`partition_by_depth_and_grain`), which buckets on `(label, depth, grain, grouping_mode)` alone.

### Fix

Adds `partition_windows`, reusing that layering — generalized as `_lineage_layers`. Layer 0 keeps the undiscriminated group id, so any query **without** window-over-window generates byte-identical SQL to before.

### Validation

- Full suite green: **8,427 passed, 0 failures** (excluding `adventureworks_execution` and the network-dependent `test_clickhouse_server`), including all 423 TPC-DS / TPC-H / thelook benchmark rows.
- New regression test `tests/test_window_over_window_cte_split.py` asserts both the CTE split and the executed rows.
- Audited every other derivation on `DEFAULT_RULE` for the same hazard and probed the reachable ones — `group_to` chains, nested `unnest`, window→BASIC→window, three-deep window chains, `partition by` a sibling window, `lag()` ordered by a sibling window, and an aggregate filtered on a window output all produce correct values. `union`/`tvf_union`/`multiselect`/`recursive`/`subselect` are structurally one node each.

## Also included

`chart_fixes` — altair/terminal renderer fixes, chart-type rendering coverage, and agent syntax examples.

## Version

`0.3.336` → `0.3.337` (Python + both `Cargo.toml`s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUxTJRYB8UVLaeWWAfvrK5
