### PR TITLE
[CI] Take network and executor churn out of the test path

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -124,6 +124,16 @@ jobs:
             echo "== $script"
             uv sync --script "$script" || echo "WARNING: could not pre-warm $script"
           done
+      - name: Pre-fetch the gcat parquet fixtures
+        # tests/modeling/gcat/setup.sql builds its tables from nine parquet
+        # files on GCS. Left to the tests that is ~6.5MB plus an INSTALL httpfs
+        # pulled inside the pytest step on every matrix job, and latency is what
+        # hurts: a degraded runner took gcat from 4.4s to 365s while every
+        # CPU-bound test in the same job held at 1.0x. Fetched here it is a
+        # named step and the tests read local files. Like the uv warm above this
+        # is an optimization, never a gate -- the conftest falls back to the
+        # original URLs unless every file is present.
+        run: python .scripts/fetch_gcat_data.py
       - name: Lint with mypy
         run: |
           # stop the build if there are Python syntax errors or undefined names

--- a/.scripts/fetch_gcat_data.py
+++ b/.scripts/fetch_gcat_data.py
@@ -1,0 +1,57 @@
+"""Pre-fetch the gcat parquet fixtures so the test run does no network I/O.
+
+`tests/modeling/gcat/setup.sql` builds its tables from nine parquet files on
+GCS. Left to the tests that is ~6.5MB pulled inside the pytest step, plus an
+`INSTALL httpfs`, on every job of the matrix -- and it is latency, not
+bandwidth, that hurts: a degraded runner once took gcat from 4.4s to 365s.
+Fetched here it is a named step, cacheable, and the tests read local files.
+
+Fetching is an optimization, never a gate. If a download fails the conftest
+falls back to the original URLs, so a run without network access to GCS
+behaves exactly as it did before.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SETUP_SQL = ROOT / "tests" / "modeling" / "gcat" / "setup.sql"
+DATA_DIR = ROOT / "tests" / "modeling" / "gcat" / "data"
+URL_PATTERN = re.compile(r"https://storage\.googleapis\.com/[^']+\.parquet")
+
+
+def urls_from(setup_sql: Path) -> list[str]:
+    return sorted(set(URL_PATTERN.findall(setup_sql.read_text(encoding="utf-8"))))
+
+
+def fetch(url: str, target: Path) -> bool:
+    try:
+        with urllib.request.urlopen(url, timeout=60) as response:
+            payload = response.read()
+    except Exception as e:
+        print(f"WARNING: could not fetch {url}: {e}")
+        return False
+    target.write_bytes(payload)
+    return True
+
+
+def main() -> int:
+    if not SETUP_SQL.exists():
+        print(f"WARNING: {SETUP_SQL} missing; nothing to fetch")
+        return 0
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    for url in urls_from(SETUP_SQL):
+        target = DATA_DIR / url.rsplit("/", 1)[-1]
+        if target.exists() and target.stat().st_size:
+            print(f"cached  {target.name}")
+            continue
+        print(f"{'fetched' if fetch(url, target) else 'FAILED '} {target.name}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/engine/scripts/test_source_pushdown.py
+++ b/tests/engine/scripts/test_source_pushdown.py
@@ -327,24 +327,36 @@ def workspace() -> Path:
     return SCRIPT.parent
 
 
-def sql_for(workspace: Path, query: str) -> str:
-    executor = Dialects.DUCK_DB.default_executor(
+@pytest.fixture(scope="module")
+def executor(workspace: Path):
+    """One executor for the module, with ``MODEL`` already applied.
+
+    Building an executor installs the duckdb extensions and recreates the
+    ``uv_run`` macro -- ~0.37s that used to be paid on every ``sql_for`` and on
+    both sides of every pushdown comparison. Declaring the model once and
+    reusing the connection halves this file's runtime and removes the same
+    number of script spawns, with no loss of coverage: pushdown is chosen when
+    the query is generated, not when the executor is built, so one connection
+    serves both sides.
+    """
+    built = Dialects.DUCK_DB.default_executor(
         environment=Environment(working_path=workspace),
         conf=DuckDBConfig(enable_python_datasources=True),
     )
-    return "\n".join(executor.generate_sql(MODEL + query))
+    built.execute_text(MODEL)
+    return built
 
 
-def rows_for(workspace: Path, query: str, pushdown: bool) -> list[tuple]:
+def sql_for(executor, query: str) -> str:
+    return "\n".join(executor.generate_sql(query))
+
+
+def rows_for(executor, query: str, pushdown: bool) -> list[tuple]:
     original = BaseDialect.source_pushdown
     if not pushdown:
         BaseDialect.source_pushdown = lambda self, cte, address: None
     try:
-        executor = Dialects.DUCK_DB.default_executor(
-            environment=Environment(working_path=workspace),
-            conf=DuckDBConfig(enable_python_datasources=True),
-        )
-        result = executor.execute_text(MODEL + query)
+        result = executor.execute_text(query)
         cursor = result[-1] if isinstance(result, list) else result
         return [tuple(row) for row in cursor.fetchall()]
     finally:
@@ -396,26 +408,26 @@ CASES = [
 
 
 @pytest.mark.parametrize("query,expected_arg", CASES, ids=lambda v: str(v)[:40])
-def test_pushdown_never_changes_the_answer(workspace, query, expected_arg):
-    on = rows_for(workspace, query, pushdown=True)
-    off = rows_for(workspace, query, pushdown=False)
+def test_pushdown_never_changes_the_answer(executor, query, expected_arg):
+    on = rows_for(executor, query, pushdown=True)
+    off = rows_for(executor, query, pushdown=False)
     assert on == off
     assert on, "query returned no rows; it would not discriminate"
 
 
 @pytest.mark.parametrize("query,expected_arg", CASES, ids=lambda v: str(v)[:40])
-def test_pushdown_fires_exactly_where_expected(workspace, query, expected_arg):
-    sql = sql_for(workspace, query)
+def test_pushdown_fires_exactly_where_expected(executor, query, expected_arg):
+    sql = sql_for(executor, query)
     if expected_arg is None:
         assert "args :=" not in sql, sql
     else:
         assert expected_arg in pushed_args(sql), sql
 
 
-def test_a_limit_never_travels_without_its_ordering(workspace):
+def test_a_limit_never_travels_without_its_ordering(executor):
     """The bug this guards: pushing `--limit N` alone under an ORDER BY makes
     the source truncate an arbitrary N rows instead of the top N."""
-    sql = sql_for(workspace, "select id order by id desc limit 5;")
+    sql = sql_for(executor, "select id order by id desc limit 5;")
     args = pushed_args(sql)
     assert "--limit" in args
     assert args.index("--order-by") < args.index("--limit"), args
@@ -426,29 +438,29 @@ def test_render_args_pairs_limit_with_order_by():
     assert render_args(request) == "--order-by id:desc --limit 5"
 
 
-def test_ordered_limit_returns_the_top_rows_not_arbitrary_ones(workspace):
-    rows = rows_for(workspace, "select id order by id desc limit 5;", pushdown=True)
+def test_ordered_limit_returns_the_top_rows_not_arbitrary_ones(executor):
+    rows = rows_for(executor, "select id order by id desc limit 5;", pushdown=True)
     assert [row[0] for row in rows] == [39, 38, 37, 36, 35]
 
 
-def test_a_value_needing_quoting_is_not_pushed_but_still_filters(workspace):
+def test_a_value_needing_quoting_is_not_pushed_but_still_filters(executor):
     """'north side' has a space, so it cannot survive the shell transport."""
     query = "where label = 'north side' select id, label order by id asc;"
-    assert "args :=" not in sql_for(workspace, query)
-    rows = rows_for(workspace, query, pushdown=True)
-    assert rows == rows_for(workspace, query, pushdown=False)
+    assert "args :=" not in sql_for(executor, query)
+    rows = rows_for(executor, query, pushdown=True)
+    assert rows == rows_for(executor, query, pushdown=False)
     assert {row[1] for row in rows} == {"north side"}
 
 
-def test_partial_pushdown_leaves_the_rest_to_sql(workspace):
+def test_partial_pushdown_leaves_the_rest_to_sql(executor):
     """One conjunct is pushable and one is not; the answer is still exact."""
     query = (
         "where state = 'CA' and label = 'north side' "
         "select id, state, label order by id asc;"
     )
-    sql = sql_for(workspace, query)
+    sql = sql_for(executor, query)
     assert "--filter state=CA" in pushed_args(sql)
     assert "label" not in pushed_args(sql)
-    rows = rows_for(workspace, query, pushdown=True)
-    assert rows == rows_for(workspace, query, pushdown=False)
+    rows = rows_for(executor, query, pushdown=True)
+    assert rows == rows_for(executor, query, pushdown=False)
     assert all(row[1] == "CA" and row[2] == "north side" for row in rows)

--- a/tests/modeling/gcat/conftest.py
+++ b/tests/modeling/gcat/conftest.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 from pytest import fixture
@@ -5,6 +6,26 @@ from pytest import fixture
 from trilogy import Dialects, Environment, Executor
 
 ROOT = Path(__file__).parent
+DATA_DIR = ROOT / "data"
+URL_PATTERN = re.compile(r"https://storage\.googleapis\.com/[^']+\.parquet")
+
+
+def localized_setup_sql(setup_sql: Path, data_dir: Path) -> str:
+    """``setup.sql`` with its GCS reads pointed at pre-fetched local parquet.
+
+    Falls back to the original text unless every file is present, so a
+    checkout that never ran `.scripts/fetch_gcat_data.py` behaves exactly as
+    it did before. The httpfs install goes with them: it is only there to
+    read those URLs, and it is a network round trip of its own.
+    """
+    sql = setup_sql.read_text(encoding="utf-8")
+    urls = sorted(set(URL_PATTERN.findall(sql)))
+    local = {url: data_dir / url.rsplit("/", 1)[-1] for url in urls}
+    if not urls or not all(p.exists() and p.stat().st_size for p in local.values()):
+        return sql
+    for url, path in local.items():
+        sql = sql.replace(url, path.as_posix())
+    return sql.replace("INSTALL httpfs;", "").replace("LOAD httpfs;", "")
 
 
 @fixture(scope="session")
@@ -13,7 +34,7 @@ def gcat_env_base():
         working_path=Path(__file__).parent,
     )
     base = Dialects.DUCK_DB.default_executor(environment=env)
-    base.execute_raw_sql(ROOT / "setup.sql")
+    base.execute_raw_sql(localized_setup_sql(ROOT / "setup.sql", DATA_DIR))
     yield base
 
 


### PR DESCRIPTION
When a CI runner degrades, only the tests that touch the network or spawn processes degrade with it. Measured on the same job, same commit:

| file | healthy | degraded | ratio |
| --- | --- | --- | --- |
| `tests/modeling/gcat/test_gcat.py` | 4.4s | 365.0s | **83x** |
| `tests/engine/scripts/test_source_pushdown.py` | 20.8s | 1101.6s | **53x** |
| `tests/engine/scripts/test_python_source.py` | 4.7s | 304.8s | **65x** |
| `tests/modeling/tpc_ds_duckdb/test_queries.py` | 62.3s | 57.8s | 0.9x |
| `tests/complex/test_bound_conversion_existence.py` | 63.7s | 61.6s | 1.0x |
| `tests/rendering/test_rendering.py` | 0.2s | 0.2s | 0.8x |

Twice in two days that was enough to blow the 45-minute job cap — and it fails opaquely, as `The operation was canceled` with **no failing test and no durations**, because no *individual* test crosses `faulthandler_timeout`. This cuts the work instead of widening the cap.

## gcat: fetch the fixtures in a named step

`tests/modeling/gcat/setup.sql` built its tables from nine parquet files on GCS (~6.5MB) plus an `INSTALL httpfs`, pulled inside the pytest step on every job of the matrix. `.scripts/fetch_gcat_data.py` fetches them in a named step and the conftest points `setup.sql` at the local copies, dropping httpfs along with them.

Like the uv warm step above it, this is an optimization and never a gate: unless all nine files are present the conftest returns the original SQL untouched, so a checkout that never runs the script behaves exactly as before. Verified both ways — 40 passed, 1 skipped, identical.

## test_source_pushdown: stop rebuilding the executor

`rows_for`/`sql_for` built a fresh executor per call, paying the model declaration and `uv_run` macro recreation ~30 times at ~0.37s each. One module-scoped executor with the model applied once takes the file from **31.3s to 15.2s** and removes the same number of script spawns.

Pushdown is chosen when the query is generated, not when the executor is built, so one connection still serves both sides of every comparison — no coverage is lost. All 58 tests pass, in random order too.

## Verification

- 303 passed / 1 skipped across `tests/engine/scripts/`, `tests/modeling/gcat/`, `tests/io/`, `tests/ai/test_syntax_examples.py`
- 98 passed in randomized order (fixture-sharing safety)
- `ruff`, `black --check`, `mypy trilogy` all clean

## Note on scope

This is the only part of `more_eval_tuning` (#653) that is not already on main — the planner work there landed as #659. An earlier `UV_OFFLINE` experiment was dropped: it did not prevent a recurrence, and it would turn the uv warm step's deliberately non-gating failure into a hard one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXyHxwSrdhHmjgGExB4Wrz