### PR TITLE
[Bug] Custom function imports: namespace to a copy, never in place

### DIFF
--- a/crates/trilogy-io/Cargo.toml
+++ b/crates/trilogy-io/Cargo.toml
@@ -2,7 +2,7 @@
 name = "trilogy-io"
 # Synced from the python __init__ by the same release flow as trilogy-parser;
 # a published crate version always corresponds to a real pytrilogy release.
-version = "0.3.337"
+version = "0.3.338"
 edition = "2021"
 description = "Write a program that is a Trilogy data source: Arrow out, contract flags in."
 license = "MIT"

--- a/tests/parsing/test_custom_function_namespace_isolation.py
+++ b/tests/parsing/test_custom_function_namespace_isolation.py
@@ -1,0 +1,88 @@
+"""An import must not rewrite the source environment's custom functions.
+
+A parsed import environment is shared - process-wide by the import store, and
+object-for-object with its importer on a bare ``import x;`` - so the factory an
+aliased import namespaces is the same object the next edge namespaces. Mutating
+it re-prefixed the previous edge's work until the accumulated address resolved
+to nothing (``Undefined concept: launch.launch....manufacturer.col``).
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from trilogy import Environment, parse
+from trilogy.parsing.v2 import import_service as isvc
+
+ROOT_TEXT = "import mid as one;\nimport mid as two;\nimport leaf as direct;\n"
+
+
+@pytest.fixture(autouse=True)
+def clean_store():
+    isvc.clear_import_env_store()
+    yield
+    isvc.clear_import_env_store()
+
+
+@pytest.fixture
+def diamond(tmp_path: Path) -> Path:
+    """helper is reached under four aliases through two levels of nesting."""
+    (tmp_path / "helper.preql").write_text("def double(col) -> col * 2;\n")
+    (tmp_path / "leaf.preql").write_text(
+        "import helper;\nkey id int;\nproperty id.doubled <- @double(id);\n"
+    )
+    (tmp_path / "mid.preql").write_text(
+        "import helper;\nimport leaf as left;\nimport leaf as right;\n"
+    )
+    return tmp_path
+
+
+def _arg_names(env: Environment) -> dict[str, list[str]]:
+    return {
+        key: [arg.name for arg in factory.function_arguments]
+        for key, factory in env.functions.items()
+    }
+
+
+def _parse_root(model_dir: Path) -> dict[str, list[str]]:
+    env = Environment(working_path=str(model_dir))
+    parse(ROOT_TEXT, env)
+    return _arg_names(env)
+
+
+def test_with_namespace_returns_a_copy():
+    env = Environment()
+    parse("key x int;\ndef double(col) -> col * 2;", env)
+    source = env.functions["double"]
+
+    first = source.with_namespace("a")
+    assert first is not source
+    assert [arg.name for arg in source.function_arguments] == ["col"]
+    assert [arg.name for arg in first.function_arguments] == ["a.col"]
+
+    second = source.with_namespace("b")
+    assert [arg.name for arg in second.function_arguments] == ["b.col"]
+    assert [arg.name for arg in first.function_arguments] == ["a.col"]
+    assert [arg.name for arg in source.function_arguments] == ["col"]
+
+
+def test_argument_addresses_match_the_import_depth(diamond: Path):
+    for key, args in _parse_root(diamond).items():
+        for arg in args:
+            assert arg.count(".") <= key.count("."), (key, arg)
+
+
+def test_concurrent_parses_match_a_sequential_parse(diamond: Path):
+    """The directory runner parses models in a thread pool against the shared
+    import store; a mutating with_namespace tore between body and arguments."""
+    expected = _parse_root(diamond)
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        results = list(pool.map(_parse_root, [diamond] * 8))
+    assert all(result == expected for result in results)
+
+
+def test_custom_function_resolves_through_nested_aliases(diamond: Path):
+    env = Environment(working_path=str(diamond))
+    parse(ROOT_TEXT, env)
+    assert env.concepts["one.left.doubled"].lineage is not None

--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from trilogy.executor import Executor
     from trilogy.parser import parse
 
-__version__ = "0.3.337"
+__version__ = "0.3.338"
 
 __all__ = [
     "CONFIG",

--- a/trilogy/core/models/author.py
+++ b/trilogy/core/models/author.py
@@ -3292,17 +3292,21 @@ class CustomFunctionFactory:
         self.function_arguments = function_arguments
         self.name = name
 
-    def with_namespace(self, namespace: str):
-        self.namespace = namespace
-        self.function = (
-            self.function.with_namespace(namespace)
-            if isinstance(self.function, Namespaced)
-            else self.function
+    def with_namespace(self, namespace: str) -> CustomFunctionFactory:
+        # Copy, never mutate: the source environment is shared across import
+        # edges, so rewriting in place re-prefixes arguments once per edge.
+        return CustomFunctionFactory(
+            function=(
+                self.function.with_namespace(namespace)
+                if isinstance(self.function, Namespaced)
+                else self.function
+            ),
+            namespace=namespace,
+            function_arguments=[
+                x.with_namespace(namespace) for x in self.function_arguments
+            ],
+            name=self.name,
         )
-        self.function_arguments = [
-            x.with_namespace(namespace) for x in self.function_arguments
-        ]
-        return self
 
     def to_dict(self) -> dict:
         from pydantic import TypeAdapter

--- a/trilogy/scripts/dependency/Cargo.toml
+++ b/trilogy/scripts/dependency/Cargo.toml
@@ -4,7 +4,7 @@ name = "trilogy-parser"
 # crates.io releases ride the same stream (see pythonpublish.yml), so a
 # published crate version always corresponds to the pytrilogy release
 # whose grammar it carries.
-version = "0.3.337"
+version = "0.3.338"
 edition = "2021"
 description = "Parser and import/datasource dependency resolver for the Trilogy language"
 license = "MIT"


### PR DESCRIPTION
`CustomFunctionFactory.with_namespace` rewrote the factory it was called on. A parsed import environment is shared — process-wide by the import store, and object-for-object with its importer on a bare `import x;` — so the factory an aliased import namespaces is the same object the next edge namespaces. Each edge re-prefixed the previous edge's work: an argument declared `col` became `direct.two.two.one.one.right.left.col`, growing with the size of the import graph.

The accumulation alone was survivable, because body references and argument bindings accumulated together and still matched at substitution time. It turned fatal under the directory runner's thread pool: `with_namespace` wrote `self.function` and `self.function_arguments` in two separate statements, so a thread invoking `@fn(...)` in between deep-copied a body one level deeper than the names it matched against. Substitution silently no-opped and the accumulated reference survived into concept lineage, failing as `Undefined concept: launch.launch....manufacturer.col` — intermittently, depending on interleaving.

Returns a new factory instead. Argument addresses now equal the real import nesting and are byte-identical across repeated and threaded parses.

### Coverage
`tests/parsing/test_custom_function_namespace_isolation.py`, over a diamond import graph (`helper` reached under four aliases through two levels of nesting):
- `with_namespace` returns a copy and leaves the source untouched across two edges
- argument addresses are no deeper than the function's own key — pre-fix this was `direct.two.two.two.one.one.one.right.left.col` for `one.double`
- four-thread concurrent parses match a sequential parse
- a custom-function-derived concept still resolves through nested aliases

The first two fail on the pre-fix code; all four pass after.

### Release
Version bumped 0.3.337 → 0.3.338 so prod can move off the 0.3.335 pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7htrxYbRdFZqyn459pRrJ