### PR TITLE
[Bug] Hide partition sources a statement's row gate contradicts (#665)

### DIFF
--- a/tests/engine/test_partition_source_exclusion.py
+++ b/tests/engine/test_partition_source_exclusion.py
@@ -1,0 +1,193 @@
+"""A sibling model's partition sources must never rebuild a target whose row
+gate excludes them: once the statement WHERE contradicts a `complete where`,
+that source is hidden from discovery, so a `merge` origin is planned instead of
+the sibling's direct binding and no union is filtered to nothing."""
+
+import pytest
+
+from trilogy import Dialects
+from trilogy.core.enums import ComparisonOperator
+from trilogy.core.models.build import BuildComparison, BuildWhereClause
+from trilogy.core.processing.partial_bridging import drop_excluded_partials
+
+COMMON = """
+key city enum<string>['A', 'B'];
+key tree_id string;
+property tree_id.dbh float;
+"""
+
+MODEL_A_SOURCES = """
+property tree_id.raw_dbh float;
+auto proc_dbh <- raw_dbh * 1.0;
+merge proc_dbh into dbh;
+
+key a_source enum<string>['A1', 'A2'];
+
+root partial datasource a_one (tree_id: tree_id, city: city, src: a_source, raw: ?raw_dbh)
+grain (tree_id) complete where city = 'A' and a_source = 'A1'
+query '''select 'a1' as tree_id, 'A' as city, 'A1' as src, 1.0 as raw''';
+
+root partial datasource a_two (tree_id: tree_id, city: city, src: a_source, raw: ?raw_dbh)
+grain (tree_id) complete where city = 'A' and a_source = 'A2'
+query '''select 'a2' as tree_id, 'A' as city, 'A2' as src, 2.0 as raw''';
+"""
+
+MODEL_A_TARGET = """
+partial datasource a_out (tree_id, city, src: a_source, ?dbh)
+grain (tree_id) complete where city = 'A'
+address out_a;
+"""
+
+MODEL_B = """
+key b_source enum<string>['B1', 'B2'];
+
+root partial datasource b_one (tree_id: tree_id, city: city, src: b_source, dbh: ?dbh)
+grain (tree_id) complete where city = 'B' and b_source = 'B1'
+query '''select 'b1' as tree_id, 'B' as city, 'B1' as src, 9.0 as dbh''';
+
+root partial datasource b_two (tree_id: tree_id, city: city, src: b_source, dbh: ?dbh)
+grain (tree_id) complete where city = 'B' and b_source = 'B2'
+query '''select 'b2' as tree_id, 'B' as city, 'B2' as src, 8.0 as dbh''';
+"""
+
+MODEL_B_SINGLE = """
+key b_source enum<string>['B1'];
+
+root partial datasource b_one (tree_id: tree_id, city: city, src: b_source, dbh: ?dbh)
+grain (tree_id) complete where city = 'B' and b_source = 'B1'
+query '''select 'b1' as tree_id, 'B' as city, 'B1' as src, 9.0 as dbh''';
+"""
+
+A_ROWS = [("a1", "A", "A1", 1.0), ("a2", "A", "A2", 2.0)]
+
+
+def _executor(*models: str):
+    executor = Dialects.DUCK_DB.default_executor()
+    executor.parse_text("".join(models))
+    return executor
+
+
+def _refresh_target(executor) -> tuple[str, list[tuple]]:
+    target = executor.environment.datasources["a_out"]
+    sql = executor.update_datasource(target, dry_run=True)
+    assert sql is not None
+    executor.update_datasource(target)
+    rows = executor.execute_raw_sql(
+        "select tree_id, city, src, dbh from out_a order by tree_id"
+    ).fetchall()
+    return sql, rows
+
+
+def test_target_alone_builds_from_own_partition():
+    sql, rows = _refresh_target(_executor(COMMON, MODEL_A_SOURCES, MODEL_A_TARGET))
+    assert "a_one" in sql and "a_two" in sql
+    assert rows == A_ROWS
+
+
+@pytest.mark.parametrize(
+    "sibling", [MODEL_B, MODEL_B_SINGLE], ids=["two_partitions", "one_partition"]
+)
+def test_sibling_partition_never_rebuilds_target(sibling):
+    sql, rows = _refresh_target(
+        _executor(COMMON, MODEL_A_SOURCES, MODEL_A_TARGET, sibling)
+    )
+    assert "b_one" not in sql and "b_two" not in sql, sql
+    assert "a_one" in sql and "a_two" in sql, sql
+    assert rows == A_ROWS
+
+
+def test_select_through_merge_reads_own_partition_only():
+    executor = _executor(COMMON, MODEL_A_SOURCES, MODEL_B)
+    a_rows = executor.execute_text(
+        "where city = 'A' select tree_id, dbh order by tree_id asc;"
+    )[-1].fetchall()
+    assert a_rows == [("a1", 1.0), ("a2", 2.0)]
+    b_rows = executor.execute_text(
+        "where city = 'B' select tree_id, dbh order by tree_id asc;"
+    )[-1].fetchall()
+    assert b_rows == [("b1", 9.0), ("b2", 8.0)]
+
+
+def _city_gate(environment, value: str) -> BuildWhereClause:
+    return BuildWhereClause(
+        conditional=BuildComparison(
+            left=environment.concepts["local.city"],
+            right=value,
+            operator=ComparisonOperator.EQ,
+        )
+    )
+
+
+def test_drop_excluded_partials_hides_contradicted_sources():
+    executor = _executor(COMMON, MODEL_A_SOURCES, MODEL_B)
+    environment = executor.environment.materialize_for_select()
+    drop_excluded_partials(environment, _city_gate(environment, "A"))
+    assert set(environment.datasources) == {"a_one", "a_two"}
+
+
+def test_drop_excluded_partials_keeps_everything_without_gate():
+    executor = _executor(COMMON, MODEL_A_SOURCES, MODEL_B)
+    environment = executor.environment.materialize_for_select()
+    before = set(environment.datasources)
+    drop_excluded_partials(environment, None)
+    assert set(environment.datasources) == before
+
+
+def test_drop_excluded_partials_stands_down_for_cross_row_stage():
+    executor = _executor(
+        COMMON, MODEL_A_SOURCES, MODEL_B, "auto tree_count <- count(tree_id) by city;"
+    )
+    environment = executor.environment.materialize_for_select()
+    before = set(environment.datasources)
+    gate = BuildWhereClause(
+        conditional=_city_gate(environment, "A").conditional
+        + BuildComparison(
+            left=environment.concepts["local.tree_count"],
+            right=0,
+            operator=ComparisonOperator.GT,
+        )
+    )
+    drop_excluded_partials(environment, gate)
+    assert set(environment.datasources) == before
+
+
+THREE_WAY = """
+key channel enum<string>['WEB', 'CATALOG', 'STORE'];
+key order_id int;
+property <order_id, channel>.amount float;
+
+partial datasource web (raw(''' 'WEB' '''): channel, id: order_id, amt: amount)
+grain (order_id, channel) complete where channel = 'WEB'
+query '''select 1 as id, 10.0 as amt''';
+
+partial datasource catalog (raw(''' 'CATALOG' '''): channel, id: order_id, amt: amount)
+grain (order_id, channel) complete where channel = 'CATALOG'
+query '''select 2 as id, 20.0 as amt''';
+
+partial datasource store (raw(''' 'STORE' '''): channel, id: order_id, amt: amount)
+grain (order_id, channel) complete where channel = 'STORE'
+query '''select 3 as id, 30.0 as amt''';
+"""
+
+
+def test_surviving_arms_still_union_over_reduced_domain():
+    executor = _executor(THREE_WAY)
+    query = "where channel in ('WEB', 'CATALOG') select sum(amount) as total;"
+    sql = executor.generate_sql(query)[-1]
+    assert "store" not in sql, sql
+    assert executor.execute_text(query)[-1].fetchall() == [(30.0,)]
+
+
+def test_reduced_domain_recorded_by_address_and_canonical():
+    executor = _executor(THREE_WAY)
+    environment = executor.environment.materialize_for_select()
+    gate = BuildWhereClause(
+        conditional=BuildComparison(
+            left=environment.concepts["local.channel"],
+            right=("WEB", "CATALOG"),
+            operator=ComparisonOperator.IN,
+        )
+    )
+    drop_excluded_partials(environment, gate)
+    assert set(environment.datasources) == {"web", "catalog"}
+    assert environment.excluded_enum_values["local.channel"] == frozenset({"STORE"})

