### PR TITLE
[FEAT] Run outputs + declared `[dependencies]` with a `when` condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,12 +423,13 @@ runs *because* another one failed:
 ```
 
 `when` is `completed` (the default, and the derived-edge rule), `failed`, or
-`always`. A `failed` script stands down as a successful skip when its
-upstreams held, so the run stays green; it runs when one of them broke, and
-anything it hands back — a `call`ed program printing
-`::trilogy-output name=fix_pr value=https://…` — is listed under Outputs
-after the summary and recorded in the `--report-file` report. Paths are
-relative to the toml, and naming a script the run does not manage is an error.
+`always`. A `failed` script stands down as a successful skip when its upstreams
+held, so the run stays green — and anything downstream of it stands down the
+same way, since the script it was waiting on never ran. It runs when one of
+them broke, and anything it hands back — a `call`ed program printing
+`::trilogy-output name=fix_pr value=https://…` — is listed under Outputs after
+the summary and recorded in the `--report-file` report. Paths are relative to
+the toml, and naming a script the run does not manage is an error.
 
 ## More Resources
 

--- a/README.md
+++ b/README.md
@@ -410,6 +410,26 @@ stubs out that dialect's connection parameters in `[engine.config]`. Init
 refuses to run over an existing `trilogy.toml`; `--force` overwrites it and
 leaves every other file untouched.
 
+### Declared dependencies
+
+Directory runs (`trilogy run .`) order scripts by what they import, declare
+and persist, and a script whose upstream failed is skipped. A `[dependencies]`
+table declares the one kind of edge content cannot express — a script that
+runs *because* another one failed:
+
+```toml
+[dependencies]
+"repair.preql" = { after = ["refresh.preql"], when = "failed" }
+```
+
+`when` is `completed` (the default, and the derived-edge rule), `failed`, or
+`always`. A `failed` script stands down as a successful skip when its
+upstreams held, so the run stays green; it runs when one of them broke, and
+anything it hands back — a `call`ed program printing
+`::trilogy-output name=fix_pr value=https://…` — is listed under Outputs
+after the summary and recorded in the `--report-file` report. Paths are
+relative to the toml, and naming a script the run does not manage is an error.
+
 ## More Resources
 
 - [Interactive demo](https://trilogydata.dev/demo/)

--- a/tests/execution/test_run_outputs.py
+++ b/tests/execution/test_run_outputs.py
@@ -1,0 +1,174 @@
+"""Run outputs: ``::trilogy-output`` markers on a called program's stdout become
+``output`` report records and a summary section (``trilogy.execution.outputs``)."""
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from tests.scripts.test_json_output import events_of, parse_events
+from trilogy import Dialects, Environment
+from trilogy.execution.outputs import (
+    RunOutput,
+    collected_outputs,
+    parse_output_line,
+    record_outputs,
+    reset_outputs,
+    scan_outputs,
+)
+from trilogy.execution.report import ReportSink, set_report_sink
+from trilogy.scripts.trilogy import cli
+
+PR_URL = "https://github.com/o/r/pull/45?tab=files&x=1"
+
+
+@pytest.fixture(autouse=True)
+def _clean_outputs():
+    reset_outputs()
+    yield
+    reset_outputs()
+    from trilogy.scripts import display_core
+
+    display_core.set_output_format("rich")
+
+
+def test_parse_link_defaults_kind_and_keeps_value_verbatim():
+    out = parse_output_line(f"::trilogy-output name=fix_pr value={PR_URL}")
+    assert out == RunOutput("fix_pr", PR_URL, "link")
+
+
+def test_parse_text_default_and_explicit_kind():
+    assert parse_output_line("::trilogy-output name=note value=hello world") == (
+        RunOutput("note", "hello world", "text")
+    )
+    assert parse_output_line(
+        f"::trilogy-output kind=text name=raw value={PR_URL}"
+    ) == RunOutput("raw", PR_URL, "text")
+
+
+def test_parse_json_kind():
+    out = parse_output_line('::trilogy-output name=stats kind=json value={"rows": 3}')
+    assert out == RunOutput("stats", {"rows": 3}, "json")
+    degraded = parse_output_line("::trilogy-output name=stats kind=json value={oops")
+    assert degraded == RunOutput("stats", "{oops", "text")
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "plain stdout line",
+        "::trilogy-output name=no_value",
+        "::trilogy-output value=no name",
+        "::trilogy-output name=1bad value=x",
+        "::trilogy-output name=ok color=red value=x",
+        "::trilogy-output name=ok kind=blob value=x",
+    ],
+)
+def test_parse_rejects(line: str):
+    assert parse_output_line(line) is None
+
+
+def test_scan_outputs_keeps_order_and_source():
+    text = (
+        "starting\n"
+        "::trilogy-output name=a value=1\n"
+        "noise\n"
+        "  ::trilogy-output name=b value=2  \n"
+    )
+    assert scan_outputs(text, source="./x.py") == [
+        RunOutput("a", "1", "text", "./x.py"),
+        RunOutput("b", "2", "text", "./x.py"),
+    ]
+
+
+def test_record_outputs_emits_report_records(tmp_path: Path):
+    report = tmp_path / "report.jsonl"
+    set_report_sink(ReportSink(report, "run-1", "run"))
+    try:
+        record_outputs([RunOutput("fix_pr", PR_URL, "link", "./repair.py")])
+    finally:
+        set_report_sink(None)
+    records = [json.loads(line) for line in report.read_text().splitlines()]
+    assert len(records) == 1
+    assert records[0]["type"] == "output"
+    assert records[0]["run_id"] == "run-1"
+    assert {k: records[0][k] for k in ("name", "kind", "value", "source")} == {
+        "name": "fix_pr",
+        "kind": "link",
+        "value": PR_URL,
+        "source": "./repair.py",
+    }
+    assert collected_outputs() == [RunOutput("fix_pr", PR_URL, "link", "./repair.py")]
+
+
+def _emit_script(tmp_path: Path, name: str, exit_code: int = 0) -> None:
+    (tmp_path / name).write_text(
+        "import sys\n"
+        "print('working...')\n"
+        f"print('::trilogy-output name=fix_pr value={PR_URL}')\n"
+        f"sys.exit({exit_code})\n",
+        newline="\n",
+    )
+
+
+def test_call_execution_records_outputs(tmp_path: Path):
+    _emit_script(tmp_path, "emit.py")
+    exec = Dialects.DUCK_DB.default_executor(
+        environment=Environment(working_path=tmp_path)
+    )
+    exec.execute_text("call `./emit.py`;")
+    assert collected_outputs() == [RunOutput("fix_pr", PR_URL, "link", "./emit.py")]
+
+
+def test_call_failure_keeps_outputs_it_declared(tmp_path: Path):
+    _emit_script(tmp_path, "boom.py", exit_code=2)
+    exec = Dialects.DUCK_DB.default_executor(
+        environment=Environment(working_path=tmp_path)
+    )
+    with pytest.raises(RuntimeError, match="exit 2"):
+        exec.execute_text("call `./boom.py`;")
+    assert collected_outputs() == [RunOutput("fix_pr", PR_URL, "link", "./boom.py")]
+
+
+def _call_workspace(tmp_path: Path) -> Path:
+    _emit_script(tmp_path, "emit.py")
+    script = tmp_path / "job.preql"
+    script.write_text("call `./emit.py`;\n", encoding="utf-8")
+    return script
+
+
+def test_cli_run_reports_and_prints_outputs(tmp_path: Path):
+    script = _call_workspace(tmp_path)
+    report = tmp_path / "report.jsonl"
+    result = CliRunner().invoke(
+        cli, ["run", str(script), "duck_db", "--report-file", str(report)]
+    )
+    assert result.exit_code == 0, result.output
+    records = [json.loads(line) for line in report.read_text().splitlines()]
+    outputs = [r for r in records if r["type"] == "output"]
+    assert [(o["name"], o["kind"], o["value"]) for o in outputs] == [
+        ("fix_pr", "link", PR_URL)
+    ]
+    assert records[-1]["type"] == "summary"
+    assert f"Output fix_pr (link): {PR_URL}" in result.output
+
+
+def test_cli_run_json_mode_emits_outputs_event(tmp_path: Path):
+    script = _call_workspace(tmp_path)
+    result = CliRunner().invoke(
+        cli, ["run", str(script), "duck_db", "--format", "json"]
+    )
+    assert result.exit_code == 0, result.output
+    events = events_of(parse_events(result.output), "outputs")
+    assert len(events) == 1
+    assert events[0]["outputs"] == [
+        {"name": "fix_pr", "kind": "link", "value": PR_URL, "source": "./emit.py"}
+    ]
+
+
+def test_cli_run_directory_prints_outputs(tmp_path: Path):
+    _call_workspace(tmp_path)
+    result = CliRunner().invoke(cli, ["run", str(tmp_path), "duck_db"])
+    assert result.exit_code == 0, result.output
+    assert "fix_pr" in result.output

--- a/tests/execution/test_run_outputs.py
+++ b/tests/execution/test_run_outputs.py
@@ -2,6 +2,7 @@
 ``output`` report records and a summary section (``trilogy.execution.outputs``)."""
 
 import json
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -18,6 +19,8 @@ from trilogy.execution.outputs import (
     scan_outputs,
 )
 from trilogy.execution.report import ReportSink, set_report_sink
+from trilogy.scripts import display_core
+from trilogy.scripts.display import show_run_outputs
 from trilogy.scripts.trilogy import cli
 
 PR_URL = "https://github.com/o/r/pull/45?tab=files&x=1"
@@ -31,6 +34,31 @@ def _clean_outputs():
     from trilogy.scripts import display_core
 
     display_core.set_output_format("rich")
+
+
+#: CI runs the CLI suites twice, with and without ``rich`` installed, and the
+#: two renderings are different code paths. Tests that check what a run printed
+#: pin the mode explicitly and assert the rendering that mode produces, so one
+#: run covers both.
+rich_modes = pytest.mark.parametrize("rich", [True, False], ids=["rich", "plain"])
+
+
+def assert_output_listed(
+    printed: str, name: str, kind: str, value: str, rich: bool
+) -> None:
+    if rich:
+        assert "Outputs" in printed
+        assert name in printed and kind in printed
+    else:
+        assert f"Output {name} ({kind}): {value}" in printed
+
+
+@contextmanager
+def rich_mode(enabled: bool):
+    if enabled and not display_core.RICH_AVAILABLE:
+        pytest.skip("rich not installed")
+    with display_core.set_rich_mode(enabled):
+        yield
 
 
 def test_parse_link_defaults_kind_and_keeps_value_verbatim():
@@ -138,12 +166,14 @@ def _call_workspace(tmp_path: Path) -> Path:
     return script
 
 
-def test_cli_run_reports_and_prints_outputs(tmp_path: Path):
+@rich_modes
+def test_cli_run_reports_and_prints_outputs(tmp_path: Path, rich: bool):
     script = _call_workspace(tmp_path)
     report = tmp_path / "report.jsonl"
-    result = CliRunner().invoke(
-        cli, ["run", str(script), "duck_db", "--report-file", str(report)]
-    )
+    with rich_mode(rich):
+        result = CliRunner().invoke(
+            cli, ["run", str(script), "duck_db", "--report-file", str(report)]
+        )
     assert result.exit_code == 0, result.output
     records = [json.loads(line) for line in report.read_text().splitlines()]
     outputs = [r for r in records if r["type"] == "output"]
@@ -151,7 +181,7 @@ def test_cli_run_reports_and_prints_outputs(tmp_path: Path):
         ("fix_pr", "link", PR_URL)
     ]
     assert records[-1]["type"] == "summary"
-    assert f"Output fix_pr (link): {PR_URL}" in result.output
+    assert_output_listed(result.output, "fix_pr", "link", PR_URL, rich)
 
 
 def test_cli_run_json_mode_emits_outputs_event(tmp_path: Path):
@@ -167,8 +197,24 @@ def test_cli_run_json_mode_emits_outputs_event(tmp_path: Path):
     ]
 
 
-def test_cli_run_directory_prints_outputs(tmp_path: Path):
+@rich_modes
+def test_show_run_outputs_renders_in_both_modes(rich: bool, capsys):
+    with rich_mode(rich):
+        show_run_outputs([RunOutput("fix_pr", PR_URL, "link", "./emit.py")])
+    assert_output_listed(capsys.readouterr().out, "fix_pr", "link", PR_URL, rich)
+
+
+@rich_modes
+def test_show_run_outputs_says_nothing_when_there_are_none(rich: bool, capsys):
+    with rich_mode(rich):
+        show_run_outputs([])
+    assert capsys.readouterr().out == ""
+
+
+@rich_modes
+def test_cli_run_directory_prints_outputs(tmp_path: Path, rich: bool):
     _call_workspace(tmp_path)
-    result = CliRunner().invoke(cli, ["run", str(tmp_path), "duck_db"])
+    with rich_mode(rich):
+        result = CliRunner().invoke(cli, ["run", str(tmp_path), "duck_db"])
     assert result.exit_code == 0, result.output
-    assert "fix_pr" in result.output
+    assert_output_listed(result.output, "fix_pr", "link", PR_URL, rich)

--- a/tests/scripts/test_declared_dependencies.py
+++ b/tests/scripts/test_declared_dependencies.py
@@ -12,6 +12,11 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
+from tests.execution.test_run_outputs import (
+    assert_output_listed,
+    rich_mode,
+    rich_modes,
+)
 from trilogy.core import graph as nx
 from trilogy.scripts.dependency import (
     DependencyResolver,
@@ -20,6 +25,7 @@ from trilogy.scripts.dependency import (
 )
 from trilogy.scripts.parallel_execution import (
     ExecutionResult,
+    RunState,
     _mark_node_complete,
 )
 from trilogy.scripts.project_config import (
@@ -161,12 +167,14 @@ def test_declared_cycle_is_refused(tmp_path: Path):
 # Scheduling
 # ---------------------------------------------------------------------------
 
-A, B, REPAIR = (str(Path(f"/scripts/{n}.preql")) for n in ("a", "b", "repair"))
+A, B, REPAIR, NOTIFY = (
+    str(Path(f"/scripts/{n}.preql")) for n in ("a", "b", "repair", "notify")
+)
 
 
 def _graph(edges: list[tuple[str, str, str | None]]) -> nx.DiGraph:
+    """Only the nodes the edges name, so `ready` reads as what this graph released."""
     graph = nx.DiGraph()
-    graph.add_nodes_from([A, B, REPAIR])
     for upstream, dependent, when in edges:
         graph.add_edge(upstream, dependent)
         if when:
@@ -174,91 +182,97 @@ def _graph(edges: list[tuple[str, str, str | None]]) -> nx.DiGraph:
     return graph
 
 
-class _Run:
-    """The scheduler's state for one run, so a test reads as a sequence of
-    outcomes rather than a dozen positional arguments."""
+def _finish(state: RunState, node: str, success: bool) -> None:
+    """Claim `node` off the ready queue and complete it, as a worker would."""
+    if node in state.ready:
+        state.ready.remove(node)
+    state.in_progress.add(node)
+    _mark_node_complete(state, node, success, None)
 
-    def __init__(self, graph: nx.DiGraph) -> None:
-        self.graph = graph
-        self.node_map = {k: ScriptNode(path=Path(k)) for k in graph.nodes()}
-        self.completed: set[str] = set()
-        self.failed: set[str] = set()
-        self.in_progress: set[str] = set()
-        self.remaining = {k: graph.in_degree(k) for k in graph.nodes()}
-        self.ready: list[str] = []
-        self.results: list[ExecutionResult] = []
-        self.triggered: set[str] = set()
 
-    def finish(self, node: str, success: bool) -> None:
-        self.in_progress.add(node)
-        _mark_node_complete(
-            node,
-            success,
-            self.graph,
-            self.node_map,
-            self.completed,
-            self.failed,
-            self.in_progress,
-            self.remaining,
-            self.ready,
-            self.results,
-            None,
-            self.triggered,
-        )
-
-    def result_for(self, node: str) -> ExecutionResult:
-        return next(r for r in self.results if str(r.node.path) == node)
+def _result_for(state: RunState, node: str) -> ExecutionResult:
+    return next(r for r in state.results if str(r.node.path) == node)
 
 
 def test_repair_runs_when_its_upstream_fails():
-    run = _Run(_graph([(A, REPAIR, "failed")]))
-    run.finish(A, success=False)
-    assert run.ready == [REPAIR]
-    assert run.results == []
+    state = RunState.for_graph(_graph([(A, REPAIR, "failed")]))
+    _finish(state, A, success=False)
+    assert state.ready == [REPAIR]
+    assert state.results == []
 
 
 def test_repair_stands_down_when_its_upstream_succeeds():
-    run = _Run(_graph([(A, REPAIR, "failed")]))
-    run.finish(A, success=True)
-    assert run.ready == []
-    result = run.result_for(REPAIR)
+    state = RunState.for_graph(_graph([(A, REPAIR, "failed")]))
+    _finish(state, A, success=True)
+    assert state.ready == []
+    result = _result_for(state, REPAIR)
     assert result.success and result.skipped
     assert "a.preql did not fail" in str(result.error)
-    assert REPAIR in run.completed and REPAIR not in run.failed
+    assert REPAIR in state.completed and REPAIR not in state.failed
 
 
 def test_always_runs_either_way():
     for success in (True, False):
-        run = _Run(_graph([(A, REPAIR, "always")]))
-        run.finish(A, success=success)
-        assert run.ready == [REPAIR]
+        state = RunState.for_graph(_graph([(A, REPAIR, "always")]))
+        _finish(state, A, success=success)
+        assert state.ready == [REPAIR]
 
 
 def test_derived_edge_still_skips_on_failure():
-    run = _Run(_graph([(A, B, None)]))
-    run.finish(A, success=False)
-    result = run.result_for(B)
+    state = RunState.for_graph(_graph([(A, B, None)]))
+    _finish(state, A, success=False)
+    result = _result_for(state, B)
     assert not result.success and result.skipped
-    assert B in run.failed
+    assert B in state.failed
 
 
 def test_a_dependency_skip_is_not_a_failure():
     # a -> b (derived), b -> repair (when=failed). a fails, so b is skipped —
     # but b did not *fail*, so the repair for b has nothing to repair.
-    run = _Run(_graph([(A, B, None), (B, REPAIR, "failed")]))
-    run.finish(A, success=False)
-    assert run.ready == []
-    assert not run.result_for(B).success
-    repair = run.result_for(REPAIR)
+    state = RunState.for_graph(_graph([(A, B, None), (B, REPAIR, "failed")]))
+    _finish(state, A, success=False)
+    assert state.ready == []
+    assert not _result_for(state, B).success
+    repair = _result_for(state, REPAIR)
     assert repair.success and repair.skipped
 
 
+def test_a_stood_down_repair_does_not_release_its_downstream():
+    # notify exists to announce the repair. The repair never ran, so there is
+    # nothing to announce — and nothing failed either, so the skip is green.
+    state = RunState.for_graph(_graph([(A, REPAIR, "failed"), (REPAIR, NOTIFY, None)]))
+    _finish(state, A, success=True)
+    assert state.ready == []
+    notify = _result_for(state, NOTIFY)
+    assert notify.success and notify.skipped
+    assert "repair.preql stood down" in str(notify.error)
+    assert NOTIFY not in state.failed
+
+
+def test_a_repair_that_fired_releases_its_downstream():
+    state = RunState.for_graph(_graph([(A, REPAIR, "failed"), (REPAIR, NOTIFY, None)]))
+    _finish(state, A, success=False)
+    assert state.ready == [REPAIR]
+    _finish(state, REPAIR, success=True)
+    assert state.ready == [NOTIFY]
+
+
+def test_a_repair_that_fired_and_broke_skips_its_downstream_red():
+    state = RunState.for_graph(_graph([(A, REPAIR, "failed"), (REPAIR, NOTIFY, None)]))
+    _finish(state, A, success=False)
+    _finish(state, REPAIR, success=False)
+    assert state.ready == []
+    notify = _result_for(state, NOTIFY)
+    assert not notify.success and notify.skipped
+    assert NOTIFY in state.failed
+
+
 def test_repair_waits_for_every_upstream():
-    run = _Run(_graph([(A, REPAIR, "failed"), (B, REPAIR, "failed")]))
-    run.finish(A, success=False)
-    assert run.ready == []  # b still running
-    run.finish(B, success=True)
-    assert run.ready == [REPAIR]
+    state = RunState.for_graph(_graph([(A, REPAIR, "failed"), (B, REPAIR, "failed")]))
+    _finish(state, A, success=False)
+    assert REPAIR not in state.ready  # b still running
+    _finish(state, B, success=True)
+    assert state.ready == [REPAIR]
 
 
 # ---------------------------------------------------------------------------
@@ -306,12 +320,14 @@ def _file_end(records: list[dict], name: str) -> dict:
     )
 
 
-def test_run_directory_fires_the_repair_on_failure(tmp_path: Path):
+@rich_modes
+def test_run_directory_fires_the_repair_on_failure(tmp_path: Path, rich: bool):
     _repair_workspace(tmp_path, BROKEN)
     report = tmp_path / "report.jsonl"
-    result = CliRunner().invoke(
-        cli, ["run", str(tmp_path), "duck_db", "--report-file", str(report)]
-    )
+    with rich_mode(rich):
+        result = CliRunner().invoke(
+            cli, ["run", str(tmp_path), "duck_db", "--report-file", str(report)]
+        )
     # The upstream failed, so the run is red — but the repair ran and reported.
     assert result.exit_code == 1, result.output
     records = _records(report)
@@ -323,7 +339,7 @@ def test_run_directory_fires_the_repair_on_failure(tmp_path: Path):
     summary = records[-1]
     assert summary["type"] == "summary"
     assert (summary["succeeded"], summary["failed"], summary["skipped"]) == (1, 1, 0)
-    assert f"Output fix_pr (link): {PR_URL}" in result.output
+    assert_output_listed(result.output, "fix_pr", "link", PR_URL, rich)
 
 
 def test_run_directory_stands_the_repair_down_on_success(tmp_path: Path):

--- a/tests/scripts/test_declared_dependencies.py
+++ b/tests/scripts/test_declared_dependencies.py
@@ -1,0 +1,343 @@
+"""`[dependencies]` in trilogy.toml: declared edges with a `when` condition.
+
+Derived edges (imports, declare/persist) skip a dependent when its upstream
+fails. A declared `when = "failed"` edge is the opposite: the dependent runs
+*because* the upstream failed — a repair script — and stands down as a
+successful skip when it did not, so the run stays green.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from trilogy.core import graph as nx
+from trilogy.scripts.dependency import (
+    DependencyResolver,
+    ScriptNode,
+    edge_condition,
+)
+from trilogy.scripts.parallel_execution import (
+    ExecutionResult,
+    _mark_node_complete,
+)
+from trilogy.scripts.project_config import (
+    DeclaredDependency,
+    load_declared_dependencies,
+)
+from trilogy.scripts.trilogy import cli
+
+
+@pytest.fixture(autouse=True)
+def _reset_output_format():
+    from trilogy.scripts import display_core
+
+    yield
+    display_core.set_output_format("rich")
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+
+def _toml(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "trilogy.toml"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_load_declared_dependencies(tmp_path: Path):
+    path = _toml(
+        tmp_path,
+        "[dependencies]\n"
+        '"repair.preql" = { after = ["refresh.preql", "sub/other.preql"], when = "failed" }\n'
+        '"audit.preql" = { after = "refresh.preql" }\n',
+    )
+    assert load_declared_dependencies(path) == [
+        DeclaredDependency(
+            script=(tmp_path / "repair.preql").resolve(),
+            after=(
+                (tmp_path / "refresh.preql").resolve(),
+                (tmp_path / "sub" / "other.preql").resolve(),
+            ),
+            when="failed",
+        ),
+        DeclaredDependency(
+            script=(tmp_path / "audit.preql").resolve(),
+            after=((tmp_path / "refresh.preql").resolve(),),
+            when="completed",
+        ),
+    ]
+
+
+def test_no_section_is_no_dependencies(tmp_path: Path):
+    assert (
+        load_declared_dependencies(_toml(tmp_path, '[engine]\ndialect = "duck_db"\n'))
+        == []
+    )
+
+
+@pytest.mark.parametrize(
+    "body, error, match",
+    [
+        ('[dependencies]\n"a.preql" = ["b.preql"]\n', TypeError, "must be a table"),
+        (
+            '[dependencies]\n"a.preql" = { when = "failed" }\n',
+            ValueError,
+            "needs `after`",
+        ),
+        ('[dependencies]\n"a.preql" = { after = [] }\n', ValueError, "needs `after`"),
+        (
+            '[dependencies]\n"a.preql" = { after = ["b.preql"], when = "sometimes" }\n',
+            ValueError,
+            "must be one of",
+        ),
+        (
+            '[dependencies]\n"a.preql" = { after = ["b.preql"], on = "failed" }\n',
+            ValueError,
+            "unknown keys",
+        ),
+    ],
+)
+def test_load_rejects_malformed_entries(tmp_path: Path, body: str, error, match: str):
+    with pytest.raises(error, match=match):
+        load_declared_dependencies(_toml(tmp_path, body))
+
+
+# ---------------------------------------------------------------------------
+# Graph
+# ---------------------------------------------------------------------------
+
+
+def _scripts(tmp_path: Path, **files: str) -> dict[str, str]:
+    keys = {}
+    for name, body in files.items():
+        path = tmp_path / f"{name}.preql"
+        path.write_text(body, encoding="utf-8")
+        keys[name] = str(ScriptNode(path=path).path)
+    return keys
+
+
+def test_folder_graph_carries_declared_edges(tmp_path: Path):
+    keys = _scripts(tmp_path, a="select 1 -> x;", repair="select 2 -> y;")
+    _toml(
+        tmp_path,
+        '[dependencies]\n"repair.preql" = { after = ["a.preql"], when = "failed" }\n',
+    )
+    graph = DependencyResolver().build_folder_graph(tmp_path)
+    assert graph.has_edge(keys["a"], keys["repair"])
+    assert edge_condition(graph, keys["a"], keys["repair"]) == "failed"
+
+
+def test_derived_edges_read_as_completed(tmp_path: Path):
+    keys = _scripts(tmp_path, a="key x int;", b="import a;\nselect x;")
+    graph = DependencyResolver().build_folder_graph(tmp_path)
+    assert edge_condition(graph, keys["a"], keys["b"]) == "completed"
+
+
+def test_declared_edge_naming_an_unknown_script_is_refused(tmp_path: Path):
+    _scripts(tmp_path, a="select 1 -> x;")
+    _toml(
+        tmp_path,
+        '[dependencies]\n"repair.preql" = { after = ["a.preql"], when = "failed" }\n',
+    )
+    with pytest.raises(ValueError, match="repair.preql, which is not a script"):
+        DependencyResolver().build_folder_graph(tmp_path)
+
+
+def test_declared_cycle_is_refused(tmp_path: Path):
+    _scripts(tmp_path, a="key x int;", b="import a;\nselect x;")
+    _toml(
+        tmp_path,
+        '[dependencies]\n"a.preql" = { after = ["b.preql"], when = "always" }\n',
+    )
+    with pytest.raises(ValueError, match="Circular"):
+        DependencyResolver().build_folder_graph(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Scheduling
+# ---------------------------------------------------------------------------
+
+A, B, REPAIR = (str(Path(f"/scripts/{n}.preql")) for n in ("a", "b", "repair"))
+
+
+def _graph(edges: list[tuple[str, str, str | None]]) -> nx.DiGraph:
+    graph = nx.DiGraph()
+    graph.add_nodes_from([A, B, REPAIR])
+    for upstream, dependent, when in edges:
+        graph.add_edge(upstream, dependent)
+        if when:
+            graph.edges[(upstream, dependent)]["when"] = when
+    return graph
+
+
+class _Run:
+    """The scheduler's state for one run, so a test reads as a sequence of
+    outcomes rather than a dozen positional arguments."""
+
+    def __init__(self, graph: nx.DiGraph) -> None:
+        self.graph = graph
+        self.node_map = {k: ScriptNode(path=Path(k)) for k in graph.nodes()}
+        self.completed: set[str] = set()
+        self.failed: set[str] = set()
+        self.in_progress: set[str] = set()
+        self.remaining = {k: graph.in_degree(k) for k in graph.nodes()}
+        self.ready: list[str] = []
+        self.results: list[ExecutionResult] = []
+        self.triggered: set[str] = set()
+
+    def finish(self, node: str, success: bool) -> None:
+        self.in_progress.add(node)
+        _mark_node_complete(
+            node,
+            success,
+            self.graph,
+            self.node_map,
+            self.completed,
+            self.failed,
+            self.in_progress,
+            self.remaining,
+            self.ready,
+            self.results,
+            None,
+            self.triggered,
+        )
+
+    def result_for(self, node: str) -> ExecutionResult:
+        return next(r for r in self.results if str(r.node.path) == node)
+
+
+def test_repair_runs_when_its_upstream_fails():
+    run = _Run(_graph([(A, REPAIR, "failed")]))
+    run.finish(A, success=False)
+    assert run.ready == [REPAIR]
+    assert run.results == []
+
+
+def test_repair_stands_down_when_its_upstream_succeeds():
+    run = _Run(_graph([(A, REPAIR, "failed")]))
+    run.finish(A, success=True)
+    assert run.ready == []
+    result = run.result_for(REPAIR)
+    assert result.success and result.skipped
+    assert "a.preql did not fail" in str(result.error)
+    assert REPAIR in run.completed and REPAIR not in run.failed
+
+
+def test_always_runs_either_way():
+    for success in (True, False):
+        run = _Run(_graph([(A, REPAIR, "always")]))
+        run.finish(A, success=success)
+        assert run.ready == [REPAIR]
+
+
+def test_derived_edge_still_skips_on_failure():
+    run = _Run(_graph([(A, B, None)]))
+    run.finish(A, success=False)
+    result = run.result_for(B)
+    assert not result.success and result.skipped
+    assert B in run.failed
+
+
+def test_a_dependency_skip_is_not_a_failure():
+    # a -> b (derived), b -> repair (when=failed). a fails, so b is skipped —
+    # but b did not *fail*, so the repair for b has nothing to repair.
+    run = _Run(_graph([(A, B, None), (B, REPAIR, "failed")]))
+    run.finish(A, success=False)
+    assert run.ready == []
+    assert not run.result_for(B).success
+    repair = run.result_for(REPAIR)
+    assert repair.success and repair.skipped
+
+
+def test_repair_waits_for_every_upstream():
+    run = _Run(_graph([(A, REPAIR, "failed"), (B, REPAIR, "failed")]))
+    run.finish(A, success=False)
+    assert run.ready == []  # b still running
+    run.finish(B, success=True)
+    assert run.ready == [REPAIR]
+
+
+# ---------------------------------------------------------------------------
+# End to end
+# ---------------------------------------------------------------------------
+
+PR_URL = "https://github.com/o/r/pull/45"
+
+BROKEN = """key fid int;
+
+datasource broken (
+    fid
+)
+grain (fid)
+query '''
+select not_a_real_column as fid
+''';
+
+select fid;
+"""
+
+OK = "select 1 -> num;\n"
+
+
+def _repair_workspace(tmp_path: Path, upstream_body: str) -> None:
+    (tmp_path / "upstream.preql").write_text(upstream_body, encoding="utf-8")
+    (tmp_path / "repair.preql").write_text("call `./repair.py`;\n", encoding="utf-8")
+    (tmp_path / "repair.py").write_text(
+        f"print('::trilogy-output name=fix_pr value={PR_URL}')\n", newline="\n"
+    )
+    _toml(
+        tmp_path,
+        '[engine]\ndialect = "duck_db"\n\n'
+        '[dependencies]\n"repair.preql" = { after = ["upstream.preql"], when = "failed" }\n',
+    )
+
+
+def _records(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def _file_end(records: list[dict], name: str) -> dict:
+    return next(
+        r for r in records if r["type"] == "file_end" and Path(r["file"]).name == name
+    )
+
+
+def test_run_directory_fires_the_repair_on_failure(tmp_path: Path):
+    _repair_workspace(tmp_path, BROKEN)
+    report = tmp_path / "report.jsonl"
+    result = CliRunner().invoke(
+        cli, ["run", str(tmp_path), "duck_db", "--report-file", str(report)]
+    )
+    # The upstream failed, so the run is red — but the repair ran and reported.
+    assert result.exit_code == 1, result.output
+    records = _records(report)
+    assert _file_end(records, "upstream.preql")["success"] is False
+    repair = _file_end(records, "repair.preql")
+    assert repair["success"] is True and "skipped" not in repair
+    outputs = [r for r in records if r["type"] == "output"]
+    assert [(o["name"], o["value"]) for o in outputs] == [("fix_pr", PR_URL)]
+    summary = records[-1]
+    assert summary["type"] == "summary"
+    assert (summary["succeeded"], summary["failed"], summary["skipped"]) == (1, 1, 0)
+    assert f"Output fix_pr (link): {PR_URL}" in result.output
+
+
+def test_run_directory_stands_the_repair_down_on_success(tmp_path: Path):
+    _repair_workspace(tmp_path, OK)
+    report = tmp_path / "report.jsonl"
+    result = CliRunner().invoke(
+        cli, ["run", str(tmp_path), "duck_db", "--report-file", str(report)]
+    )
+    assert result.exit_code == 0, result.output
+    records = _records(report)
+    repair = _file_end(records, "repair.preql")
+    assert repair["success"] is True and repair["skipped"] is True
+    assert "did not fail" in repair["error"]
+    assert not [r for r in records if r["type"] == "output"]
+    summary = records[-1]
+    assert (summary["succeeded"], summary["failed"], summary["skipped"]) == (1, 0, 1)
+    assert summary["success"] is True

--- a/tests/scripts/test_parallel.py
+++ b/tests/scripts/test_parallel.py
@@ -7,22 +7,18 @@ import pytest
 from trilogy.core import graph as nx
 from trilogy.scripts.dependency import ScriptNode
 from trilogy.scripts.parallel_execution import (
+    OUTCOME_FAILED,
     ExecutionResult,
-    NodeMap,
+    RunState,
     _get_next_ready,
     _is_execution_done,
     _mark_node_complete,
-    _propagate_failure,
+    _settle_dependents,
 )
 
-# State-tracking collections are keyed by the graph's string node keys.
+# The scheduler keys its state on the graph's string node keys.
 CompletedSet = set[str]
-FailedSet = set[str]
-InProgressSet = set[str]
-ResultsList = list[ExecutionResult]
-RemainingDepsDict = dict[str, int]
 ReadyList = list[str]
-OnCompleteCallback = Any  # Callable[[ExecutionResult], None] | None
 
 
 # ============================================================================
@@ -49,11 +45,6 @@ def node_c() -> str:
 @pytest.fixture
 def node_d() -> str:
     return str(Path("/scripts/d.sql"))
-
-
-@pytest.fixture
-def node_map(node_a: str, node_b: str, node_c: str, node_d: str) -> NodeMap:
-    return {key: ScriptNode(path=Path(key)) for key in (node_a, node_b, node_c, node_d)}
 
 
 @pytest.fixture
@@ -148,184 +139,101 @@ class TestIsExecutionDone:
 
 
 # ============================================================================
-# Tests for _propagate_failure
+# Tests for _settle_dependents
 # ============================================================================
 
 
-class TestPropagateFailure:
+class TestSettleDependents:
+    """A node that did not succeed skips its unstarted dependents, recursively."""
+
     def test_marks_direct_dependent_as_failed(
-        self,
-        linear_graph: nx.DiGraph,
-        node_map: NodeMap,
-        node_a: str,
-        node_b: str,
+        self, linear_graph: nx.DiGraph, node_a: str, node_b: str
     ) -> None:
-        completed: CompletedSet = {node_a}
-        failed: FailedSet = {node_a}
-        in_progress: InProgressSet = set()
-        results: ResultsList = []
+        state = RunState.for_graph(linear_graph)
+        state.completed.add(node_a)
+        state.failed.add(node_a)
 
-        _propagate_failure(
-            node_a,
-            linear_graph,
-            node_map,
-            completed,
-            in_progress,
-            results,
-            failed,
-            None,
-        )
+        _settle_dependents(state, node_a, OUTCOME_FAILED, None)
 
-        assert node_b in completed
-        assert node_b in failed
-        assert len(results) == 2  # B and C both failed
+        assert node_b in state.completed
+        assert node_b in state.failed
+        assert len(state.results) == 2  # B and C both failed
 
     def test_recursively_marks_all_dependents(
-        self,
-        linear_graph: nx.DiGraph,
-        node_map: NodeMap,
-        node_a: str,
-        node_b: str,
-        node_c: str,
+        self, linear_graph: nx.DiGraph, node_a: str, node_b: str, node_c: str
     ) -> None:
-        completed: CompletedSet = {node_a}
-        failed: FailedSet = {node_a}
-        in_progress: InProgressSet = set()
-        results: ResultsList = []
+        state = RunState.for_graph(linear_graph)
+        state.completed.add(node_a)
+        state.failed.add(node_a)
 
-        _propagate_failure(
-            node_a,
-            linear_graph,
-            node_map,
-            completed,
-            in_progress,
-            results,
-            failed,
-            None,
-        )
+        _settle_dependents(state, node_a, OUTCOME_FAILED, None)
 
-        assert node_b in failed
-        assert node_c in failed
-        assert len(results) == 2
+        assert node_b in state.failed
+        assert node_c in state.failed
+        assert len(state.results) == 2
 
     def test_skips_already_completed_nodes(
-        self,
-        linear_graph: nx.DiGraph,
-        node_map: NodeMap,
-        node_a: str,
-        node_b: str,
-        node_c: str,
+        self, linear_graph: nx.DiGraph, node_a: str, node_b: str
     ) -> None:
-        completed: CompletedSet = {node_a, node_b}  # B already done
-        failed: FailedSet = {node_a}
-        in_progress: InProgressSet = set()
-        results: ResultsList = []
+        state = RunState.for_graph(linear_graph)
+        state.completed.update({node_a, node_b})  # B already done
+        state.failed.add(node_a)
 
-        _propagate_failure(
-            node_a,
-            linear_graph,
-            node_map,
-            completed,
-            in_progress,
-            results,
-            failed,
-            None,
-        )
+        _settle_dependents(state, node_a, OUTCOME_FAILED, None)
 
-        # B is skipped because it's already completed
-        # C is NOT marked because propagate_failure only looks at direct successors
-        # and B (the successor of A) is already completed, so recursion stops there
-        assert len(results) == 0  # No new failures - B was already done
+        # C is never reached: recursion stops at the completed B.
+        assert len(state.results) == 0
 
     def test_skips_in_progress_nodes(
-        self,
-        linear_graph: nx.DiGraph,
-        node_map: NodeMap,
-        node_a: str,
-        node_b: str,
+        self, linear_graph: nx.DiGraph, node_a: str, node_b: str
     ) -> None:
-        completed: CompletedSet = {node_a}
-        failed: FailedSet = {node_a}
-        in_progress: InProgressSet = {node_b}  # B is running
-        results: ResultsList = []
+        state = RunState.for_graph(linear_graph)
+        state.completed.add(node_a)
+        state.failed.add(node_a)
+        state.in_progress.add(node_b)  # B is running
 
-        _propagate_failure(
-            node_a,
-            linear_graph,
-            node_map,
-            completed,
-            in_progress,
-            results,
-            failed,
-            None,
-        )
+        _settle_dependents(state, node_a, OUTCOME_FAILED, None)
 
-        # B should be skipped since it's in progress
-        assert node_b not in failed
-        # C is NOT marked because B (A's successor) is in_progress,
-        # so propagation stops there and doesn't recurse
-        assert len(results) == 0
+        assert node_b not in state.failed
+        assert len(state.results) == 0
 
-    def test_calls_callback_for_each_failed_node(
-        self, linear_graph: nx.DiGraph, node_map: NodeMap, node_a: str
+    def test_calls_callback_for_each_skipped_node(
+        self, linear_graph: nx.DiGraph, node_a: str
     ) -> None:
-        completed: CompletedSet = {node_a}
-        failed: FailedSet = {node_a}
-        in_progress: InProgressSet = set()
-        results: ResultsList = []
+        state = RunState.for_graph(linear_graph)
+        state.completed.add(node_a)
+        state.failed.add(node_a)
         callback = Mock()
 
-        _propagate_failure(
-            node_a,
-            linear_graph,
-            node_map,
-            completed,
-            in_progress,
-            results,
-            failed,
-            callback,
-        )
+        _settle_dependents(state, node_a, OUTCOME_FAILED, callback)
 
         assert callback.call_count == 2  # Called for B and C
 
     def test_sets_correct_error_message(
-        self, linear_graph: nx.DiGraph, node_map: NodeMap, node_a: str
+        self, linear_graph: nx.DiGraph, node_a: str
     ) -> None:
-        completed: CompletedSet = {node_a}
-        failed: FailedSet = {node_a}
-        in_progress: InProgressSet = set()
-        results: ResultsList = []
+        state = RunState.for_graph(linear_graph)
+        state.completed.add(node_a)
+        state.failed.add(node_a)
 
-        _propagate_failure(
-            node_a,
-            linear_graph,
-            node_map,
-            completed,
-            in_progress,
-            results,
-            failed,
-            None,
-        )
+        _settle_dependents(state, node_a, OUTCOME_FAILED, None)
 
-        for result in results:
+        for result in state.results:
             assert result.success is False
             assert isinstance(result.error, RuntimeError)
             assert "Skipped due to failed dependency" in str(result.error)
             assert result.duration == 0.0
 
-    def test_handles_empty_graph(self, node_map: NodeMap, node_a: str) -> None:
+    def test_handles_node_with_no_dependents(self, node_a: str) -> None:
         graph = nx.DiGraph()
-        graph.add_node(node_a)  # No edges
-        completed: CompletedSet = {node_a}
-        failed: FailedSet = {node_a}
-        in_progress: InProgressSet = set()
-        results: ResultsList = []
+        graph.add_node(node_a)
+        state = RunState.for_graph(graph)
+        state.completed.add(node_a)
+        state.failed.add(node_a)
 
-        _propagate_failure(
-            node_a, graph, node_map, completed, in_progress, results, failed, None
-        )
+        _settle_dependents(state, node_a, OUTCOME_FAILED, None)
 
-        assert len(results) == 0  # No dependents to mark
+        assert len(state.results) == 0
 
 
 # ============================================================================
@@ -335,340 +243,129 @@ class TestPropagateFailure:
 
 class TestMarkNodeComplete:
     def test_adds_node_to_completed(
-        self,
-        node_map: NodeMap,
-        node_a: str,
-        node_b: str,
-        node_c: str,
-        linear_graph: nx.DiGraph,
+        self, linear_graph: nx.DiGraph, node_a: str
     ) -> None:
-        completed: CompletedSet = set()
-        failed: FailedSet = set()
-        in_progress: InProgressSet = {node_a}
-        remaining_deps: RemainingDepsDict = {node_a: 0, node_b: 1, node_c: 1}
-        ready: ReadyList = []
-        results: ResultsList = []
+        state = RunState.for_graph(linear_graph)
+        state.in_progress.add(node_a)
 
-        _mark_node_complete(
-            node_a,
-            True,
-            linear_graph,
-            node_map,
-            completed,
-            failed,
-            in_progress,
-            remaining_deps,
-            ready,
-            results,
-            None,
-        )
+        _mark_node_complete(state, node_a, True, None)
 
-        assert node_a in completed
+        assert node_a in state.completed
 
     def test_removes_node_from_in_progress(
-        self,
-        node_map: NodeMap,
-        node_a: str,
-        node_b: str,
-        node_c: str,
-        linear_graph: nx.DiGraph,
+        self, linear_graph: nx.DiGraph, node_a: str
     ) -> None:
-        completed: CompletedSet = set()
-        failed: FailedSet = set()
-        in_progress: InProgressSet = {node_a}
-        remaining_deps: RemainingDepsDict = {node_a: 0, node_b: 1, node_c: 1}
-        ready: ReadyList = []
-        results: ResultsList = []
+        state = RunState.for_graph(linear_graph)
+        state.in_progress.add(node_a)
 
-        _mark_node_complete(
-            node_a,
-            True,
-            linear_graph,
-            node_map,
-            completed,
-            failed,
-            in_progress,
-            remaining_deps,
-            ready,
-            results,
-            None,
-        )
+        _mark_node_complete(state, node_a, True, None)
 
-        assert node_a not in in_progress
+        assert node_a not in state.in_progress
 
     def test_adds_to_failed_on_failure(
-        self, node_map: NodeMap, node_a: str, linear_graph: nx.DiGraph
+        self, linear_graph: nx.DiGraph, node_a: str
     ) -> None:
-        completed: CompletedSet = set()
-        failed: FailedSet = set()
-        in_progress: InProgressSet = {node_a}
-        remaining_deps: RemainingDepsDict = {node_a: 0}
-        ready: ReadyList = []
-        results: ResultsList = []
+        state = RunState.for_graph(linear_graph)
+        state.in_progress.add(node_a)
 
-        _mark_node_complete(
-            node_a,
-            False,  # Failed
-            linear_graph,
-            node_map,
-            completed,
-            failed,
-            in_progress,
-            remaining_deps,
-            ready,
-            results,
-            None,
-        )
+        _mark_node_complete(state, node_a, False, None)
 
-        assert node_a in failed
+        assert node_a in state.failed
 
     def test_decrements_dependent_remaining_deps(
-        self,
-        linear_graph: nx.DiGraph,
-        node_map: NodeMap,
-        node_a: str,
-        node_b: str,
-        node_c: str,
+        self, linear_graph: nx.DiGraph, node_a: str, node_b: str
     ) -> None:
-        completed: CompletedSet = set()
-        failed: FailedSet = set()
-        in_progress: InProgressSet = {node_a}
-        remaining_deps: RemainingDepsDict = {node_a: 0, node_b: 1, node_c: 1}
-        ready: ReadyList = []
-        results: ResultsList = []
+        state = RunState.for_graph(linear_graph)
+        state.in_progress.add(node_a)
 
-        _mark_node_complete(
-            node_a,
-            True,
-            linear_graph,
-            node_map,
-            completed,
-            failed,
-            in_progress,
-            remaining_deps,
-            ready,
-            results,
-            None,
-        )
+        _mark_node_complete(state, node_a, True, None)
 
-        assert remaining_deps[node_b] == 0
+        assert state.remaining_deps[node_b] == 0
 
     def test_adds_to_ready_when_deps_satisfied(
-        self,
-        linear_graph: nx.DiGraph,
-        node_map: NodeMap,
-        node_a: str,
-        node_b: str,
-        node_c: str,
+        self, linear_graph: nx.DiGraph, node_a: str, node_b: str
     ) -> None:
-        completed: CompletedSet = set()
-        failed: FailedSet = set()
-        in_progress: InProgressSet = {node_a}
-        remaining_deps: RemainingDepsDict = {node_a: 0, node_b: 1, node_c: 1}
-        ready: ReadyList = []
-        results: ResultsList = []
+        state = RunState.for_graph(linear_graph)
+        state.in_progress.add(node_a)
 
-        _mark_node_complete(
-            node_a,
-            True,
-            linear_graph,
-            node_map,
-            completed,
-            failed,
-            in_progress,
-            remaining_deps,
-            ready,
-            results,
-            None,
-        )
+        _mark_node_complete(state, node_a, True, None)
 
-        assert node_b in ready
+        assert node_b in state.ready
 
     def test_propagates_failure_to_dependents(
-        self,
-        linear_graph: nx.DiGraph,
-        node_map: NodeMap,
-        node_a: str,
-        node_b: str,
-        node_c: str,
+        self, linear_graph: nx.DiGraph, node_a: str, node_b: str, node_c: str
     ) -> None:
-        completed: CompletedSet = set()
-        failed: FailedSet = set()
-        in_progress: InProgressSet = {node_a}
-        remaining_deps: RemainingDepsDict = {node_a: 0, node_b: 1, node_c: 1}
-        ready: ReadyList = []
-        results: ResultsList = []
+        state = RunState.for_graph(linear_graph)
+        state.in_progress.add(node_a)
 
-        _mark_node_complete(
-            node_a,
-            False,  # Failed
-            linear_graph,
-            node_map,
-            completed,
-            failed,
-            in_progress,
-            remaining_deps,
-            ready,
-            results,
-            None,
-        )
+        _mark_node_complete(state, node_a, False, None)
 
-        assert node_b in failed
-        assert node_c in failed
-        assert len(results) == 2
+        assert node_b in state.failed
+        assert node_c in state.failed
+        assert len(state.results) == 2
 
     def test_skips_already_completed_dependents(
-        self,
-        linear_graph: nx.DiGraph,
-        node_map: NodeMap,
-        node_a: str,
-        node_b: str,
-        node_c: str,
+        self, linear_graph: nx.DiGraph, node_a: str, node_b: str
     ) -> None:
-        completed: CompletedSet = {node_b}  # B already done
-        failed: FailedSet = set()
-        in_progress: InProgressSet = {node_a}
-        remaining_deps: RemainingDepsDict = {node_a: 0, node_b: 0, node_c: 1}
-        ready: ReadyList = []
-        results: ResultsList = []
+        state = RunState.for_graph(linear_graph)
+        state.in_progress.add(node_a)
+        state.completed.add(node_b)  # B already done
 
-        _mark_node_complete(
-            node_a,
-            True,
-            linear_graph,
-            node_map,
-            completed,
-            failed,
-            in_progress,
-            remaining_deps,
-            ready,
-            results,
-            None,
-        )
+        _mark_node_complete(state, node_a, True, None)
 
-        # B was already completed, shouldn't be added to ready
-        assert node_b not in ready
+        assert node_b not in state.ready
 
     def test_diamond_both_deps_must_complete(
         self,
         diamond_graph: nx.DiGraph,
-        node_map: NodeMap,
         node_a: str,
         node_b: str,
         node_c: str,
         node_d: str,
     ) -> None:
         """D requires both B and C to complete."""
-        completed: CompletedSet = {node_a}
-        failed: FailedSet = set()
-        in_progress: InProgressSet = {node_b}
-        remaining_deps: RemainingDepsDict = {node_a: 0, node_b: 0, node_c: 0, node_d: 2}
-        ready: ReadyList = []
-        results: ResultsList = []
+        state = RunState.for_graph(diamond_graph)
+        state.in_progress.add(node_a)
+        _mark_node_complete(state, node_a, True, None)
 
-        # Complete B
-        _mark_node_complete(
-            node_b,
-            True,
-            diamond_graph,
-            node_map,
-            completed,
-            failed,
-            in_progress,
-            remaining_deps,
-            ready,
-            results,
-            None,
-        )
+        state.in_progress.add(node_b)
+        _mark_node_complete(state, node_b, True, None)
 
         # D shouldn't be ready yet (still waiting on C)
-        assert node_d not in ready
-        assert remaining_deps[node_d] == 1
+        assert node_d not in state.ready
+        assert state.remaining_deps[node_d] == 1
 
-        # Complete C
-        in_progress.add(node_c)
-        _mark_node_complete(
-            node_c,
-            True,
-            diamond_graph,
-            node_map,
-            completed,
-            failed,
-            in_progress,
-            remaining_deps,
-            ready,
-            results,
-            None,
-        )
+        state.in_progress.add(node_c)
+        _mark_node_complete(state, node_c, True, None)
 
-        # Now D should be ready
-        assert node_d in ready
-        assert remaining_deps[node_d] == 0
+        assert node_d in state.ready
+        assert state.remaining_deps[node_d] == 0
 
     def test_diamond_one_path_fails(
         self,
         diamond_graph: nx.DiGraph,
-        node_map: NodeMap,
         node_a: str,
         node_b: str,
-        node_c: str,
         node_d: str,
     ) -> None:
         """If B fails in diamond, D should fail even though C succeeds."""
-        completed: CompletedSet = {node_a}
-        failed: FailedSet = set()
-        in_progress: InProgressSet = {node_b}
-        remaining_deps: RemainingDepsDict = {node_a: 0, node_b: 0, node_c: 0, node_d: 2}
-        ready: ReadyList = []
-        results: ResultsList = []
+        state = RunState.for_graph(diamond_graph)
+        state.in_progress.add(node_a)
+        _mark_node_complete(state, node_a, True, None)
 
-        # B fails
-        _mark_node_complete(
-            node_b,
-            False,
-            diamond_graph,
-            node_map,
-            completed,
-            failed,
-            in_progress,
-            remaining_deps,
-            ready,
-            results,
-            None,
-        )
+        state.in_progress.add(node_b)
+        _mark_node_complete(state, node_b, False, None)
 
-        # D should be failed
-        assert node_d in failed
+        assert node_d in state.failed
 
     def test_calls_callback_for_propagated_failures(
-        self,
-        linear_graph: nx.DiGraph,
-        node_map: NodeMap,
-        node_a: str,
-        node_b: str,
-        node_c: str,
+        self, linear_graph: nx.DiGraph, node_a: str
     ) -> None:
-        completed: CompletedSet = set()
-        failed: FailedSet = set()
-        in_progress: InProgressSet = {node_a}
-        remaining_deps: RemainingDepsDict = {node_a: 0, node_b: 1, node_c: 1}
-        ready: ReadyList = []
-        results: ResultsList = []
+        state = RunState.for_graph(linear_graph)
+        state.in_progress.add(node_a)
         callback = Mock()
 
-        _mark_node_complete(
-            node_a,
-            False,
-            linear_graph,
-            node_map,
-            completed,
-            failed,
-            in_progress,
-            remaining_deps,
-            ready,
-            results,
-            callback,
-        )
+        _mark_node_complete(state, node_a, False, callback)
 
         # Callback should be called for B and C
         assert callback.call_count == 2
@@ -719,124 +416,43 @@ class TestIntegration:
     def test_full_linear_execution_success(
         self,
         linear_graph: nx.DiGraph,
-        node_map: NodeMap,
         node_a: str,
         node_b: str,
         node_c: str,
     ) -> None:
         """Simulate successful execution of A -> B -> C."""
-        completed: CompletedSet = set()
-        failed: FailedSet = set()
-        in_progress: InProgressSet = set()
-        remaining_deps: RemainingDepsDict = {node_a: 0, node_b: 1, node_c: 1}
-        ready: ReadyList = [node_a]
-        results: ResultsList = []
+        state = RunState.for_graph(linear_graph)
 
-        # Execute A
-        node = _get_next_ready(ready)
-        assert node == node_a
-        in_progress.add(node)
-        _mark_node_complete(
-            node,
-            True,
-            linear_graph,
-            node_map,
-            completed,
-            failed,
-            in_progress,
-            remaining_deps,
-            ready,
-            results,
-            None,
-        )
+        for expected in (node_a, node_b, node_c):
+            node = _get_next_ready(state.ready)
+            assert node == expected
+            state.in_progress.add(node)
+            _mark_node_complete(state, node, True, None)
 
-        # B should now be ready
-        assert node_b in ready
-        assert _is_execution_done(completed, 3) is False
-
-        # Execute B
-        node = _get_next_ready(ready)
-        assert node == node_b
-        in_progress.add(node)
-        _mark_node_complete(
-            node,
-            True,
-            linear_graph,
-            node_map,
-            completed,
-            failed,
-            in_progress,
-            remaining_deps,
-            ready,
-            results,
-            None,
-        )
-
-        # C should now be ready
-        assert node_c in ready
-
-        # Execute C
-        node = _get_next_ready(ready)
-        assert node == node_c
-        in_progress.add(node)
-        _mark_node_complete(
-            node,
-            True,
-            linear_graph,
-            node_map,
-            completed,
-            failed,
-            in_progress,
-            remaining_deps,
-            ready,
-            results,
-            None,
-        )
-
-        # All done
-        assert _is_execution_done(completed, 3) is True
-        assert len(failed) == 0
-        assert len(results) == 0  # No failures recorded
+        assert _is_execution_done(state.completed, 3) is True
+        assert len(state.failed) == 0
+        assert len(state.results) == 0  # No failures recorded
 
     def test_full_linear_execution_early_failure(
         self,
         linear_graph: nx.DiGraph,
-        node_map: NodeMap,
         node_a: str,
         node_b: str,
         node_c: str,
     ) -> None:
         """Simulate A fails, B and C should be skipped."""
-        completed: CompletedSet = set()
-        failed: FailedSet = set()
-        in_progress: InProgressSet = set()
-        remaining_deps: RemainingDepsDict = {node_a: 0, node_b: 1, node_c: 1}
-        ready: ReadyList = [node_a]
-        results: ResultsList = []
+        state = RunState.for_graph(linear_graph)
 
-        # Execute A (fails)
-        node = _get_next_ready(ready)
-        in_progress.add(node)
-        _mark_node_complete(
-            node,
-            False,  # Failed!
-            linear_graph,
-            node_map,
-            completed,
-            failed,
-            in_progress,
-            remaining_deps,
-            ready,
-            results,
-            None,
-        )
+        node = _get_next_ready(state.ready)
+        state.in_progress.add(node)
+        _mark_node_complete(state, node, False, None)
 
         # All nodes should be marked as completed (A executed, B & C skipped)
-        assert _is_execution_done(completed, 3) is True
-        assert node_a in failed
-        assert node_b in failed
-        assert node_c in failed
-        assert len(results) == 2  # B and C recorded as failed
+        assert _is_execution_done(state.completed, 3) is True
+        assert node_a in state.failed
+        assert node_b in state.failed
+        assert node_c in state.failed
+        assert len(state.results) == 2  # B and C recorded as failed
 
 
 # ── EagerBFSStrategy callback exception resilience ────────────────────────────

--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from trilogy.executor import Executor
     from trilogy.parser import parse
 
-__version__ = "0.3.341"
+__version__ = "0.3.342"
 
 __all__ = [
     "CONFIG",

--- a/trilogy/execution/config.py
+++ b/trilogy/execution/config.py
@@ -238,6 +238,7 @@ _KNOWN_TOP_LEVEL: set[str] = {
     "import_paths",
     "cloud",
     "environments",
+    "dependencies",
 }
 _KNOWN_SECTIONS: dict[str, set[str] | None] = {
     "engine": {"dialect", "config", "env_file", "parallelism"},
@@ -250,6 +251,9 @@ _KNOWN_SECTIONS: dict[str, set[str] | None] = {
     "project": {"name"},
     "report": {"theme"},
     "environments": {"home"},
+    # Keyed by script path, read by `scripts.project_config
+    # .load_declared_dependencies`, which validates each entry itself.
+    "dependencies": None,
     # Consumed by `trilogy cloud` (scripts/cloud.py), not by RuntimeConfig —
     # listed so the documented [cloud] section doesn't audit as unknown.
     # `api_url`/`org` say which environment to talk to; the rest are the

--- a/trilogy/execution/outputs.py
+++ b/trilogy/execution/outputs.py
@@ -1,0 +1,128 @@
+"""Run outputs: values a script hands back to whoever ran it.
+
+A program run by a ``call`` statement reports an output by printing one
+marker line on stdout::
+
+    ::trilogy-output name=fix_pr kind=link value=https://github.com/o/r/pull/45
+
+``name`` is required; ``kind`` is ``link``, ``text`` or ``json`` and defaults
+to ``link`` for an http(s) URL and ``text`` otherwise; ``value`` must come
+last and takes the rest of the line verbatim, so URLs carrying ``=`` or ``&``
+survive. Every other stdout line is left alone.
+
+Each output becomes an ``output`` report record and is printed with the
+run's summary, so a script's result reads the same on a laptop and in an
+orchestrator that parses the report. Outputs are collected per process,
+like the report sink: parallel execution emits them from worker threads.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import threading
+from dataclasses import dataclass
+from typing import Any
+
+from trilogy.constants import logger
+from trilogy.execution.report import emit_report
+
+MARKER = "::trilogy-output"
+OUTPUT_KINDS = ("link", "text", "json")
+
+_MARKER_RE = re.compile(rf"^{re.escape(MARKER)}\s+((?:\w+=\S*\s+)*)value=(.*)$")
+_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.-]*$")
+_URL_RE = re.compile(r"^https?://\S+$")
+
+
+@dataclass(frozen=True)
+class RunOutput:
+    name: str
+    value: Any
+    kind: str
+    source: str | None = None
+
+    def as_record(self) -> dict[str, Any]:
+        record: dict[str, Any] = {
+            "name": self.name,
+            "kind": self.kind,
+            "value": self.value,
+        }
+        if self.source:
+            record["source"] = self.source
+        return record
+
+
+def parse_output_line(line: str, source: str | None = None) -> RunOutput | None:
+    """The output a marker line declares, or ``None`` for any other line.
+
+    A line that starts with the marker but does not parse is a script author's
+    mistake, so it is logged rather than silently dropped."""
+    stripped = line.strip()
+    if not stripped.startswith(MARKER):
+        return None
+    match = _MARKER_RE.match(stripped)
+    if match is None:
+        logger.warning(f"ignoring malformed output marker: {stripped}")
+        return None
+    attrs: dict[str, str] = {}
+    for token in match.group(1).split():
+        key, _, val = token.partition("=")
+        attrs[key] = val
+    value: Any = match.group(2).strip()
+    name = attrs.pop("name", "")
+    kind = attrs.pop("kind", None)
+    if attrs or not _NAME_RE.match(name):
+        logger.warning(f"ignoring malformed output marker: {stripped}")
+        return None
+    if kind is None:
+        kind = "link" if _URL_RE.match(value) else "text"
+    if kind not in OUTPUT_KINDS:
+        logger.warning(f"ignoring output '{name}' with unknown kind '{kind}'")
+        return None
+    if kind == "json":
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            logger.warning(f"output '{name}' is not valid JSON; keeping it as text")
+            kind = "text"
+    return RunOutput(name=name, value=value, kind=kind, source=source)
+
+
+def scan_outputs(text: str, source: str | None = None) -> list[RunOutput]:
+    """Every output declared in a program's stdout, in order."""
+    outputs = []
+    for line in text.splitlines():
+        output = parse_output_line(line, source)
+        if output is not None:
+            outputs.append(output)
+    return outputs
+
+
+def is_output_line(line: str) -> bool:
+    return line.strip().startswith(MARKER)
+
+
+_COLLECTED: list[RunOutput] = []
+_LOCK = threading.Lock()
+
+
+def record_outputs(outputs: list[RunOutput]) -> None:
+    """Keep outputs for the run summary and write each to the report."""
+    if not outputs:
+        return
+    with _LOCK:
+        _COLLECTED.extend(outputs)
+    for output in outputs:
+        emit_report("output", **output.as_record())
+
+
+def collected_outputs() -> list[RunOutput]:
+    with _LOCK:
+        return list(_COLLECTED)
+
+
+def reset_outputs() -> None:
+    """Start a run with no outputs; the CLI calls this per invocation."""
+    with _LOCK:
+        _COLLECTED.clear()

--- a/trilogy/execution/report.py
+++ b/trilogy/execution/report.py
@@ -39,6 +39,9 @@ Record vocabulary (fields with ``None`` values are omitted):
 - ``state_snapshot``: a full StateSnapshot payload (see
   ``trilogy.execution.state.snapshot``), or {path} when written to a file
 - ``error``: error_type, message, file (fatal errors outside the file loop)
+- ``output``: name, kind ("link" | "text" | "json"), value, source (the
+  program that declared it) — a value a ``call``ed program handed back via a
+  ``::trilogy-output`` stdout marker (see ``trilogy.execution.outputs``)
 - ``summary``: terminal record — success, exit_code, total, succeeded,
   failed, skipped, partial_failure, total_duration_s, refreshed_assets.
   A multi-phase command (``integration --refresh-derived failed`` runs

--- a/trilogy/executor.py
+++ b/trilogy/executor.py
@@ -899,6 +899,11 @@ class Executor:
     @execute_query.register
     def _(self, query: ProcessedCallStatement) -> ResultProtocol | None:
         from trilogy.dialect.python_source import build_script_command
+        from trilogy.execution.outputs import (
+            is_output_line,
+            record_outputs,
+            scan_outputs,
+        )
 
         arg_pairs: list[tuple[str, Any]] = []
         if query.query is not None:
@@ -942,10 +947,16 @@ class Executor:
             cwd=str(self.environment.working_path),
             check=False,
         )
-        if completed.stdout and completed.stdout.strip():
-            logger.info(
-                f"call script '{query.target}' stdout: {completed.stdout.strip()}"
-            )
+        # Outputs are kept even when the script then fails: a repair script
+        # that opened an issue and died still reported where the issue is.
+        record_outputs(scan_outputs(completed.stdout or "", source=query.target))
+        stdout = "\n".join(
+            line
+            for line in (completed.stdout or "").splitlines()
+            if not is_output_line(line)
+        ).strip()
+        if stdout:
+            logger.info(f"call script '{query.target}' stdout: {stdout}")
         if completed.returncode != 0:
             detail = (completed.stderr or "").strip() or (
                 completed.stdout or ""

--- a/trilogy/scripts/dependency.py
+++ b/trilogy/scripts/dependency.py
@@ -7,6 +7,53 @@ from typing import Protocol, TypeAlias
 from trilogy.core import graph as nx
 from trilogy.execution.state import StaleAsset
 from trilogy.parsing.exceptions import ParseError
+from trilogy.scripts.project_config import (
+    DEFAULT_DEPENDENCY_CONDITION,
+    find_trilogy_config,
+    load_declared_dependencies,
+)
+
+#: Edge attribute naming the condition a declared dependency runs on.
+#: Derived edges carry none and read as `completed`.
+EDGE_CONDITION = "when"
+
+
+def edge_condition(graph: nx.DiGraph, upstream: str, dependent: str) -> str:
+    return str(
+        graph.edges[(upstream, dependent)].get(
+            EDGE_CONDITION, DEFAULT_DEPENDENCY_CONDITION
+        )
+    )
+
+
+def add_declared_edges(
+    graph: nx.DiGraph, folder: Path, path_to_key: dict[Path, str]
+) -> None:
+    """Overlay the folder's `[dependencies]` on a derived script graph.
+
+    A declared edge names two scripts the run manages, or it is a mistake in
+    the toml: raising here is what stops a mistyped `after` from silently
+    ordering nothing. A declared edge over a derived one keeps its `when` —
+    the declaration is the more specific statement.
+    """
+    config_path = find_trilogy_config(folder)
+    if config_path is None:
+        return
+    for dep in load_declared_dependencies(config_path):
+        if dep.script not in path_to_key:
+            raise ValueError(
+                f"[dependencies] names {dep.script.name}, which is not a script under {folder}"
+            )
+        for upstream in dep.after:
+            if upstream not in path_to_key:
+                raise ValueError(
+                    f"[dependencies] {dep.script.name} runs after {upstream.name}, "
+                    f"which is not a script under {folder}"
+                )
+            graph.add_edge(path_to_key[upstream], path_to_key[dep.script])
+            graph.edges[(path_to_key[upstream], path_to_key[dep.script])][
+                EDGE_CONDITION
+            ] = dep.when
 
 
 def normalize_path_variants(path: str | Path) -> Path:
@@ -188,6 +235,7 @@ class ETLDependencyStrategy:
             if from_path in path_to_key and to_path in path_to_key:
                 graph.add_edge(path_to_key[from_path], path_to_key[to_path])
 
+        add_declared_edges(graph, folder, path_to_key)
         return graph
 
     def build_graph(self, nodes: list[ScriptNode]) -> nx.DiGraph:
@@ -239,6 +287,7 @@ class ETLDependencyStrategy:
             if from_path in path_to_key and to_path in path_to_key:
                 graph.add_edge(path_to_key[from_path], path_to_key[to_path])
 
+        add_declared_edges(graph, directory, path_to_key)
         return graph
 
 

--- a/trilogy/scripts/display.py
+++ b/trilogy/scripts/display.py
@@ -53,6 +53,7 @@ from trilogy.scripts.display_execution import (  # noqa: F401
     show_execution_start,
     show_execution_summary,
     show_formatting_result,
+    show_run_outputs,
     show_statement_result,
     show_statement_type,
     summarize_definitions,

--- a/trilogy/scripts/display_execution.py
+++ b/trilogy/scripts/display_execution.py
@@ -1,11 +1,13 @@
 """Display helpers for single-script execution output."""
 
+import json
 import os
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from trilogy.core.statements.execute import ProcessedChartStatement
+    from trilogy.execution.outputs import RunOutput
 
 from click import echo
 
@@ -350,6 +352,32 @@ def show_execution_summary(
             print_success(
                 f"Statements: {num_queries} Completed in: {format_duration(total_duration)}"
             )
+
+
+def show_run_outputs(outputs: "Sequence[RunOutput]") -> None:
+    """List the outputs called programs handed back, after the summary."""
+    if not outputs:
+        return
+    if is_json_mode():
+        emit_event("outputs", outputs=[o.as_record() for o in outputs])
+        return
+    if _core.RICH_AVAILABLE and _core.console is not None:
+        from rich.table import Table
+
+        table = Table(title="Outputs", show_header=True)
+        table.add_column("Name", style="cyan")
+        table.add_column("Kind", style="dim")
+        table.add_column("Value")
+        for o in outputs:
+            table.add_row(o.name, o.kind, _output_text(o))
+        _core.console.print(table)
+    else:
+        for o in outputs:
+            echo(f"Output {o.name} ({o.kind}): {_output_text(o)}")
+
+
+def _output_text(output: "RunOutput") -> str:
+    return json.dumps(output.value) if output.kind == "json" else str(output.value)
 
 
 def show_formatting_result(

--- a/trilogy/scripts/display_parallel.py
+++ b/trilogy/scripts/display_parallel.py
@@ -92,6 +92,16 @@ def failure_report(summary: "ParallelExecutionSummary") -> str:
     return "\n".join(lines)
 
 
+def _node_label(node: Any) -> str:
+    from trilogy.scripts.dependency import ScriptNode
+
+    return (
+        node.path.name
+        if isinstance(node, ScriptNode)
+        else getattr(node, "address", str(node))
+    )
+
+
 def _stat_row_label(noun: str, verb: str, dry_run: bool) -> str:
     return f"{noun} That Would Be {verb}" if dry_run else f"{noun} {verb}"
 
@@ -205,7 +215,11 @@ def show_script_result(
         )
         return
     if _core.RICH_AVAILABLE and _core.console is not None:
-        if result.success:
+        if result.success and result.skipped:
+            _core.console.print(
+                f"  [dim]\u2298 {_node_label(result.node)} - {result.error}[/dim]"
+            )
+        elif result.success:
             if isinstance(result.node, ScriptNode):
                 _core.console.print(
                     f"  [green]\u2713[/green] {result.node.path.name} ({result.duration:.2f}s){stats_str}"
@@ -228,7 +242,9 @@ def show_script_result(
             else:
                 _core.console.print(str(result))
     else:
-        if result.success:
+        if result.success and result.skipped:
+            print(f"  \u2298 {_node_label(result.node)} - {result.error}")
+        elif result.success:
             if isinstance(result.node, ScriptNode):
                 print(
                     f"  \u2713 {result.node.path.name} ({result.duration:.2f}s){stats_str}"

--- a/trilogy/scripts/display_parallel.py
+++ b/trilogy/scripts/display_parallel.py
@@ -9,6 +9,7 @@ import trilogy.scripts.display_core as _core
 from trilogy.scripts.display_core import _FdStderrCapture, emit_event, is_json_mode
 
 if TYPE_CHECKING:
+    from trilogy.scripts.dependency import ExecutionNode
     from trilogy.scripts.parallel_execution import (
         ExecutionResult,
         ParallelExecutionSummary,
@@ -92,14 +93,10 @@ def failure_report(summary: "ParallelExecutionSummary") -> str:
     return "\n".join(lines)
 
 
-def _node_label(node: Any) -> str:
+def _node_label(node: "ExecutionNode") -> str:
     from trilogy.scripts.dependency import ScriptNode
 
-    return (
-        node.path.name
-        if isinstance(node, ScriptNode)
-        else getattr(node, "address", str(node))
-    )
+    return node.path.name if isinstance(node, ScriptNode) else node.address
 
 
 def _stat_row_label(noun: str, verb: str, dry_run: bool) -> str:

--- a/trilogy/scripts/parallel_execution.py
+++ b/trilogy/scripts/parallel_execution.py
@@ -24,6 +24,7 @@ from trilogy.scripts.dependency import (
     ManagedRefreshNode,
     ScriptNode,
     create_script_nodes,
+    edge_condition,
 )
 from trilogy.utility import safe_open
 
@@ -46,8 +47,10 @@ class ExecutionResult:
     error: Exception | None = None
     duration: float = 0.0  # seconds
     stats: ExecutionStats | None = None
-    # True when the node never ran because a dependency failed. Kept distinct
-    # from success=False so telemetry can separate real failures from skips.
+    # True when the node never ran: because a dependency failed
+    # (success=False), or because its declared `when` condition was not met
+    # (success=True — a repair script standing down is the pipeline working).
+    # Kept distinct so telemetry can separate real failures from skips.
     skipped: bool = False
 
 
@@ -111,6 +114,162 @@ def build_node_map(graph: nx.DiGraph) -> NodeMap:
     return {key: ScriptNode(path=Path(key)) for key in graph.nodes()}
 
 
+# How a node ended, as far as its dependents are concerned. A dependency-skip
+# is not a failure of *this* script, and a `when = "failed"` dependent must
+# not fire on it — only on the script that actually broke.
+OUTCOME_SUCCEEDED = "succeeded"
+OUTCOME_FAILED = "failed"
+OUTCOME_SKIPPED = "skipped"
+#: Set of nodes whose `when = "failed"` condition has been met.
+TriggeredSet = set[str]
+
+DEPENDENCY_SKIP = "Skipped due to failed dependency"
+
+
+def _waits_for_failure(graph: nx.DiGraph, node_key: str) -> list[str]:
+    """The upstreams `node_key` runs *because of*, when it is a repair script."""
+    return [
+        upstream
+        for upstream in graph.predecessors(node_key)
+        if edge_condition(graph, upstream, node_key) == "failed"
+    ]
+
+
+def _finish_without_running(
+    node_key: str,
+    reason: str,
+    success: bool,
+    graph: nx.DiGraph,
+    node_map: NodeMap,
+    completed: CompletedSet,
+    failed: FailedSet,
+    in_progress: InProgressSet,
+    remaining_deps: RemainingDepsDict,
+    ready: ReadyList,
+    results: ResultsList,
+    triggered: TriggeredSet,
+    on_script_complete: OnCompleteCallback,
+) -> None:
+    result = ExecutionResult(
+        node=node_map[node_key],
+        success=success,
+        error=RuntimeError(reason),
+        duration=0.0,
+        skipped=True,
+    )
+    results.append(result)
+    completed.add(node_key)
+    if not success:
+        failed.add(node_key)
+    if on_script_complete:
+        on_script_complete(result)
+    _settle_dependents(
+        node_key,
+        OUTCOME_SUCCEEDED if success else OUTCOME_SKIPPED,
+        graph,
+        node_map,
+        completed,
+        failed,
+        in_progress,
+        remaining_deps,
+        ready,
+        results,
+        triggered,
+        on_script_complete,
+    )
+
+
+def _settle_dependents(
+    node_key: str,
+    outcome: str,
+    graph: nx.DiGraph,
+    node_map: NodeMap,
+    completed: CompletedSet,
+    failed: FailedSet,
+    in_progress: InProgressSet,
+    remaining_deps: RemainingDepsDict,
+    ready: ReadyList,
+    results: ResultsList,
+    triggered: TriggeredSet,
+    on_script_complete: OnCompleteCallback,
+) -> None:
+    """Tell every unstarted dependent of `node_key` how it ended.
+
+    A derived edge (`when = "completed"`) is the old rule: a failure or a
+    dependency-skip upstream skips the dependent, recursively, before it
+    ever counts down. A declared `failed` or `always` edge counts every
+    outcome down instead, and when the dependent's last upstream settles it
+    either runs, or — a repair script whose upstreams all held — stands
+    down as a *successful* skip so the pipeline stays green.
+    """
+    for dependent in graph.successors(node_key):
+        if dependent in completed or dependent in in_progress:
+            continue
+        when = edge_condition(graph, node_key, dependent)
+        if when == "completed" and outcome != OUTCOME_SUCCEEDED:
+            _finish_without_running(
+                dependent,
+                DEPENDENCY_SKIP,
+                False,
+                graph,
+                node_map,
+                completed,
+                failed,
+                in_progress,
+                remaining_deps,
+                ready,
+                results,
+                triggered,
+                on_script_complete,
+            )
+            continue
+        if when == "failed" and outcome == OUTCOME_FAILED:
+            triggered.add(dependent)
+        remaining_deps[dependent] -= 1
+        if remaining_deps[dependent] > 0:
+            continue
+        watched = _waits_for_failure(graph, dependent)
+        if watched and dependent not in triggered:
+            names = ", ".join(Path(key).name for key in watched)
+            _finish_without_running(
+                dependent,
+                f"{names} did not fail, so this script had nothing to do",
+                True,
+                graph,
+                node_map,
+                completed,
+                failed,
+                in_progress,
+                remaining_deps,
+                ready,
+                results,
+                triggered,
+                on_script_complete,
+            )
+        elif any(
+            upstream in failed
+            and edge_condition(graph, upstream, dependent) == "completed"
+            for upstream in graph.predecessors(dependent)
+        ):
+            _finish_without_running(
+                dependent,
+                DEPENDENCY_SKIP,
+                False,
+                graph,
+                node_map,
+                completed,
+                failed,
+                in_progress,
+                remaining_deps,
+                ready,
+                results,
+                triggered,
+                on_script_complete,
+            )
+        else:
+            ready.append(dependent)
+
+
 def _propagate_failure(
     failed_key: str,
     graph: nx.DiGraph,
@@ -120,34 +279,30 @@ def _propagate_failure(
     results: ResultsList,
     failed: FailedSet,
     on_script_complete: OnCompleteCallback,
+    remaining_deps: RemainingDepsDict | None = None,
+    ready: ReadyList | None = None,
+    triggered: TriggeredSet | None = None,
 ) -> None:
+    """Mark every unstarted dependent of a node that did not run as skipped.
+
+    The counters are optional only for graphs with no declared edges, where
+    nothing ever counts down past a failure; a graph carrying `when` edges
+    must pass the run's own state or a conditional dependent is lost.
     """
-    Recursively mark all *unstarted* dependents of a failed node as failed and skipped.
-    """
-    for dependent in graph.successors(failed_key):
-        if dependent not in completed and dependent not in in_progress:
-            skip_result = ExecutionResult(
-                node=node_map[dependent],
-                success=False,
-                error=RuntimeError("Skipped due to failed dependency"),
-                duration=0.0,
-                skipped=True,
-            )
-            results.append(skip_result)
-            completed.add(dependent)
-            failed.add(dependent)
-            if on_script_complete:
-                on_script_complete(skip_result)
-            _propagate_failure(
-                dependent,
-                graph,
-                node_map,
-                completed,
-                in_progress,
-                results,
-                failed,
-                on_script_complete,
-            )
+    _settle_dependents(
+        failed_key,
+        OUTCOME_SKIPPED,
+        graph,
+        node_map,
+        completed,
+        failed,
+        in_progress,
+        remaining_deps if remaining_deps is not None else {},
+        ready if ready is not None else [],
+        results,
+        triggered if triggered is not None else set(),
+        on_script_complete,
+    )
 
 
 def _get_next_ready(ready: ReadyList) -> str | None:
@@ -169,78 +324,30 @@ def _mark_node_complete(
     ready: ReadyList,
     results: ResultsList,
     on_script_complete: OnCompleteCallback,
+    triggered: TriggeredSet | None = None,
 ) -> None:
     """
-    Mark a node as complete, update dependent counts, and add newly ready/skipped nodes.
+    Mark an executed node complete and settle its dependents: count down,
+    release, or skip them according to each edge's condition.
     """
     in_progress.discard(node_key)
     completed.add(node_key)
     if not success:
         failed.add(node_key)
-
-    # Update dependents
-    for dependent in graph.successors(node_key):
-        if dependent in completed or dependent in in_progress:
-            continue
-
-        if success:
-            remaining_deps[dependent] -= 1
-            if remaining_deps[dependent] == 0:
-                # Check if any dependency failed before running
-                deps = set(graph.predecessors(dependent))
-                if deps & failed:
-                    # Skip this node - dependency failed
-                    skip_result = ExecutionResult(
-                        node=node_map[dependent],
-                        success=False,
-                        error=RuntimeError("Skipped due to failed dependency"),
-                        duration=0.0,
-                        skipped=True,
-                    )
-                    results.append(skip_result)
-                    completed.add(dependent)
-                    failed.add(dependent)
-                    if on_script_complete:
-                        on_script_complete(skip_result)
-                    # Recursively mark dependents as failed
-                    _propagate_failure(
-                        dependent,
-                        graph,
-                        node_map,
-                        completed,
-                        in_progress,
-                        results,
-                        failed,
-                        on_script_complete,
-                    )
-                else:
-                    ready.append(dependent)
-        else:
-            # Current node failed - mark this dependent as skipped
-            if dependent not in failed:
-                skip_result = ExecutionResult(
-                    node=node_map[dependent],
-                    success=False,
-                    error=RuntimeError("Skipped due to failed dependency"),
-                    duration=0.0,
-                    skipped=True,
-                )
-                results.append(skip_result)
-                completed.add(dependent)
-                failed.add(dependent)
-                if on_script_complete:
-                    on_script_complete(skip_result)
-                # Recursively mark dependents as failed
-                _propagate_failure(
-                    dependent,
-                    graph,
-                    node_map,
-                    completed,
-                    in_progress,
-                    results,
-                    failed,
-                    on_script_complete,
-                )
+    _settle_dependents(
+        node_key,
+        OUTCOME_SUCCEEDED if success else OUTCOME_FAILED,
+        graph,
+        node_map,
+        completed,
+        failed,
+        in_progress,
+        remaining_deps,
+        ready,
+        results,
+        triggered if triggered is not None else set(),
+        on_script_complete,
+    )
 
 
 def _is_execution_done(completed: CompletedSet, total_count: int) -> bool:
@@ -298,6 +405,7 @@ def _create_worker(
     execution_fn: Callable[[Any, Any], Any],
     on_script_start: Callable[[Any], None] | None,
     on_script_complete: OnCompleteCallback,
+    triggered: TriggeredSet | None = None,
 ) -> Callable[[], None]:
     """
     Create a worker function for thread execution to process the dependency graph.
@@ -352,6 +460,7 @@ def _create_worker(
                         ready,
                         results,
                         on_script_complete,
+                        triggered,
                     )
                     work_available.notify_all()  # Notify other workers of new ready/completed state
 
@@ -390,6 +499,7 @@ class EagerBFSStrategy:
         failed: FailedSet = set()
         in_progress: InProgressSet = set()
         results: ResultsList = []
+        triggered: TriggeredSet = set()
 
         # Calculate in-degrees (number of incomplete dependencies)
         remaining_deps: RemainingDepsDict = {
@@ -418,6 +528,7 @@ class EagerBFSStrategy:
             execution_fn=execution_fn,
             on_script_start=on_script_start,
             on_script_complete=on_script_complete,
+            triggered=triggered,
         )
 
         # Start worker threads
@@ -515,13 +626,15 @@ class ParallelExecutor:
         )
 
         total_duration = (datetime.now() - start_time).total_seconds()
-        successful = sum(1 for r in results if r.success)
+        successful = sum(1 for r in results if r.success and not r.skipped)
+        # A conditional script that stood down: not a failure, not a run.
+        skipped = sum(1 for r in results if r.success and r.skipped)
         failed = sum(1 for r in results if not r.success)
 
         return ParallelExecutionSummary(
             total_scripts=total_scripts,
             successful=successful,
-            skipped=0,
+            skipped=skipped,
             failed=failed,
             total_duration=total_duration,
             results=results,
@@ -974,7 +1087,7 @@ def run_parallel_execution(
         summary = ParallelExecutionSummary(
             total_scripts=summary.total_scripts,
             successful=summary.successful - skipped,
-            skipped=skipped,
+            skipped=summary.skipped + skipped,
             failed=summary.failed,
             total_duration=summary.total_duration,
             results=summary.results,
@@ -983,7 +1096,7 @@ def run_parallel_execution(
     show_parallel_execution_summary(summary)
     show_run_outputs(collected_outputs())
 
-    dep_skipped = sum(1 for r in summary.results if r.skipped)
+    dep_skipped = sum(1 for r in summary.results if r.skipped and not r.success)
     real_failed = summary.failed - dep_skipped
     emit_report(
         "summary",

--- a/trilogy/scripts/parallel_execution.py
+++ b/trilogy/scripts/parallel_execution.py
@@ -14,6 +14,7 @@ from click.exceptions import Exit
 from trilogy import Executor
 from trilogy.constants import logger
 from trilogy.core import graph as nx
+from trilogy.execution.outputs import collected_outputs, reset_outputs
 from trilogy.execution.report import emit_report, exit_code_for
 from trilogy.scripts.common import CLIRuntimeParams, ExecutionStats, RefreshParams
 from trilogy.scripts.dependency import (
@@ -785,6 +786,7 @@ def run_parallel_execution(
         show_execution_info,
         show_parallel_execution_start,
         show_parallel_execution_summary,
+        show_run_outputs,
     )
     from trilogy.scripts.environment import parse_env_vars
 
@@ -877,6 +879,7 @@ def run_parallel_execution(
     # Get execution strategy
     strategy = get_execution_strategy(cli_params.execution_strategy)
 
+    reset_outputs()
     # Set up parallel executor
     parallel_exec = ParallelExecutor(
         max_workers=parallelism,
@@ -978,6 +981,7 @@ def run_parallel_execution(
         )
 
     show_parallel_execution_summary(summary)
+    show_run_outputs(collected_outputs())
 
     dep_skipped = sum(1 for r in summary.results if r.skipped)
     real_failed = summary.failed - dep_skipped

--- a/trilogy/scripts/parallel_execution.py
+++ b/trilogy/scripts/parallel_execution.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import threading
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from io import StringIO
@@ -114,16 +114,54 @@ def build_node_map(graph: nx.DiGraph) -> NodeMap:
     return {key: ScriptNode(path=Path(key)) for key in graph.nodes()}
 
 
-# How a node ended, as far as its dependents are concerned. A dependency-skip
-# is not a failure of *this* script, and a `when = "failed"` dependent must
-# not fire on it — only on the script that actually broke.
+# How a node ended, as far as its dependents are concerned. The three ways of
+# not succeeding stay distinct because they license different things: only a
+# script that actually broke fires a `when = "failed"` dependent, and only a
+# red outcome makes the dependents it skips red.
 OUTCOME_SUCCEEDED = "succeeded"
 OUTCOME_FAILED = "failed"
 OUTCOME_SKIPPED = "skipped"
+OUTCOME_STOOD_DOWN = "stood_down"
 #: Set of nodes whose `when = "failed"` condition has been met.
 TriggeredSet = set[str]
 
 DEPENDENCY_SKIP = "Skipped due to failed dependency"
+
+
+@dataclass
+class RunState:
+    """The bookkeeping one run shares across its worker threads.
+
+    It travels as a unit because it is one: every scheduling decision reads
+    and writes several of these together, and a caller that assembles them
+    piecemeal can hand over a counter the run does not own — which loses a
+    conditional dependent without ever raising.
+    """
+
+    graph: nx.DiGraph
+    node_map: NodeMap
+    completed: CompletedSet = field(default_factory=set)
+    failed: FailedSet = field(default_factory=set)
+    in_progress: InProgressSet = field(default_factory=set)
+    remaining_deps: RemainingDepsDict = field(default_factory=dict)
+    ready: ReadyList = field(default_factory=list)
+    results: ResultsList = field(default_factory=list)
+    triggered: TriggeredSet = field(default_factory=set)
+
+    @classmethod
+    def for_graph(cls, graph: nx.DiGraph) -> RunState:
+        """A run about to start: in-degrees counted, roots already ready."""
+        remaining = {key: graph.in_degree(key) for key in graph.nodes()}
+        return cls(
+            graph=graph,
+            node_map=build_node_map(graph),
+            remaining_deps=remaining,
+            ready=[key for key in graph.nodes() if remaining[key] == 0],
+        )
+
+    @property
+    def total_count(self) -> int:
+        return len(self.graph.nodes())
 
 
 def _waits_for_failure(graph: nx.DiGraph, node_key: str) -> list[str]:
@@ -136,173 +174,96 @@ def _waits_for_failure(graph: nx.DiGraph, node_key: str) -> list[str]:
 
 
 def _finish_without_running(
+    state: RunState,
     node_key: str,
     reason: str,
     success: bool,
-    graph: nx.DiGraph,
-    node_map: NodeMap,
-    completed: CompletedSet,
-    failed: FailedSet,
-    in_progress: InProgressSet,
-    remaining_deps: RemainingDepsDict,
-    ready: ReadyList,
-    results: ResultsList,
-    triggered: TriggeredSet,
     on_script_complete: OnCompleteCallback,
 ) -> None:
+    """Complete a node that never ran, then settle its own dependents.
+
+    `success` is the colour of the skip, and it is what those dependents
+    inherit: a repair standing down is green and skips its dependents green,
+    a broken upstream is red and skips them red. Either way the node did not
+    run, so it cannot satisfy a `completed` edge.
+    """
     result = ExecutionResult(
-        node=node_map[node_key],
+        node=state.node_map[node_key],
         success=success,
         error=RuntimeError(reason),
         duration=0.0,
         skipped=True,
     )
-    results.append(result)
-    completed.add(node_key)
+    state.results.append(result)
+    state.completed.add(node_key)
     if not success:
-        failed.add(node_key)
+        state.failed.add(node_key)
     if on_script_complete:
         on_script_complete(result)
     _settle_dependents(
+        state,
         node_key,
-        OUTCOME_SUCCEEDED if success else OUTCOME_SKIPPED,
-        graph,
-        node_map,
-        completed,
-        failed,
-        in_progress,
-        remaining_deps,
-        ready,
-        results,
-        triggered,
+        OUTCOME_STOOD_DOWN if success else OUTCOME_SKIPPED,
         on_script_complete,
     )
 
 
 def _settle_dependents(
+    state: RunState,
     node_key: str,
     outcome: str,
-    graph: nx.DiGraph,
-    node_map: NodeMap,
-    completed: CompletedSet,
-    failed: FailedSet,
-    in_progress: InProgressSet,
-    remaining_deps: RemainingDepsDict,
-    ready: ReadyList,
-    results: ResultsList,
-    triggered: TriggeredSet,
     on_script_complete: OnCompleteCallback,
 ) -> None:
     """Tell every unstarted dependent of `node_key` how it ended.
 
-    A derived edge (`when = "completed"`) is the old rule: a failure or a
-    dependency-skip upstream skips the dependent, recursively, before it
-    ever counts down. A declared `failed` or `always` edge counts every
-    outcome down instead, and when the dependent's last upstream settles it
-    either runs, or — a repair script whose upstreams all held — stands
-    down as a *successful* skip so the pipeline stays green.
+    A derived edge (`when = "completed"`) is satisfied only by a node that
+    ran and succeeded. Every other outcome skips the dependent, recursively,
+    in the colour of that outcome — red for a failure or a failure-skip,
+    green for an upstream that stood down. A declared `failed` or `always`
+    edge counts every outcome down instead, and when the dependent's last
+    upstream settles it either runs or — a repair whose upstreams all held —
+    stands down as a green skip so the pipeline stays green.
     """
-    for dependent in graph.successors(node_key):
-        if dependent in completed or dependent in in_progress:
+    for dependent in state.graph.successors(node_key):
+        if dependent in state.completed or dependent in state.in_progress:
             continue
-        when = edge_condition(graph, node_key, dependent)
+        when = edge_condition(state.graph, node_key, dependent)
         if when == "completed" and outcome != OUTCOME_SUCCEEDED:
+            stood_down = outcome == OUTCOME_STOOD_DOWN
+            reason = (
+                f"{Path(node_key).name} stood down, so this script had nothing to do"
+                if stood_down
+                else DEPENDENCY_SKIP
+            )
             _finish_without_running(
-                dependent,
-                DEPENDENCY_SKIP,
-                False,
-                graph,
-                node_map,
-                completed,
-                failed,
-                in_progress,
-                remaining_deps,
-                ready,
-                results,
-                triggered,
-                on_script_complete,
+                state, dependent, reason, stood_down, on_script_complete
             )
             continue
         if when == "failed" and outcome == OUTCOME_FAILED:
-            triggered.add(dependent)
-        remaining_deps[dependent] -= 1
-        if remaining_deps[dependent] > 0:
+            state.triggered.add(dependent)
+        state.remaining_deps[dependent] -= 1
+        if state.remaining_deps[dependent] > 0:
             continue
-        watched = _waits_for_failure(graph, dependent)
-        if watched and dependent not in triggered:
+        watched = _waits_for_failure(state.graph, dependent)
+        if watched and dependent not in state.triggered:
             names = ", ".join(Path(key).name for key in watched)
             _finish_without_running(
+                state,
                 dependent,
                 f"{names} did not fail, so this script had nothing to do",
                 True,
-                graph,
-                node_map,
-                completed,
-                failed,
-                in_progress,
-                remaining_deps,
-                ready,
-                results,
-                triggered,
                 on_script_complete,
             )
         elif any(
-            upstream in failed
-            and edge_condition(graph, upstream, dependent) == "completed"
-            for upstream in graph.predecessors(dependent)
+            upstream in state.failed
+            and edge_condition(state.graph, upstream, dependent) == "completed"
+            for upstream in state.graph.predecessors(dependent)
         ):
             _finish_without_running(
-                dependent,
-                DEPENDENCY_SKIP,
-                False,
-                graph,
-                node_map,
-                completed,
-                failed,
-                in_progress,
-                remaining_deps,
-                ready,
-                results,
-                triggered,
-                on_script_complete,
+                state, dependent, DEPENDENCY_SKIP, False, on_script_complete
             )
         else:
-            ready.append(dependent)
-
-
-def _propagate_failure(
-    failed_key: str,
-    graph: nx.DiGraph,
-    node_map: NodeMap,
-    completed: CompletedSet,
-    in_progress: InProgressSet,
-    results: ResultsList,
-    failed: FailedSet,
-    on_script_complete: OnCompleteCallback,
-    remaining_deps: RemainingDepsDict | None = None,
-    ready: ReadyList | None = None,
-    triggered: TriggeredSet | None = None,
-) -> None:
-    """Mark every unstarted dependent of a node that did not run as skipped.
-
-    The counters are optional only for graphs with no declared edges, where
-    nothing ever counts down past a failure; a graph carrying `when` edges
-    must pass the run's own state or a conditional dependent is lost.
-    """
-    _settle_dependents(
-        failed_key,
-        OUTCOME_SKIPPED,
-        graph,
-        node_map,
-        completed,
-        failed,
-        in_progress,
-        remaining_deps if remaining_deps is not None else {},
-        ready if ready is not None else [],
-        results,
-        triggered if triggered is not None else set(),
-        on_script_complete,
-    )
+            state.ready.append(dependent)
 
 
 def _get_next_ready(ready: ReadyList) -> str | None:
@@ -313,39 +274,23 @@ def _get_next_ready(ready: ReadyList) -> str | None:
 
 
 def _mark_node_complete(
+    state: RunState,
     node_key: str,
     success: bool,
-    graph: nx.DiGraph,
-    node_map: NodeMap,
-    completed: CompletedSet,
-    failed: FailedSet,
-    in_progress: InProgressSet,
-    remaining_deps: RemainingDepsDict,
-    ready: ReadyList,
-    results: ResultsList,
     on_script_complete: OnCompleteCallback,
-    triggered: TriggeredSet | None = None,
 ) -> None:
     """
     Mark an executed node complete and settle its dependents: count down,
     release, or skip them according to each edge's condition.
     """
-    in_progress.discard(node_key)
-    completed.add(node_key)
+    state.in_progress.discard(node_key)
+    state.completed.add(node_key)
     if not success:
-        failed.add(node_key)
+        state.failed.add(node_key)
     _settle_dependents(
+        state,
         node_key,
         OUTCOME_SUCCEEDED if success else OUTCOME_FAILED,
-        graph,
-        node_map,
-        completed,
-        failed,
-        in_progress,
-        remaining_deps,
-        ready,
-        results,
-        triggered if triggered is not None else set(),
         on_script_complete,
     )
 
@@ -390,26 +335,18 @@ def _execute_single(
 
 
 def _create_worker(
-    graph: nx.DiGraph,
-    node_map: NodeMap,
+    state: RunState,
     lock: threading.Lock,
     work_available: threading.Condition,
-    completed: CompletedSet,
-    failed: FailedSet,
-    in_progress: InProgressSet,
-    remaining_deps: RemainingDepsDict,
-    ready: ReadyList,
-    results: ResultsList,
-    total_count: int,
     executor_factory: Callable[[Any], Any],
     execution_fn: Callable[[Any, Any], Any],
     on_script_start: Callable[[Any], None] | None,
     on_script_complete: OnCompleteCallback,
-    triggered: TriggeredSet | None = None,
 ) -> Callable[[], None]:
     """
     Create a worker function for thread execution to process the dependency graph.
     """
+    total_count = state.total_count
 
     def worker() -> None:
         while True:
@@ -417,29 +354,31 @@ def _create_worker(
 
             with work_available:
                 # Wait for work or global completion
-                while not ready and not _is_execution_done(completed, total_count):
+                while not state.ready and not _is_execution_done(
+                    state.completed, total_count
+                ):
                     work_available.wait()
 
-                if _is_execution_done(completed, total_count):
+                if _is_execution_done(state.completed, total_count):
                     return
 
-                node_key = _get_next_ready(ready)
+                node_key = _get_next_ready(state.ready)
                 if node_key is None:
                     # Should be impossible if total_count check is correct, but handles race condition safety
                     continue
 
-                in_progress.add(node_key)
+                state.in_progress.add(node_key)
 
             # Execute outside the lock
             if node_key is not None:
-                node = node_map[node_key]
+                node = state.node_map[node_key]
                 if on_script_start:
                     on_script_start(node)
                 result = _execute_single(node, executor_factory, execution_fn)
 
                 # Use the lock for state updates and notification
                 with lock:
-                    results.append(result)
+                    state.results.append(result)
 
                     if on_script_complete:
                         try:
@@ -449,18 +388,7 @@ def _create_worker(
                             logger.debug("on_script_complete callback failed: %s", e)
 
                     _mark_node_complete(
-                        node_key,
-                        result.success,
-                        graph,
-                        node_map,
-                        completed,
-                        failed,
-                        in_progress,
-                        remaining_deps,
-                        ready,
-                        results,
-                        on_script_complete,
-                        triggered,
+                        state, node_key, result.success, on_script_complete
                     )
                     work_available.notify_all()  # Notify other workers of new ready/completed state
 
@@ -489,50 +417,23 @@ class EagerBFSStrategy:
         if not graph.nodes():
             return []
 
-        node_map = build_node_map(graph)
+        state = RunState.for_graph(graph)
 
         lock = threading.Lock()
         work_available = threading.Condition(lock)
 
-        # Track state
-        completed: CompletedSet = set()
-        failed: FailedSet = set()
-        in_progress: InProgressSet = set()
-        results: ResultsList = []
-        triggered: TriggeredSet = set()
-
-        # Calculate in-degrees (number of incomplete dependencies)
-        remaining_deps: RemainingDepsDict = {
-            key: graph.in_degree(key) for key in graph.nodes()
-        }
-
-        # Ready queue - keys with all dependencies satisfied initially (in-degree 0)
-        ready: ReadyList = [key for key in graph.nodes() if remaining_deps[key] == 0]
-
-        total_count = len(graph.nodes())
-
-        # Create the worker function
         worker = _create_worker(
-            graph=graph,
-            node_map=node_map,
+            state=state,
             lock=lock,
             work_available=work_available,
-            completed=completed,
-            failed=failed,
-            in_progress=in_progress,
-            remaining_deps=remaining_deps,
-            ready=ready,
-            results=results,
-            total_count=total_count,
             executor_factory=executor_factory,
             execution_fn=execution_fn,
             on_script_start=on_script_start,
             on_script_complete=on_script_complete,
-            triggered=triggered,
         )
 
         # Start worker threads
-        workers = min(max_workers, total_count)
+        workers = min(max_workers, state.total_count)
         threads: list[threading.Thread] = []
         for _ in range(workers):
             t = threading.Thread(target=worker, daemon=True)
@@ -547,7 +448,7 @@ class EagerBFSStrategy:
         for t in threads:
             t.join()
 
-        return results
+        return state.results
 
 
 class ParallelExecutor:

--- a/trilogy/scripts/project_config.py
+++ b/trilogy/scripts/project_config.py
@@ -8,9 +8,19 @@ so its importers are unaffected.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 
+import tomllib
+
 TRILOGY_CONFIG_NAME = "trilogy.toml"
+
+#: When a declared dependent runs, given what its `after` scripts did.
+#: `completed` is the derived-edge rule (run after they succeed, skip if one
+#: failed); `failed` runs only when at least one of them failed — a repair
+#: script; `always` runs once they are all finished, whatever happened.
+DEPENDENCY_CONDITIONS = ("completed", "failed", "always")
+DEFAULT_DEPENDENCY_CONDITION = "completed"
 
 # Directory holding root datasource definitions, relative to the project root.
 # `init` scaffolds it and `ingest` writes generated models into it by default —
@@ -33,3 +43,73 @@ def find_trilogy_config(start_path: Path | None = None) -> Path | None:
         if candidate.exists():
             return candidate
     return None
+
+
+@dataclass(frozen=True)
+class DeclaredDependency:
+    """One `[dependencies]` entry: `script` runs after every path in `after`,
+    on the condition `when`. Paths are absolute, resolved from the config."""
+
+    script: Path
+    after: tuple[Path, ...]
+    when: str = DEFAULT_DEPENDENCY_CONDITION
+
+
+def load_declared_dependencies(config_path: Path) -> list[DeclaredDependency]:
+    """The `[dependencies]` table of a trilogy.toml.
+
+    Edges between scripts are normally derived from what they import, declare
+    and persist; this is the one place to declare an edge the content cannot
+    express — chiefly a script that must run *because* another failed::
+
+        [dependencies]
+        "repair.preql" = { after = ["refresh.preql"], when = "failed" }
+
+    Keys and `after` entries are paths relative to the config's directory.
+    Consumers (the local directory runner, and the platform ordering a
+    schedule tick) share this reader so they cannot disagree about the shape.
+    """
+    parsed = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    section = parsed.get("dependencies")
+    if section is None:
+        return []
+    if not isinstance(section, dict):
+        raise TypeError("[dependencies] must be a table of script -> settings")
+    base = config_path.parent
+    declared: list[DeclaredDependency] = []
+    for script, spec in section.items():
+        if not isinstance(spec, dict):
+            raise TypeError(
+                f"[dependencies] {script!r} must be a table like "
+                '{ after = [...], when = "failed" }'
+            )
+        unknown = set(spec) - {"after", "when"}
+        if unknown:
+            raise ValueError(
+                f"[dependencies] {script!r} has unknown keys: {sorted(unknown)}"
+            )
+        after = spec.get("after")
+        if isinstance(after, str):
+            after = [after]
+        if (
+            not isinstance(after, list)
+            or not after
+            or not all(isinstance(a, str) for a in after)
+        ):
+            raise ValueError(
+                f"[dependencies] {script!r} needs `after`: a script path or a list of them"
+            )
+        when = spec.get("when", DEFAULT_DEPENDENCY_CONDITION)
+        if when not in DEPENDENCY_CONDITIONS:
+            raise ValueError(
+                f"[dependencies] {script!r}: `when` must be one of "
+                f"{', '.join(DEPENDENCY_CONDITIONS)}, not {when!r}"
+            )
+        declared.append(
+            DeclaredDependency(
+                script=(base / script).resolve(),
+                after=tuple((base / a).resolve() for a in after),
+                when=when,
+            )
+        )
+    return declared

--- a/trilogy/scripts/single_execution.py
+++ b/trilogy/scripts/single_execution.py
@@ -9,6 +9,7 @@ from trilogy.core.statements.execute import (
     ProcessedValidateStatement,
 )
 from trilogy.dialect.results import ChartResult
+from trilogy.execution.outputs import collected_outputs, reset_outputs
 from trilogy.execution.report import (
     emit_asset_refresh,
     emit_asset_refresh_query,
@@ -45,6 +46,7 @@ from trilogy.scripts.display import (
     show_execution_start,
     show_execution_summary,
     show_root_probe_breakdown,
+    show_run_outputs,
     show_statement_result,
     show_statement_type,
     show_watermarks,
@@ -334,6 +336,7 @@ def execute_run_mode(
     """Execute queries in run mode with progress tracking. Under ``dry_run``
     the same statements are compiled and printed, and none of them run."""
     start = datetime.now()
+    reset_outputs()
     show_execution_start(len(queries), dry_run=dry_run)
 
     # Zero executable statements is the whole trigger: an import-only or empty
@@ -368,6 +371,7 @@ def execute_run_mode(
 
     total_duration = datetime.now() - start
     show_execution_summary(len(queries), total_duration, exception is None, total_rows)
+    show_run_outputs(collected_outputs())
 
     if exception:
         raise exception


### PR DESCRIPTION
Two halves of the failure-repair loop for trilogy-cloud, both platform-agnostic: the same script behaves identically under a local `trilogy run .` and on a tenant VM.

## 1. Run outputs

A program run by a `call` statement can hand a value back to whoever ran it by printing one marker line on stdout:

```
::trilogy-output name=fix_pr kind=link value=https://github.com/o/r/pull/45?tab=files
```

- `name` is required; `kind` is `link` | `text` | `json`, defaulting to `link` for an http(s) URL and `text` otherwise; `value` must come last and takes the rest of the line verbatim, so URLs carrying `=` or `&` survive.
- Each output becomes an `output` record in the `--report-file` JSONL report (`name`, `kind`, `value`, `source` = the called program) and is printed in an **Outputs** section after the run summary; JSON mode emits an `outputs` event.
- Outputs are recorded before the exit code is checked, so a script that opened an issue and then failed still reports where the issue is. Marker lines are stripped from the stdout the executor logs; a malformed marker is logged and dropped.

New `trilogy/execution/outputs.py`; `Executor` call handler scans the child's stdout; `report.py` vocabulary documents the record; `show_run_outputs` wired into both the single-file and directory paths.

## 2. Declared dependencies

Directory runs order scripts by derived edges and skip a dependent whose upstream failed. A `[dependencies]` table declares the one edge content cannot express — a script that runs *because* another failed:

```toml
[dependencies]
"repair.preql" = { after = ["refresh.preql"], when = "failed" }
```

- `when` is `completed` (the derived-edge rule, default), `failed`, or `always`. Paths are relative to the toml; naming a script the run does not manage is an error, and a declared cycle is refused like a derived one.
- Loader is stdlib-only in `scripts.project_config` (`load_declared_dependencies`) so trilogy-cloud can share it when ordering a schedule tick; `[dependencies]` is a known section for the config audit.
- `ETLDependencyStrategy` overlays declared edges on the derived graph as a `when` edge attribute (`dependency.edge_condition`).
- The parallel scheduler settles dependents by outcome (`_settle_dependents`): a derived edge skips on failure as before; a `failed`/`always` edge counts every outcome down, and a repair whose upstreams held stands down as a **successful** skip (⊘ in the tracker, `skipped` in the summary, `success=true, skipped=true` in the report) so the run stays green. A dependency-skip is not a failure and never fires a repair.
- README documents the section. Version → 0.3.340.

## Tests

- `tests/execution/test_run_outputs.py` (16): parser, report records, call execution incl. failure, CLI rich/JSON/directory.
- `tests/scripts/test_declared_dependencies.py` (19): loader validation, graph overlay + refusals, scheduler unit cases (fires on failure, stands down on success, `always`, derived skip unchanged, skip-is-not-failure, waits for every upstream), and two end-to-end directory runs: a broken upstream fires the repair which reports its output with exit 1; a healthy upstream stands it down with exit 0.
- `tests/scripts`, `tests/execution`, `tests/cli` and the call suite: 2386 passed; ruff / black / mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KyCf6qs4p2F15W96SaYgqo