--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from trilogy.executor import Executor
     from trilogy.parser import parse
 
-__version__ = "0.3.342"
+__version__ = "0.3.343"
 
 __all__ = [
     "CONFIG",

--- a/trilogy/core/models/build_environment.py
+++ b/trilogy/core/models/build_environment.py
@@ -123,6 +123,11 @@ class BuildEnvironment:
     # instead). Composite of graph facts and author derivations; dissolves once
     # join typing consults per-side origin nodes directly.
     scoped_partial_derived: set[str] = field(default_factory=set)
+    # Discriminator address -> enum values this statement's row gate rules out
+    # (`partial_bridging.drop_excluded_partials`). Partition-family proofs
+    # (union coverage, `merge_conditions`) run over the remaining domain, so
+    # hiding a contradicted arm never breaks the proof the other arms need.
+    excluded_enum_values: dict[str, frozenset[str]] = field(default_factory=dict)
     # Members of each build-scoped join key equivalence group, keyed by the
     # group's canonical address: exactly the authored relation endpoints (union
     # of the scoped merge map's source->canonical entries), NOT the transitive

--- a/trilogy/core/processing/condition_utility.py
+++ b/trilogy/core/processing/condition_utility.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+from collections.abc import Mapping
 from datetime import date, datetime, timedelta
 from decimal import Decimal
 from enum import Enum
@@ -444,6 +445,34 @@ def is_fully_covered(
     return current_end >= end
 
 
+# Discriminator address (or canonical address) -> enum values the statement's
+# row gate rules out. A per-statement view of the domain: a partition family
+# is complete once it covers the values that can still occur.
+ExcludedEnumValues = Mapping[str, frozenset[str]]
+
+
+def gate_allowed_values(conditional: BoolExpr) -> dict[str, set[object]]:
+    """Address -> literal values a row gate's EQ/IS/IN atoms allow."""
+    return _build_allowed_map(decompose_condition(conditional))
+
+
+def effective_enum_domain(
+    datatype: Any,
+    concept: BuildConcept,
+    excluded: ExcludedEnumValues | None,
+) -> Any:
+    """``datatype`` with the values the statement rules out for ``concept``
+    removed, so a domain proof runs over what can still occur."""
+    if not excluded or not isinstance(datatype, EnumType):
+        return datatype
+    gone = excluded.get(concept.address) or excluded.get(concept.canonical_address)
+    if not gone:
+        return datatype
+    return EnumType(
+        type=datatype.type, values=[v for v in datatype.values if str(v) not in gone]
+    )
+
+
 def conditions_cover_domain(
     grouped: dict[str, tuple[Any, list[tuple[ComparisonOperator, Any]]]],
 ) -> bool:
@@ -460,6 +489,7 @@ def conditions_cover_domain(
 
 def simplify_conditions(
     conditions: list[BoolExpr],
+    excluded: ExcludedEnumValues | None = None,
 ) -> bool:
     # Key by address string: concept objects from different datasources may not
     # hash/compare identically even when they represent the same concept.
@@ -490,7 +520,10 @@ def simplify_conditions(
                 return False
             comparison = raw_comparison
 
-        entry = grouped.setdefault(concept.canonical_address, (concept.datatype, []))
+        entry = grouped.setdefault(
+            concept.canonical_address,
+            (effective_enum_domain(concept.datatype, concept, excluded), []),
+        )
         entry[1].append((condition.operator, comparison))
 
     return conditions_cover_domain(grouped)
@@ -725,6 +758,7 @@ def strip_condition_atoms(
 
 def merge_conditions(
     conditions: list[BoolExpr],
+    excluded: ExcludedEnumValues | None = None,
 ) -> BoolExpr | None:
     """Merge a list of OR'd conditions into a minimal equivalent.
 
@@ -749,7 +783,7 @@ def merge_conditions(
     if not all_varying:
         return combine_condition_atoms(common)
 
-    if not simplify_conditions(all_varying):
+    if not simplify_conditions(all_varying, excluded):
         return conditions[0]
 
     return combine_condition_atoms(common)

--- a/trilogy/core/processing/node_generators/select_helpers/datasource_injection.py
+++ b/trilogy/core/processing/node_generators/select_helpers/datasource_injection.py
@@ -16,7 +16,11 @@ from trilogy.core.models.build import (
 )
 from trilogy.core.models.core import EnumType
 from trilogy.core.models.datasource import Address
-from trilogy.core.processing.condition_utility import simplify_conditions
+from trilogy.core.processing.condition_utility import (
+    ExcludedEnumValues,
+    effective_enum_domain,
+    simplify_conditions,
+)
 
 
 def _datasource_score(ds: BuildDatasource) -> int:
@@ -72,6 +76,7 @@ def _best_enum_union(
     dses: list[BuildDatasource],
     enum_type: EnumType,
     merge_key: BuildConcept,
+    excluded: ExcludedEnumValues | None = None,
 ) -> list[list[BuildDatasource]] | None:
     """Find the best minimal covering combinations for an enum-partitioned key.
 
@@ -85,7 +90,13 @@ def _best_enum_union(
     returns vs. dim, all keyed by the same channel enum) each contribute
     their own union datasource instead of collapsing into the single best.
     Materialized table sources score higher than script/query sources.
+    Coverage is judged over the effective domain: values the statement's row
+    gate rules out (``excluded``) need no arm, and an arm for such a value
+    cannot contribute.
     """
+    required = {
+        str(v) for v in effective_enum_domain(enum_type, merge_key, excluded).values
+    }
     by_value: dict[object, list[BuildDatasource]] = defaultdict(list)
     for ds in dses:
         if not ds.non_partial_for:
@@ -93,12 +104,12 @@ def _best_enum_union(
         val = _extract_enum_value_for_key(
             ds.non_partial_for.conditional, merge_key.address
         )
-        if val is None:
+        if val is None or str(val) not in required:
             continue
         by_value[val].append(ds)
 
-    # All enum values must have at least one candidate source
-    if {str(v) for v in by_value} < set(enum_type.values):
+    # Every value that can still occur must have at least one candidate source
+    if not required <= {str(v) for v in by_value}:
         return None
 
     values = list(by_value.keys())
@@ -236,7 +247,9 @@ def _merge_key(dses: list[BuildDatasource], merge_key_addr: str) -> BuildConcept
 
 
 def get_union_sources(
-    datasources: list[BuildDatasource], concepts: list[BuildConcept]
+    datasources: list[BuildDatasource],
+    concepts: list[BuildConcept],
+    excluded: ExcludedEnumValues | None = None,
 ) -> list[list[BuildDatasource]]:
     final: list[list[BuildDatasource]] = []
     for merge_key_addr, dses in _partition_families(datasources, concepts).items():
@@ -244,20 +257,22 @@ def get_union_sources(
         if merge_key is None:
             continue
         if isinstance(merge_key.datatype, EnumType):
-            result = _best_enum_union(dses, merge_key.datatype, merge_key)
+            result = _best_enum_union(dses, merge_key.datatype, merge_key, excluded)
             if result:
                 final.extend(result)
         else:
             conditions = [
                 c.non_partial_for.conditional for c in dses if c.non_partial_for
             ]
-            if simplify_conditions(conditions):
+            if simplify_conditions(conditions, excluded):
                 final.append(dses)
     return final
 
 
 def describe_incomplete_partitions(
-    datasources: list[BuildDatasource], concepts: list[BuildConcept]
+    datasources: list[BuildDatasource],
+    concepts: list[BuildConcept],
+    excluded: ExcludedEnumValues | None = None,
 ) -> str | None:
     """Why a `complete where` family failed to union into a complete source.
 
@@ -274,10 +289,11 @@ def describe_incomplete_partitions(
         if merge_key is None:
             continue
         if isinstance(merge_key.datatype, EnumType):
-            if _best_enum_union(dses, merge_key.datatype, merge_key):
+            if _best_enum_union(dses, merge_key.datatype, merge_key, excluded):
                 continue
         elif simplify_conditions(
-            [c.non_partial_for.conditional for c in dses if c.non_partial_for]
+            [c.non_partial_for.conditional for c in dses if c.non_partial_for],
+            excluded,
         ):
             continue
         names = ", ".join(sorted(d.name for d in dses))

--- a/trilogy/core/processing/node_generators/select_merge_node.py
+++ b/trilogy/core/processing/node_generators/select_merge_node.py
@@ -99,7 +99,8 @@ def create_pruned_concept_graph(
 ) -> ReferenceGraph | None:
     orig_g = g
     g = g.copy()
-    union_options = get_union_sources(datasources, all_concepts)
+    excluded = environment.excluded_enum_values if environment is not None else None
+    union_options = get_union_sources(datasources, all_concepts, excluded)
     concepts_by_address = {c.address: c for c in orig_g.concepts.values()}
     target_grain = BuildGrain.from_concepts(all_concepts)
     rollup_edges: list[tuple[str, str]] = []
@@ -128,7 +129,8 @@ def create_pruned_concept_graph(
                 x.non_partial_for.conditional
                 for x in ds_list
                 if x.non_partial_for is not None
-            ]
+            ],
+            excluded,
         )
         reduced_non_partial_for = (
             BuildWhereClause(conditional=_merged) if _merged is not None else None

--- a/trilogy/core/processing/partial_bridging.py
+++ b/trilogy/core/processing/partial_bridging.py
@@ -11,6 +11,15 @@ the binding is complete for this query. Dropping the modifier up front lets
 the fact anchor the plan with INNER star joins instead of extension
 scaffolding that is then filtered away. Running at one seam
 (``get_query_node``) keeps every downstream consumer on one judgment.
+
+``drop_excluded_partials``: a ``complete where`` source whose partition
+predicate is mutually exclusive with the statement's row gate cannot contribute
+a row, so it is hidden from discovery. Left visible it still counts as a
+binding: a bare key it binds is planned as a scan instead of through its
+``merge`` origin, and a union over the sibling partition is deemed complete and
+then filtered to nothing. The enum values the gate rules out are recorded on
+the environment so the surviving arms are still proven complete over the
+domain that remains.
 """
 
 from __future__ import annotations
@@ -26,8 +35,14 @@ from trilogy.core.models.build import (
     BuildWhereClause,
 )
 from trilogy.core.models.build_environment import BuildEnvironment
-from trilogy.core.processing.condition_utility import condition_proves_non_null
+from trilogy.core.models.core import EnumType
+from trilogy.core.processing.condition_utility import (
+    condition_proves_non_null,
+    conditions_mutually_exclusive,
+    gate_allowed_values,
+)
 from trilogy.core.processing.v4_helper.functional_dependency import build_fd_closure
+from trilogy.core.processing.v4_helper.staged_where import stage_computes_cross_row
 
 
 def _spellings(concept: BuildConcept) -> set[str]:
@@ -212,3 +227,49 @@ def heal_pinned_partials(
             and existing.identifier in replacements
         ):
             environment.datasources[name] = replacements[existing.identifier]
+
+
+def _gate_excluded_enum_values(
+    environment: BuildEnvironment, stage: BuildWhereClause
+) -> dict[str, frozenset[str]]:
+    """Enum discriminator values the gate's literal atoms rule out, keyed by
+    address and canonical address."""
+    out: dict[str, frozenset[str]] = {}
+    for address, allowed in gate_allowed_values(stage.conditional).items():
+        concept = environment.concepts.get(address)
+        if concept is None or not isinstance(concept.datatype, EnumType):
+            continue
+        gone = frozenset(str(v) for v in concept.datatype.values) - {
+            str(v) for v in allowed
+        }
+        if gone:
+            out[concept.address] = gone
+            out[concept.canonical_address] = gone
+    return out
+
+
+def drop_excluded_partials(
+    environment: BuildEnvironment, stage: BuildWhereClause | None
+) -> None:
+    """Hide every ``complete where`` source the first WHERE stage rules out.
+
+    ``stage`` is the statement's stage-1 row gate: every row the statement
+    reads passes it, so a source whose partition predicate contradicts it holds
+    no usable row. A stage that itself computes an aggregate or window sees the
+    full population, so nothing is hidden for it. Removal is from the
+    per-statement mapping only; shared build-cache objects are untouched.
+    """
+    if stage is None or stage_computes_cross_row(stage):
+        return
+    environment.excluded_enum_values = _gate_excluded_enum_values(environment, stage)
+    excluded = [
+        name
+        for name, ds in environment.datasources.items()
+        if isinstance(ds, BuildDatasource)
+        and ds.non_partial_for is not None
+        and conditions_mutually_exclusive(
+            stage.conditional, ds.non_partial_for.conditional
+        )
+    ]
+    for name in excluded:
+        del environment.datasources[name]

--- a/trilogy/core/processing/v4_helper/network_build.py
+++ b/trilogy/core/processing/v4_helper/network_build.py
@@ -276,13 +276,15 @@ def _union_candidates(
         if isinstance(datasource, BuildDatasource)
     ]
     out: dict[str, SourceCandidate] = {}
-    for group in get_union_sources(datasources, terminals):
+    excluded = environment.excluded_enum_values
+    for group in get_union_sources(datasources, terminals, excluded):
         merged = merge_conditions(
             [
                 child.non_partial_for.conditional
                 for child in group
                 if child.non_partial_for is not None
-            ]
+            ],
+            excluded,
         )
         union_datasource = BuildUnionDatasource(
             children=group,

--- a/trilogy/core/processing/v4_helper/source_planning.py
+++ b/trilogy/core/processing/v4_helper/source_planning.py
@@ -289,7 +289,8 @@ def _inject_union_datasources(
         if isinstance(datasource, BuildDatasource)
     ]
     union_edges: list[tuple[str, str]] = []
-    for datasource_group in get_union_sources(datasources, concepts):
+    excluded = environment.excluded_enum_values
+    for datasource_group in get_union_sources(datasources, concepts, excluded):
         node_address = "ds~" + "-".join(
             [datasource.name for datasource in datasource_group]
         )
@@ -300,7 +301,8 @@ def _inject_union_datasources(
                 datasource.non_partial_for.conditional
                 for datasource in datasource_group
                 if datasource.non_partial_for is not None
-            ]
+            ],
+            excluded,
         )
         non_partial_for = (
             BuildWhereClause(conditional=merged_condition)

--- a/trilogy/core/query_processor.py
+++ b/trilogy/core/query_processor.py
@@ -97,6 +97,7 @@ from trilogy.core.processing.nodes import (
     StrategyNode,
 )
 from trilogy.core.processing.partial_bridging import (
+    drop_excluded_partials,
     heal_pinned_partials,
 )
 from trilogy.core.processing.utility import unrenderable_outputs
@@ -960,6 +961,7 @@ def _plan_query_node(
                 if isinstance(x, BuildDatasource)
             ],
             [c for c in ds.partial_concepts if c.address in partial_requested],
+            build_environment.excluded_enum_values,
         )
         raise UnresolvableQueryException(
             f"Query is unresolvable: no complete sources found for output concepts"
@@ -1172,6 +1174,18 @@ def get_query_node(
         build_statement.where_clauses
     ):
         heal_pinned_partials(build_environment, build_statement.where_clause)
+    # A partition source the row gate contradicts holds no usable row for this
+    # statement; hiding it keeps a sibling partition's bindings from standing
+    # in for a `merge` origin or seeding a union that filters to nothing.
+    if isinstance(build_statement, BuildSelectLineage):
+        drop_excluded_partials(
+            build_environment,
+            (
+                build_statement.where_clauses[0]
+                if build_statement.where_clauses
+                else build_statement.where_clause
+            ),
+        )
 
     graph = generate_graph(build_environment)
 


### PR DESCRIPTION
## Description

Fixes #665: a managed datasource with `complete where city = 'A'` was rebuilt from a sibling model's `city = 'B'` partitions once that model was imported into the same environment, publishing an empty file with no error.

Two things combined once the sibling was present:

- The sibling binds the merged concept (`dbh`) directly, so the concept graph treated it as a datasource-bound root and never substituted the `merge` origin (`proc_dbh <- raw_dbh * 1.0`) the owning model relies on.
- The sibling's arms formed a union proven complete over its own discriminator, and when the target's `city = 'A'` gate contradicted every child, the union fallback kept all children with the full filter, which yields zero rows.

The fix adds `drop_excluded_partials` in `trilogy/core/processing/partial_bridging.py`, run at the `get_query_node` seam beside `heal_pinned_partials`. Any `complete where` source whose partition predicate is mutually exclusive with the stage-1 row gate is removed from the per-statement datasource mapping. The enum values the gate rules out are recorded on the build environment (`excluded_enum_values`), and the partition-family proofs (`_best_enum_union`, `merge_conditions`) run over the remaining domain, so hiding a contradicted arm never breaks the coverage proof the surviving arms need. For example `channel in ('WEB', 'CATALOG')` still unions the web and catalog arms without the store arm. A stage that itself computes an aggregate or window sees the full population per the staged-WHERE design and stands down.

With the fix, the issue's repro builds 2 rows from both the single-model and the combined entrypoint, and the single-partition sibling variant that previously failed loudly also builds correctly. Version bumped to 0.3.343.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass

Tests: `tests/engine/test_partition_source_exclusion.py` covers the refresh with a two- and one-partition sibling, a select through the merge in both directions, the helper's own behaviour, and a three-arm enum union under a two-value gate. Full suite (minus adventureworks and live-service markers) passes locally except for tests that need Google credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVWarHncuouQtUKFRJ7Ajn

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVWarHncuouQtUKFRJ7Ajn)_