### PR TITLE
[Perf] Serve DictImportResolver parses from the cross-parse import store

### DIFF
--- a/docs/handoff_dict_resolver_import_store.md
+++ b/docs/handoff_dict_resolver_import_store.md
@@ -1,0 +1,231 @@
+# Handoff: enable the cross-parse import env store for `DictImportResolver`
+
+## STATUS: LANDED 2026-09-04 (branch dict_resolver_perf)
+
+All seven items below are in. What changed, in the terms of the list:
+
+1. **Gate.** `use_store` is true for `DictImportResolver`; the
+   `IMPORT_ENV_STORE_ENABLED` flag still opts out.
+2. **Key.** Dict-resolver store keys carry `hash(text)` of the target
+   (`None` for filesystem keys, which are unchanged), so models sharing an
+   address coexist.
+3. **Closure validation reads through the resolver.** Closure deps are
+   `ClosureKey(on_disk, target)`: an absolute path read off disk, or a dict
+   resolver's canonical `content` key. `_store_lookup` takes a reader
+   callable (`ImportHydrationService._read_closure_text`); a key absent from
+   the dict invalidates the entry and never falls through to the filesystem.
+4. **`copy_for_root`.** `DictImportResolver` no longer has its `content`
+   narrowed per child. It carries a `prefix` (the importing file's dotted
+   directory, set by `copy_for_root`) and `resolve(address)` returns the
+   canonical key: `prefix + address` if present, else `address`. So a nested
+   file's `import x` is `nest.x` when that exists and the top-level `x`
+   otherwise, mirroring a filesystem import trying the file's directory and
+   then `import_paths`. Every parse-local and store key is the canonical key,
+   so a file reached relatively from one importer and absolutely from another
+   parses once. The studio's plain-deepcopy override keeps working unchanged
+   (its keys are already absolute, and its `prefix` stays empty); both shapes
+   are pinned (`test_narrowed_resolver_closure_validates_through_copy_for_root`,
+   `test_flat_config_closure_validates_with_absolute_keys`,
+   `test_nested_dict_import_falls_back_to_the_absolute_address`).
+5. **Parameters.** Child envs are built with `parameters=dict(...)`; a later
+   `set_parameters` on the importer no longer reaches a stored child, and a
+   different value is a different key
+   (`test_stored_child_env_does_not_observe_a_later_set_parameters`).
+6. **Concurrency.** `test_same_dict_model_parsed_concurrently_is_identical`
+   (4 threads x 16 parses, one store).
+7. **Memory.** `set_import_env_store_max(n)`.
+
+**Pre-existing bug fixed on the way.** With a dict resolver, `x` at the top
+level and `x` under `nest` (reached as `nest.child`'s relative `import x`)
+collided in `parsed_environments`, `text_lookup` and `in_flight_imports`,
+which were keyed by the resolver-relative target string; both import orders
+failed with an undefined concept. The same collision was silently *relied on*
+by `tests/modeling/geography/test_proper_resolution.py`, whose nested files
+import top-level modules by absolute name: the old narrowing config could not
+resolve those, but the leaked top-level text made it work when the import
+order happened to parse the top-level file first. Canonical keys fix both:
+relative shadows absolute, order-independent. Pinned by
+`test_nested_dict_import_does_not_collide_with_a_top_level_name` and
+`test_fallback_import_resolves_its_own_imports_from_its_own_directory`.
+
+**Also in this change.** `CTE.dependency_nodes` / `UnionCTE.dependency_nodes`
+return the parent list directly instead of building `SourceBinding`s and
+discarding them (the optimizer called it ~430 times per studio request).
+
+**Measured.** The studio venv imports its own site-packages pytrilogy, so
+`benchmark_endpoints.py` run as documented measures the released wheel, not
+the checkout; the numbers below are the same checkout with the store flag
+off vs on (`PYTHONPATH=<checkout>`, 20 iterations, medians):
+
+| payload / case | store off | store on |
+|---|---:|---:|
+| tpch generate_query | 28.5 ms | 18.7 ms |
+| tpch validate_query (no filters) | 5.9 ms | 1.5 ms |
+| tpch validate_query (4 filters) | 9.2 ms | 3.9 ms |
+| tpch parse_model | 39.5 ms | 21.0 ms |
+| tpch format_query | 5.9 ms | 1.5 ms |
+| tpch generate_queries x8 (batch + per-query) | 203 ms | 166 ms |
+| small_names validate_query (no filters) | 2.5 ms | 0.6 ms |
+
+Warm `generate_query` hydrates zero import files (instrumented: every store
+lookup hits); the residual is the query's own parse (~7%) and the planner.
+The store fills to 7 entries for the tpch model and 11 after `parse_model`.
+
+**Gates run.** `tests/parsing/test_import_env_store.py` (31 with
+`test_reparse_content_version.py`); store off / cold / warm SQL sha256 over all
+132 `query*.preql` (tpc_ds_duckdb + tpc_h) plus the tpch dict model under
+`StudioEnvironmentConfig`, one process, all identical; ruff / mypy / black.
+
+**Not done, by choice.** Closure validation still re-opens stdlib files from
+disk once per parse (6 `open`s per studio request, ~0.3 ms under cProfile);
+a stat-validated process-wide text cache would remove it but is ~1% here and
+adds a staleness surface, so it is left as a note.
+
+---
+
+## Original ask (written 2026-09-04 from a trilogy-studio-core perf audit)
+
+Audience: an agent starting fresh on extending the import environment store
+(`trilogy/parsing/v2/import_service.py::_IMPORT_ENV_STORE`) so that parses
+driven by a `DictImportResolver` benefit from it. Read
+`docs/handoff_immutable_import_envs.md` first for the store's design, its
+integrity stamp, and the namespaced-projection cache that hangs off each
+entry; this handoff is about the one resolver type the store currently
+refuses to serve.
+
+## Why
+
+The trilogy-studio-core resolver service (`pyserver/`) compiles every request
+against a model the client ships in the request body. It builds a fresh
+`Environment` per request with
+
+```python
+Environment(config=StudioEnvironmentConfig(import_resolver=DictImportResolver(content=..., data_files=...)))
+```
+
+where `content` maps dotted addresses (`part`, `nest.child`) to source text
+(`pyserver/env_helpers.py::parse_env_from_full_model`). Because the store gate
+in `ImportHydrationService.execute` is
+
+```python
+use_store = IMPORT_ENV_STORE_ENABLED and (
+    request.is_stdlib
+    or self.in_stdlib
+    or isinstance(environment.config.import_resolver, FileSystemImportResolver)
+)
+```
+
+every request re-hydrates every imported file from scratch. Measured on
+pytrilogy 0.3.343, Python 3.13, TPC-H benchmark payload (11 sources, 6.5 KB,
+`pyserver/scripts/payloads/tpch_large_duckdb.json`):
+
+| path | cost per request | share |
+|---|---:|---:|
+| `generate_query`: env build + import hydration | 3.4 ms | ~13% of 25 ms |
+| `parse_model` (one parse per source, 11 sources) | 58 ms before sharing hydration within the call, 36 ms after | ~5 ms per hydrated file |
+| `build_namespace_projection` | 8 calls per `generate_query` | cached only via the store |
+| Lark/pest `parse_syntax` | ~0 (its `lru_cache` hits: 7,928 hits / 17 misses in the run) | not the problem |
+
+So the cost is hydration (`hydrate_rule`, `_sort_and_create_concepts`,
+`add_import`, `build_namespace_projection`), not parsing, and it scales with
+model size: a 50-file model pays roughly 250 ms of hydration per request
+before any planning happens. Filesystem and stdlib parses already avoid all
+of this through the store; the studio service, which is the highest-volume
+caller of the parser, cannot.
+
+The upstream comment gives the reason for the exclusion:
+
+> Filesystem/stdlib texts come off disk and are process-stable, so the parsed
+> env can be shared across parses; dict-resolver texts are scoped to one
+> environment's resolver.
+
+That is a statement about the *key*, not about the mechanism. The store
+already validates an entry on reuse by re-hashing the transitive text closure
+(`_store_lookup`), so a dict-resolver entry keyed on content rather than on
+path is exactly as safe as a filesystem entry.
+
+## What to change
+
+1. **Gate.** Let `use_store` be true for `DictImportResolver` too. Keep the
+   flag so a caller can opt out.
+
+2. **Key.** For dict resolvers the address is not unique across callers:
+   two studio users can both have a file called `customer` with different
+   contents, and the service hosts many models in one process. Add
+   `hash(text)` of the target to `store_key` when the resolver is a dict (the
+   closure hash of the target is already checked in `_store_lookup`, but with
+   it in the key, alternating models no longer evict each other from the
+   LRU; they coexist). Filesystem keys can stay as they are.
+
+3. **Closure validation must read through the resolver.** `_store_lookup`
+   validates dependencies with `text_lookup.get(Path(path))` and, on a miss,
+   `safe_open(path)`. For a dict resolver a miss must read from
+   `environment.config.import_resolver.content` (see `_read_import_text`,
+   which already does this) and a key absent from the dict must invalidate
+   the entry rather than hit the filesystem. `_store_lookup` does not
+   currently receive the environment; thread it through (or pass a reader
+   callable).
+
+4. **`copy_for_root`.** The base `EnvironmentConfig.copy_for_root` narrows
+   the content dict to the keys under `root` so nested relative imports
+   resolve. The store's `root` key component already accounts for this on
+   the filesystem side. Check that the dict-narrowed resolver produces the
+   same `request.target` strings the closure was recorded under, otherwise
+   validation will look up the wrong keys. Note that the studio service
+   overrides `copy_for_root` to a plain `deepcopy` (no narrowing,
+   `pyserver/env_helpers.py::StudioEnvironmentConfig`), so both shapes need
+   a test.
+
+5. **Parameters are shared by reference.** A child env is built with
+   `parameters=environment.parameters`, the same dict object as the parent,
+   and `_params_fingerprint(environment.parameters)` is part of the key.
+   The studio calls `env.set_parameters(...)` on the *parent* after imports
+   have been parsed (`pyserver/query_helpers.py::filters_to_conditional`),
+   which mutates the dict the cached child holds. This is pre-existing for
+   filesystem parses, but the studio path exercises it on every filtered
+   dashboard query, so pin it: a stored child env must not observe a later
+   `set_parameters` on the importer, and a lookup under different parameters
+   must miss.
+
+6. **Concurrency.** The studio service parses on a thread pool (two threads
+   per process by default). The store's lock only guards the `OrderedDict`;
+   the shared envs rely on the read-only contract plus the integrity stamp,
+   the same as a directory run. Add a test that parses the same dict model
+   from several threads at once and gets identical output.
+
+7. **Memory.** `_IMPORT_ENV_STORE_MAX = 128` entries, each a whole
+   `Environment` plus its projections. A multi-tenant service will fill that
+   with many small models; that is fine, but make the cap settable (config or
+   `set_import_env_store_max`) so a deployment can size it.
+
+## How to verify
+
+- Unit: parse the same dict model twice with fresh `Environment`s and assert
+  the second parse performs no hydration of the imported files (count
+  `NativeHydrator.parse` calls for child contexts, or assert
+  `_IMPORT_ENV_STORE` hits). Then change one imported file's text and assert
+  a re-hydration of that file and of everything that transitively imports
+  it, but nothing else.
+- Cross-talk: two resolvers with the same address and different contents,
+  parsed alternately, must each get their own concepts; and after the change
+  they must both stay resident (key includes the content hash).
+- Existing suite: `tests/` must stay byte-identical on SQL; the store-off /
+  cold / warm three-leg comparison from `handoff_immutable_import_envs.md`
+  is the template.
+- End to end: in trilogy-studio-core, `pyserver/scripts/benchmark_endpoints.py`
+  prints per-endpoint medians for the two benchmark payloads. With the store
+  serving dict resolvers, the `generate_query` env+import share should drop
+  to near zero on a warm model and `parse_model` should approach the cost of
+  hydrating each source's own statements only. Compare against
+  `pyserver/benchmark_baseline.md` and the numbers above.
+
+## Pointers
+
+- Gate and store: `trilogy/parsing/v2/import_service.py` (`execute`,
+  `_store_lookup`, `_store_fill`, `_env_integrity`, `_ImportEnvEntry`).
+- Dict resolver and `copy_for_root`: `trilogy/core/models/environment.py`.
+- Studio caller: `trilogy-studio-core/pyserver/env_helpers.py`
+  (`parse_env_from_full_model`, `StudioEnvironmentConfig`,
+  `parse_source_into_env` which already shares `parsed_environments` and
+  `text_lookup` across one `parse_model` call as a stopgap).
+- Studio benchmark: `trilogy-studio-core/pyserver/scripts/benchmark_endpoints.py`.

--- a/docs/handoff_dict_resolver_import_store.md
+++ b/docs/handoff_dict_resolver_import_store.md
@@ -76,6 +76,20 @@ The store fills to 7 entries for the tpch model and 11 after `parse_model`.
 132 `query*.preql` (tpc_ds_duckdb + tpc_h) plus the tpch dict model under
 `StudioEnvironmentConfig`, one process, all identical; ruff / mypy / black.
 
+**Determinism fix found on the way.** `tests/modeling/tpc_ds_duckdb/zquery29.log`
+changed a CTE name between runs. Not the store: on origin/main the same query
+rendered `sparkling` under `PYTHONHASHSEED=0/2` and `sweltering` under seed 1.
+Planning and the pre-optimization CTE graph were identical across seeds; the
+divergence was `query_processor.generate_source_map`, which dedup'd each
+provider list with `list(set(v))`. With two equivalent parent CTEs (`macho`
+had `abhorrent` and `late`, one the `_extent_free_` variant of the other),
+the list order set the CTE's base alias and the renderer's `used_map`, so
+`MergeIrrelevantGroupBy` kept whichever came first in hash order. Now
+`list(dict.fromkeys(v))`, and the `BuildDatasource` pass is sorted by
+`safe_identifier`. All 132 corpus queries render identically under four hash
+seeds (`scratchpad corpus_seeds.py` pattern: one subprocess per seed);
+`test_q04_generation_determinism.py` is parametrized to cover query29.
+
 **Not done, by choice.** Closure validation still re-opens stdlib files from
 disk once per parse (6 `open`s per studio request, ~0.3 ms under cProfile);
 a stat-validated process-wide text cache would remove it but is ~1% here and

--- a/docs/handoff_query_gen_hotspots.md
+++ b/docs/handoff_query_gen_hotspots.md
@@ -1,0 +1,87 @@
+# Handoff: query-generation hotspots after the import store (2026-09-04)
+
+## STATUS: not started (evidence from the dict_resolver_perf pass, PR #667)
+
+Audience: an agent starting fresh on the next query-generation perf increment.
+`docs/handoff_dict_resolver_import_store.md` removed import hydration from the
+studio request path; what is left is planner- and optimizer-bound, and flat.
+Nothing below is a single dominant cost, so pick by risk, not by size.
+
+## How to measure
+
+- Studio benchmark: `trilogy-studio-core/pyserver/scripts/benchmark_endpoints.py`
+  run with `PYTHONPATH=<this checkout>` (the studio venv has its own
+  site-packages pytrilogy; without the override it measures the released
+  wheel). Payloads in `pyserver/tests/payloads/`. Judge by call counts under
+  cProfile first, walls second; the box is spiky.
+- Corpus gate: store off / cold / warm SQL sha256 over all 132 `query*.preql`
+  in one process must stay identical, and the same 132 must render
+  identically across `PYTHONHASHSEED` 0..3 (one subprocess per seed).
+
+## Warm `generate_query` profile (tpch payload, 20 iterations under cProfile)
+
+Total 1.07 s / 20 = 53 ms profiled (18.7 ms real). Shares of the request:
+
+| region | share | calls / request | note |
+|---|---:|---:|---|
+| `process_query` | 86% | 1 | everything below |
+| `search_concepts` -> `build_strategy_node` | 45% | 1 | planning |
+| `merge_node._resolve` | 28% | 3 (6 nested) | `generate_joins` 10%, `calculate_joined_pregrain` 2% |
+| `get_node_joins` | 10% | 6 | `resolve_join_order_v2` 3% |
+| `optimize_ctes` | 14% | 1 | 18 rule-loop iterations |
+| `reorder_ctes` | 4.5% | 18 | rebuilt per loop iteration |
+| `gen_inverse_map` | 1.1% | 21 | rebuilt per loop iteration |
+| `hide_unused_concept.optimize` | 2% | 6 | |
+| `inline_datasource.optimize` | 1.2% | 24 | |
+| `render_cte` | 8% | 6 | |
+| `parse_text` (the query itself, 2 parses) | 7% | 2 | not import hydration |
+| `extent_null_addresses` | 3.5% | 74 (recursive) | `join_resolution.py:151` |
+| `utility.unique` | 3.5% | 432 | see below |
+| `concepts_to_build_grain_concepts` | 5% | 87 | `build.py:489`, sorts each call |
+| `source_bindings` | 4.5% | 450 | now bypassed by `dependency_nodes` (PR #667) |
+| `inlined_alias_map` | 2% | 213 | property, sorts each call |
+| `_io.open` | 0.6% | 6 | stdlib closure validation reads |
+
+## Candidates, cheapest first
+
+1. **`utility.unique` callers.** 432 calls per request: `CTE.__post_init__`
+   (execute.py:157, 1120 calls/20), `CTE.__add__` (execute.py:296, 1800/20),
+   `base_node.__init__` (920/20), `optimize_ctes` look_at (420/20). `unique`
+   builds a dict per call. Most callers pass lists that are already unique;
+   a cheap check (`len(set(...)) == len(...)` is still O(n)) will not beat
+   it, so look at whether `__post_init__` needs to dedup at all when the
+   constructor sites already do.
+2. **`inlined_alias_map` / `concepts_to_build_grain_concepts`.** Recomputed
+   per access; both sort. `inlined_alias_map` depends on `parent_ctes` and
+   `inlined_parents`, which optimization rules mutate in place, so a cached
+   value needs invalidation on those writes (there is no setter today;
+   `add_dependency` / `replace_dependency` / `add_inlined_datasource` are the
+   known writers, but rules also assign `cte.parent_ctes = ...` directly:
+   `merge_irrelevant_group_by.py` does). Grep for `parent_ctes =` before
+   caching. `concepts_to_build_grain_concepts` is pure over its inputs and
+   could memoize on a tuple of addresses.
+3. **Stdlib text cache.** `ImportHydrationService._read_closure_text` reads
+   the six stdlib files from disk once per parse (text_lookup is per parse).
+   A process-wide `{path: (st_mtime_ns, st_size, text)}` cache keyed off
+   `os.stat` removes it. ~1% here; more on container disks. Left out of
+   PR #667 because it adds a staleness surface for a small win.
+4. **`optimize_ctes` incremental graph.** `reorder_ctes` +
+   `gen_inverse_map` rebuild the whole CTE dependency graph on every rule
+   loop iteration (18-21 per request). Rules return whether they acted; an
+   incremental update (or rebuilding only after an action, which is what the
+   `while not complete` loop already tracks via `actions_taken`) would cut
+   most rebuilds. Check `_optimization_visit_order` too. This is the largest
+   self-contained win but touches the driver every rule depends on: run the
+   corpus gate and the full suite.
+5. **Planner.** `merge_node._resolve` and `get_node_joins` are the biggest
+   pieces but they are the algorithm; `extent_null_addresses` recursing 74
+   times per request (`join_resolution.py:151`) is the one spot that looks
+   like repeated work over the same inputs. Profile before touching; the
+   v4 planner memories in MEMORY.md list the shapes that broke last time.
+
+## Gates
+
+`tests/parsing/test_import_env_store.py`, the corpus store gate, the four-seed
+determinism gate, `tests/modeling/tpc_ds_duckdb/test_queries.py` +
+`tests/modeling/tpc_h`, then the full suite
+`-m "not adventureworks_execution and not clickhouse_server"` (35 min here).

--- a/tests/modeling/tpc_ds_duckdb/test_q04_generation_determinism.py
+++ b/tests/modeling/tpc_ds_duckdb/test_q04_generation_determinism.py
@@ -12,32 +12,40 @@ Generation is in-process deterministic, so each seed needs its own
 interpreter: the test re-runs this module as a subprocess per seed. Seeds 0/1
 diverged at plan time (exposure order) and seed 2 at render time (pseudonym
 walk in CTE.get_alias); together they pin all three ordering fixes.
+
+query29 pins a fourth: `generate_source_map` dedup'd each provider list through
+a set, so with two equivalent parent CTEs the renderer's base alias (and which
+CTE survived optimization) followed the hash seed.
 """
 
 import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 working_path = Path(__file__).parent
 
 SEEDS = ("0", "1", "2")
+FILES = ("_q04_agent_rowset_union_join.preql", "query29.preql")
 
 
-def _generate() -> str:
+def _generate(name: str) -> str:
     from trilogy import Dialects
     from trilogy.core.models.environment import Environment
 
-    text = (working_path / "_q04_agent_rowset_union_join.preql").read_text()
+    text = (working_path / name).read_text()
     env = Environment(working_path=working_path)
     executor = Dialects.DUCK_DB.default_executor(environment=env)
     return executor.generate_sql(text)[-1]
 
 
-def test_q04_generation_deterministic_and_binds():
+@pytest.mark.parametrize("name", FILES)
+def test_generation_deterministic_and_binds(name: str):
     results: dict[str, str] = {}
     for seed in SEEDS:
         proc = subprocess.run(
-            [sys.executable, __file__],
+            [sys.executable, __file__, name],
             capture_output=True,
             text=True,
             timeout=300,
@@ -68,4 +76,4 @@ def test_q04_generation_deterministic_and_binds():
 
 
 if __name__ == "__main__":
-    print(_generate())
+    print(_generate(sys.argv[1]))

--- a/tests/modeling/tpc_ds_duckdb/zquery29.log
+++ b/tests/modeling/tpc_ds_duckdb/zquery29.log
@@ -1,5 +1,5 @@
 query_id = "29"
-gen_length = 7670
+gen_length = 7661
 preql_size = 1692
 comp_size = 1350
 generated_sql = """
@@ -67,7 +67,7 @@ WHERE
 GROUP BY
     1,
     2),
-sweltering as (
+sparkling as (
 SELECT
     \"vacuous\".\"store_sales_store_id\" as \"store_sales_store_id\",
     \"vacuous\".\"store_sales_store_name\" as \"store_sales_store_name\",
@@ -94,12 +94,12 @@ SELECT
     \"friendly\".\"_per_pair_item_id\" as \"per_pair_item_id\",
     \"friendly\".\"_per_pair_store_name\" as \"per_pair_store_name\",
     \"friendly\".\"_per_pair_store_text_id\" as \"per_pair_store_text_id\",
-    \"sweltering\".\"_per_pair_cq\" as \"per_pair_cq\",
-    \"sweltering\".\"_per_pair_sq\" as \"per_pair_sq\",
-    \"sweltering\".\"_per_pair_srq\" as \"per_pair_srq\"
+    \"sparkling\".\"_per_pair_cq\" as \"per_pair_cq\",
+    \"sparkling\".\"_per_pair_sq\" as \"per_pair_sq\",
+    \"sparkling\".\"_per_pair_srq\" as \"per_pair_srq\"
 FROM
-    \"sweltering\"
-    INNER JOIN \"friendly\" on \"sweltering\".\"store_sales_customer_sk\" = \"friendly\".\"_per_pair_customer_sk\" AND \"sweltering\".\"store_sales_item_sk\" = \"friendly\".\"_per_pair_item_sk\" AND \"sweltering\".\"store_sales_store_id\" is not distinct from \"friendly\".\"_per_pair_store_text_id\" AND \"sweltering\".\"store_sales_store_name\" is not distinct from \"friendly\".\"_per_pair_store_name\"
+    \"sparkling\"
+    INNER JOIN \"friendly\" on \"sparkling\".\"store_sales_customer_sk\" = \"friendly\".\"_per_pair_customer_sk\" AND \"sparkling\".\"store_sales_item_sk\" = \"friendly\".\"_per_pair_item_sk\" AND \"sparkling\".\"store_sales_store_id\" is not distinct from \"friendly\".\"_per_pair_store_text_id\" AND \"sparkling\".\"store_sales_store_name\" is not distinct from \"friendly\".\"_per_pair_store_name\"
 GROUP BY
     1,
     2,

--- a/tests/parsing/test_import_env_store.py
+++ b/tests/parsing/test_import_env_store.py
@@ -78,13 +78,10 @@ def test_transitive_content_invalidation(model_dir: Path):
 
 def test_integrity_invalidation_on_shared_mutation(model_dir: Path):
     _fresh(model_dir)
-    entry = next(
-        e
-        for e in isvc._IMPORT_ENV_STORE.values()
-        if any(k.endswith("base_ds") for k in e.env.datasources)
-    )
-    cached_ds = next(iter(entry.env.datasources.values()))
-    cached_ds.columns = cached_ds.columns[:-1]
+    # mid's entry is the one a re-parse looks up (base is reached through it)
+    for entry in isvc._IMPORT_ENV_STORE.values():
+        cached_ds = next(iter(entry.env.datasources.values()))
+        cached_ds.columns = cached_ds.columns[:-1]
     # the mutated entry is evicted and re-parsed; the fresh parse sees full columns
     recovered = _fresh(model_dir)
     ds = next(v for k, v in recovered.datasources.items() if k.endswith("base_ds"))
@@ -578,3 +575,21 @@ def test_fallback_import_resolves_its_own_imports_from_its_own_directory():
     env = _dict_env(model)
     parse("import nest.child as child;\nselect child.c;", env)
     assert "child.x.y.top_y" in env.concepts.data
+
+
+def test_deleted_dependency_invalidates_the_entry(model_dir: Path):
+    _fresh(model_dir)
+    (model_dir / "base.preql").unlink()
+    with pytest.raises(ImportError):
+        _fresh(model_dir)
+    # mid's entry could not be validated (its dependency is gone) and is evicted
+    assert not any(
+        any(k.target.endswith("mid.preql") for k in e.closure)
+        for e in isvc._IMPORT_ENV_STORE.values()
+    )
+
+
+def test_missing_dict_key_is_an_import_error():
+    env = _dict_env({"leaf": "key id int;"})
+    with pytest.raises(ImportError, match="not resolvable"):
+        parse("import absent as absent;", env)

--- a/tests/parsing/test_import_env_store.py
+++ b/tests/parsing/test_import_env_store.py
@@ -2,18 +2,22 @@
 
 The store shares parsed import Environments across fresh top-level parses.
 Entries are validated by re-hashing the transitive text closure and by an
-env-integrity stamp; anything not context-free (cycles, dict-resolver text)
-never enters the store.
+env-integrity stamp; anything not context-free (a cycle stub) never enters
+the store. Dict-resolver entries are keyed on content as well as address, and
+their closures are validated by reading back through the resolver.
 """
 
+import copy
 import sys
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
 
 from trilogy import Environment, parse
 from trilogy.core.models.environment import DictImportResolver, EnvironmentConfig
+from trilogy.parsing.v2 import hydration as hyd
 from trilogy.parsing.v2 import import_service as isvc
 
 
@@ -97,16 +101,6 @@ def test_cycle_participants_never_cached(tmp_path: Path):
     env2 = Environment(working_path=str(tmp_path))
     parse("import a as a;", env2)
     assert sorted(env2.concepts.data.keys()) == sorted(env.concepts.data.keys())
-
-
-def test_dict_resolver_bypasses_store():
-    config = EnvironmentConfig(
-        import_resolver=DictImportResolver(content={"leaf": "key id int;\n"})
-    )
-    env = Environment(config=config)
-    parse("import leaf as leaf;\nselect leaf.id;", env)
-    assert "leaf.id" in env.concepts.data
-    assert len(isvc._IMPORT_ENV_STORE) == 0
 
 
 def test_store_disabled_flag(model_dir: Path, monkeypatch):
@@ -347,3 +341,240 @@ def test_projection_publish_is_atomic_under_threads(model_dir: Path):
     )
 
     assert not errors, f"racing projection_for raised: {errors[:3]}"
+
+
+# --- dict resolver -----------------------------------------------------------
+
+DICT_MODEL = {
+    "base": "key id int;\nproperty id.name string;\n"
+    "datasource base_ds (id: id, name: name) grain (id) address base_tbl;\n",
+    "mid": "import base as base;\nauto id_doubled <- base.id * 2;\n",
+    "other": "key other_id int;\n",
+}
+DICT_ROOT = (
+    "import mid as mid;\nimport other as other;\nselect mid.base.id, mid.id_doubled;"
+)
+
+
+def _dict_env(content: dict[str, str], config_cls=EnvironmentConfig) -> Environment:
+    return Environment(
+        config=config_cls(import_resolver=DictImportResolver(content=dict(content)))
+    )
+
+
+@pytest.fixture
+def hydrations(monkeypatch) -> list[str]:
+    """Targets hydrated from scratch (the root parse excluded)."""
+    seen: list[str] = []
+    original = hyd.NativeHydrator.parse
+
+    def spy(self, document, ephemeral=False):
+        if self.token_address != "root":
+            seen.append(str(self.token_address))
+        return original(self, document, ephemeral)
+
+    monkeypatch.setattr(hyd.NativeHydrator, "parse", spy)
+    return seen
+
+
+def test_dict_resolver_second_parse_hydrates_nothing(hydrations: list[str]):
+    reference = _dict_env(DICT_MODEL)
+    parse(DICT_ROOT, reference)
+    assert sorted(hydrations) == ["base", "mid", "other"]
+    hydrations.clear()
+    warm = _dict_env(DICT_MODEL)
+    parse(DICT_ROOT, warm)
+    assert hydrations == []
+    assert _sig(reference) == _sig(warm)
+
+
+def test_dict_resolver_edit_rehydrates_only_the_affected_closure(
+    hydrations: list[str],
+):
+    parse(DICT_ROOT, _dict_env(DICT_MODEL))
+    hydrations.clear()
+    edited = {**DICT_MODEL, "base": DICT_MODEL["base"] + "property id.extra string;\n"}
+    env = _dict_env(edited)
+    parse(DICT_ROOT, env)
+    # base changed, mid imports base; other is untouched
+    assert sorted(hydrations) == ["base", "mid"]
+    assert "mid.base.extra" in env.concepts.data
+
+
+def test_dict_resolvers_sharing_an_address_coexist(hydrations: list[str]):
+    a = {"leaf": "key a_id int;\n"}
+    b = {"leaf": "key b_id int;\n"}
+    for content, expected in ((a, "leaf.a_id"), (b, "leaf.b_id"), (a, "leaf.a_id")):
+        env = _dict_env(content)
+        parse("import leaf as leaf;", env)
+        assert expected in env.concepts.data
+    # a and b each hydrated exactly once: the second parse of a was a hit
+    assert hydrations == ["leaf", "leaf"]
+    assert len(isvc._IMPORT_ENV_STORE) == 2
+
+
+def test_dict_resolver_store_disabled_flag(monkeypatch):
+    monkeypatch.setattr(isvc, "IMPORT_ENV_STORE_ENABLED", False)
+    reference = _dict_env(DICT_MODEL)
+    parse(DICT_ROOT, reference)
+    assert len(isvc._IMPORT_ENV_STORE) == 0
+    warm = _dict_env(DICT_MODEL)
+    parse(DICT_ROOT, warm)
+    assert _sig(reference) == _sig(warm)
+
+
+NESTED_MODEL = {
+    "x": "key top_x int;\n",
+    "nest.x": "key nested_x int;\n",
+    "nest.child": "import x as x;\nauto c <- x.nested_x * 2;\n",
+}
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "import x as x;\nimport nest.child as child;\nselect child.c, x.top_x;",
+        "import nest.child as child;\nimport x as x;\nselect child.c, x.top_x;",
+    ],
+)
+def test_nested_dict_import_does_not_collide_with_a_top_level_name(text: str):
+    """`nest.child`'s `import x` resolves under its own directory first, so it
+    is `nest.x`; the parse-local caches must not confuse it with the top `x`."""
+    env = _dict_env(NESTED_MODEL)
+    parse(text, env)
+    assert {"x.top_x", "child.x.nested_x", "child.c"} <= set(env.concepts.data)
+
+
+def test_narrowed_resolver_closure_validates_through_copy_for_root(
+    hydrations: list[str],
+):
+    text = "import nest.child as child;\nselect child.c;"
+    parse(text, _dict_env(NESTED_MODEL))
+    assert sorted(hydrations) == ["nest.child", "x"]
+    hydrations.clear()
+    parse(text, _dict_env(NESTED_MODEL))
+    assert hydrations == []
+    # editing the NESTED x (not the top-level one) invalidates nest.child
+    edited = {**NESTED_MODEL, "x": "key top_x int;\nkey unrelated int;\n"}
+    parse(text, _dict_env(edited))
+    assert hydrations == []
+    edited = {**NESTED_MODEL, "nest.x": "key nested_x int;\nkey nested_y int;\n"}
+    env = _dict_env(edited)
+    parse(text, env)
+    assert sorted(hydrations) == ["nest.child", "x"]
+    assert "child.x.nested_y" in env.concepts.data
+
+
+class _FlatConfig(EnvironmentConfig):
+    """The studio's shape: every dict key is absolute, nothing is narrowed."""
+
+    def copy_for_root(self, root: str | None) -> "_FlatConfig":
+        return copy.deepcopy(self)
+
+
+FLAT_MODEL = {
+    "shared.base": "key id int;\n",
+    "nest.child": "import shared.base as base;\nauto c <- base.id * 2;\n",
+}
+
+
+def test_flat_config_closure_validates_with_absolute_keys(hydrations: list[str]):
+    text = "import nest.child as child;\nimport shared.base as base;\nselect child.c, base.id;"
+    reference = _dict_env(FLAT_MODEL, _FlatConfig)
+    parse(text, reference)
+    # shared.base is a diamond (direct + via nest.child) and hydrates once
+    assert sorted(hydrations) == ["nest.child", "shared.base"]
+    hydrations.clear()
+    warm = _dict_env(FLAT_MODEL, _FlatConfig)
+    parse(text, warm)
+    assert hydrations == []
+    assert _sig(reference) == _sig(warm)
+    edited = {**FLAT_MODEL, "shared.base": "key id int;\nkey extra int;\n"}
+    env = _dict_env(edited, _FlatConfig)
+    parse(text, env)
+    assert sorted(hydrations) == ["nest.child", "shared.base"]
+    assert "child.base.extra" in env.concepts.data
+
+
+PARAM_MODEL = {"leaf": "param scale int;\nkey id int;\nauto scaled <- id * scale;\n"}
+
+
+def test_stored_child_env_does_not_observe_a_later_set_parameters(
+    hydrations: list[str],
+):
+    env = _dict_env(PARAM_MODEL)
+    env.set_parameters(scale=2)
+    parse("import leaf as leaf;", env)
+    entry = next(iter(isvc._IMPORT_ENV_STORE.values()))
+    env.set_parameters(scale=3)
+    assert entry.env.parameters == {"scale": 2}
+    hydrations.clear()
+    # a different parameter value is a different entry, not a stale hit
+    env2 = _dict_env(PARAM_MODEL)
+    env2.set_parameters(scale=3)
+    parse("import leaf as leaf;", env2)
+    assert hydrations == ["leaf"]
+    assert len(isvc._IMPORT_ENV_STORE) == 2
+
+
+def test_same_dict_model_parsed_concurrently_is_identical():
+    def work(_: int) -> tuple:
+        env = _dict_env(DICT_MODEL)
+        parse(DICT_ROOT, env)
+        return _sig(env)
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        sigs = list(pool.map(work, range(16)))
+    assert all(s == sigs[0] for s in sigs)
+    assert len(isvc._IMPORT_ENV_STORE) == 3
+
+
+def test_store_max_is_settable(monkeypatch):
+    monkeypatch.setattr(isvc, "_IMPORT_ENV_STORE_MAX", 128)
+    parse(DICT_ROOT, _dict_env(DICT_MODEL))
+    assert len(isvc._IMPORT_ENV_STORE) == 3
+    isvc.set_import_env_store_max(1)
+    assert len(isvc._IMPORT_ENV_STORE) == 1
+    parse(DICT_ROOT, _dict_env(DICT_MODEL))
+    assert len(isvc._IMPORT_ENV_STORE) == 1
+
+
+FALLBACK_MODEL = {
+    "core": "key id int;\n",
+    "y": "key top_y int;\n",
+    "nest.y": "key nested_y int;\n",
+    "nest.child": "import core as core;\nimport y as y;\nauto c <- core.id * 2;\n",
+}
+
+
+def test_nested_dict_import_falls_back_to_the_absolute_address(
+    hydrations: list[str],
+):
+    """A nested file may import a top-level module by its full address (the
+    studio ships every address absolute); a relative match still wins."""
+    text = "import nest.child as child;\nimport core as core;\nselect child.c;"
+    env = _dict_env(FALLBACK_MODEL)
+    parse(text, env)
+    assert {"child.core.id", "child.y.nested_y", "core.id"} <= set(env.concepts.data)
+    # core is one file however it is reached: hydrated once, not once per depth
+    assert sorted(hydrations) == ["core", "nest.child", "y"]
+    hydrations.clear()
+    edited = {**FALLBACK_MODEL, "core": "key id int;\nkey extra int;\n"}
+    env = _dict_env(edited)
+    parse(text, env)
+    assert sorted(hydrations) == ["core", "nest.child"]
+    assert "child.core.extra" in env.concepts.data
+
+
+def test_fallback_import_resolves_its_own_imports_from_its_own_directory():
+    """`x` reached from inside `nest` by absolute fallback is the top-level
+    file, so ITS relative imports resolve at the top level, not under nest."""
+    model = {
+        "x": "import y as y;\nauto v <- y.top_y;\n",
+        "y": "key top_y int;\n",
+        "nest.y": "key nested_y int;\n",
+        "nest.child": "import x as x;\nauto c <- x.v * 2;\n",
+    }
+    env = _dict_env(model)
+    parse("import nest.child as child;\nselect child.c;", env)
+    assert "child.x.y.top_y" in env.concepts.data

--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from trilogy.executor import Executor
     from trilogy.parser import parse
 
-__version__ = "0.3.344"
+__version__ = "0.3.345"
 
 __all__ = [
     "CONFIG",

--- a/trilogy/core/models/environment.py
+++ b/trilogy/core/models/environment.py
@@ -234,6 +234,20 @@ class DictImportResolver(BaseImportResolver):
     # a key in this map is treated as published even when there is no real file
     # on disk — useful for server / sandboxed environments.
     data_files: dict[str, bytes] = field(default_factory=dict)
+    # Dotted directory of the file whose imports this resolver serves: "" at
+    # the top level, "nest." inside `nest.child`. An import resolves under it
+    # first and then as an absolute address, the way a filesystem import tries
+    # the importing file's directory before `import_paths`.
+    prefix: str = ""
+
+    def resolve(self, address: str) -> str | None:
+        """Canonical `content` key for an import address, or None."""
+        relative = self.prefix + address
+        if relative in self.content:
+            return relative
+        if address in self.content:
+            return address
+        return None
 
     def has_data_file(self, *paths: str) -> bool:
         return any(p in self.data_files for p in paths)
@@ -247,16 +261,11 @@ class EnvironmentConfig:
     )
 
     def copy_for_root(self, root: str | None) -> EnvironmentConfig:
+        """Config for parsing an imported file; `root` is the file's canonical
+        dotted directory (or None at the top level)."""
         new = copy.deepcopy(self)
-        if isinstance(new.import_resolver, DictImportResolver) and root:
-            new.import_resolver = DictImportResolver(
-                content={
-                    k[len(root) + 1 :]: v
-                    for k, v in new.import_resolver.content.items()
-                    if k.startswith(f"{root}.")
-                },
-                data_files=new.import_resolver.data_files,
-            )
+        if isinstance(new.import_resolver, DictImportResolver):
+            new.import_resolver.prefix = f"{root}." if root else ""
         return new
 
 

--- a/trilogy/core/models/execute.py
+++ b/trilogy/core/models/execute.py
@@ -877,11 +877,12 @@ class CTE:
         self,
         include_inlined: bool = False,
     ) -> list[CTE | UnionCTE]:
-        return [
-            binding.node
-            for binding in self.source_bindings(include_inlined=include_inlined)
-            if binding.node is not None
-        ]
+        # The node list of source_bindings without building the bindings: the
+        # optimizer walks this per CTE per rule pass.
+        nodes: list[CTE | UnionCTE] = list(self.parent_ctes)
+        if include_inlined:
+            nodes.extend(self.inlined_parents)
+        return nodes
 
     def add_dependency(self, parent: CTE | UnionCTE) -> None:
         self.parent_ctes = unique(self.parent_ctes + [parent], "name")
@@ -1920,11 +1921,10 @@ class UnionCTE:
         self,
         include_branches: bool = False,
     ) -> list[CTE | UnionCTE]:
-        return [
-            binding.node
-            for binding in self.source_bindings(include_branches=include_branches)
-            if binding.node is not None
-        ]
+        nodes: list[CTE | UnionCTE] = list(self.parent_ctes)
+        if include_branches:
+            nodes.extend(self.internal_ctes)
+        return nodes
 
     def source_key_for(self, source: str | CTE | UnionCTE) -> str:
         if isinstance(source, str):

--- a/trilogy/core/query_processor.py
+++ b/trilogy/core/query_processor.py
@@ -248,7 +248,10 @@ def generate_source_map(
         unnest = [x for x in qdv if isinstance(x, UnnestJoin)]
         for _ in unnest:
             source_map[qdk] = []
-        basic = [x for x in qdv if isinstance(x, BuildDatasource)]
+        basic = sorted(
+            (x for x in qdv if isinstance(x, BuildDatasource)),
+            key=lambda x: x.safe_identifier,
+        )
         for base in basic:
             source_map[qdk].append(base.safe_identifier)
 
@@ -305,8 +308,10 @@ def generate_source_map(
             cte.name for cte in all_new_ctes if cte.source.safe_identifier in ids
         ]
         existence_source_map[ek] = ematches
+    # Order-preserving dedup: the list order is the renderer's provider
+    # preference (base alias, used_map), so it must not follow the hash seed.
     return {
-        k: [] if not v else list(set(v)) for k, v in source_map.items()
+        k: list(dict.fromkeys(v)) for k, v in source_map.items()
     }, existence_source_map
 
 

--- a/trilogy/parsing/v2/hydration.py
+++ b/trilogy/parsing/v2/hydration.py
@@ -118,7 +118,7 @@ class HydrationContext:
     import_keys: list[str] | None = None
     symbol_table: SymbolTable | None = None
     semantic_state: SemanticState | None = None
-    in_flight_imports: set[str] | None = None
+    in_flight_imports: set[ImportEnvCacheKey] | None = None
     closure_stack: list | None = None
     local_closures: dict | None = None
     in_stdlib: bool = False

--- a/trilogy/parsing/v2/import_service.py
+++ b/trilogy/parsing/v2/import_service.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import threading
 from collections import OrderedDict
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from os.path import dirname
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 from trilogy.constants import Parsing
 from trilogy.core.models.environment import (
@@ -77,10 +78,8 @@ def _suggest_import_paths(
 def _read_import_text(
     address: str, environment: Environment, is_stdlib: bool = False
 ) -> str:
-    if (
-        isinstance(environment.config.import_resolver, FileSystemImportResolver)
-        or is_stdlib
-    ):
+    resolver = environment.config.import_resolver
+    if isinstance(resolver, FileSystemImportResolver) or is_stdlib:
         try:
             with safe_open(address) as f:
                 return f.read()
@@ -93,52 +92,65 @@ def _read_import_text(
             )
             hint = f" Did you mean: {', '.join(suggestions)}?" if suggestions else ""
             raise ImportError(f"Unable to import '{address}': {exc}.{hint}") from exc
-    if isinstance(environment.config.import_resolver, DictImportResolver):
-        if address not in environment.config.import_resolver.content:
+    if isinstance(resolver, DictImportResolver):
+        key = resolver.resolve(address)
+        if key is None:
             raise ImportError(
                 f"Unable to import file {address}, not resolvable from provided source files."
             )
-        return environment.config.import_resolver.content[address]
+        return resolver.content[key]
     raise ImportError(
         f"Unable to import file {address}, resolver type "
-        f"{type(environment.config.import_resolver)} not supported"
+        f"{type(resolver)} not supported"
     )
 
 
-# Cache key for parsed import environments: (resolved target, config root).
+# Parse-local cache key for parsed import environments: (canonical target,
+# config root). Filesystem targets are absolute paths; dict-resolver targets
+# are the resolver's canonical `content` key, so a file reached relatively
+# from one importer and absolutely from another parses once.
 ImportEnvCacheKey = tuple[str, str | None]
+
+
+class ClosureKey(NamedTuple):
+    """One text an import environment depends on: an absolute path read off
+    disk, or a dict resolver's canonical content key."""
+
+    on_disk: bool
+    target: str
 
 
 # ---------------------------------------------------------------------------
 # Cross-parse import environment store.
 #
-# A parsed import file's Environment is a pure function of the resolved file
-# path, the parse-relevant config (duplicate-declaration flag, import search
+# A parsed import file's Environment is a pure function of the resolved
+# target, the parse-relevant config (duplicate-declaration flag, import search
 # paths, parameter values) and the CONTENT of the file plus everything it
 # transitively imports. Entries are validated on reuse by re-hashing that text
-# closure and by an env-integrity stamp that catches post-parse mutation of
-# the cached environment through shared objects (bare imports share objects
-# with the importing environment; see Environment.add_import). Filesystem and
-# stdlib resolution only: dict-resolver texts are re-scoped per copy_for_root
-# and are not stable process-wide.
+# closure through the importing env's resolver and by an env-integrity stamp
+# that catches post-parse mutation of the cached environment through shared
+# objects (bare imports share objects with the importing environment; see
+# Environment.add_import). Dict-resolver targets are not unique across
+# resolvers, so their keys carry the target's own text hash: models that share
+# an address coexist instead of evicting each other.
 # ---------------------------------------------------------------------------
 
 
 @dataclass
 class _ClosureFrame:
-    """Per-import-parse dependency recorder: resolved path -> hash(text) for
+    """Per-import-parse dependency recorder: closure key -> hash(text) for
     the file and everything parsed beneath it. `tainted` marks a parse whose
-    result is not context-free (cycle/depth stub baked in, or non-filesystem
-    text) and must never enter the process-wide store."""
+    result is not context-free (cycle/depth stub baked in) and must never
+    enter the process-wide store."""
 
-    deps: dict[str, int] = field(default_factory=dict)
+    deps: dict[ClosureKey, int] = field(default_factory=dict)
     tainted: bool = False
 
 
 @dataclass
 class _ImportEnvEntry:
     env: Environment
-    closure: dict[str, int]
+    closure: dict[ClosureKey, int]
     integrity: tuple
     # `with_namespace(alias)` products of `env`, keyed by alias. Only valid
     # while `env` itself is — they are dropped with the entry. Each is
@@ -176,6 +188,17 @@ def clear_import_env_store() -> None:
         _IMPORT_ENV_STORE.clear()
 
 
+def set_import_env_store_max(size: int) -> None:
+    """Size the store for the deployment: each entry holds a whole parsed
+    Environment plus its namespaced projections, and a multi-tenant service
+    fills it with one entry per (model file, content)."""
+    global _IMPORT_ENV_STORE_MAX
+    with _IMPORT_ENV_STORE_LOCK:
+        _IMPORT_ENV_STORE_MAX = size
+        while len(_IMPORT_ENV_STORE) > size:
+            _IMPORT_ENV_STORE.popitem(last=False)
+
+
 def _params_fingerprint(parameters: dict) -> tuple:
     return tuple(sorted((k, repr(v)) for k, v in parameters.items()))
 
@@ -197,28 +220,22 @@ def _env_integrity(env: Environment) -> tuple:
 
 
 def _store_lookup(
-    key: tuple, own_hash: int, text_lookup: dict[Path | str, str]
+    key: tuple,
+    own_key: ClosureKey,
+    own_hash: int,
+    read_text: Callable[[ClosureKey], str | None],
 ) -> _ImportEnvEntry | None:
     with _IMPORT_ENV_STORE_LOCK:
         entry = _IMPORT_ENV_STORE.get(key)
     if entry is None:
         return None
-    target = key[0]
-    valid = entry.closure.get(target) == own_hash
+    valid = entry.closure.get(own_key) == own_hash
     if valid:
-        for path, expected in entry.closure.items():
-            if path == target:
+        for dep, expected in entry.closure.items():
+            if dep == own_key:
                 continue
-            text = text_lookup.get(Path(path))
-            if text is None:
-                try:
-                    with safe_open(path) as f:
-                        text = f.read()
-                except OSError:
-                    valid = False
-                    break
-                text_lookup[Path(path)] = text
-            if hash(text) != expected:
+            text = read_text(dep)
+            if text is None or hash(text) != expected:
                 valid = False
                 break
     if valid and _env_integrity(entry.env) != entry.integrity:
@@ -252,11 +269,11 @@ class ImportHydrationService:
     )
     text_lookup: dict[Path | str, str] = field(default_factory=dict)
     import_keys: list[str] = field(default_factory=list)
-    # Target paths whose parse is currently on the call stack. Used to break
+    # Imports whose parse is currently on the call stack. Used to break
     # circular imports at re-entry rather than recursing until max_parse_depth.
     # Shared by reference across child ImportHydrationServices via
     # HydrationContext so cycle detection sees the full parse stack.
-    in_flight_imports: set[str] = field(default_factory=set)
+    in_flight_imports: set[ImportEnvCacheKey] = field(default_factory=set)
     # Closure recording for the cross-parse store: per-parse dependency frames
     # (shared across child services like in_flight_imports) plus the recorded
     # closure for each local parsed_environments entry.
@@ -275,21 +292,57 @@ class ImportHydrationService:
     def set_text(self, key: Path | str, text: str) -> None:
         self.text_lookup[key] = text
 
+    def _read_closure_text(self, key: ClosureKey) -> str | None:
+        if key.on_disk:
+            path = Path(key.target)
+            text = self.text_lookup.get(path)
+            if text is None:
+                try:
+                    with safe_open(key.target) as f:
+                        text = f.read()
+                except OSError:
+                    return None
+                self.text_lookup[path] = text
+            return text
+        resolver = self.environment.config.import_resolver
+        if not isinstance(resolver, DictImportResolver):
+            return None
+        return resolver.content.get(key.target)
+
     def execute(self, request: ImportRequest) -> ImportStatement:
         from trilogy.parsing.parse_engine_v2 import parse_syntax
         from trilogy.parsing.v2.hydration import HydrationContext, NativeHydrator
 
         environment = self.environment
+        resolver = environment.config.import_resolver
         key_path = self.import_keys + [request.cache_key]
         cache_lookup = "-".join(key_path)
-        target_key = str(request.token_lookup)
+        is_dict = not request.is_stdlib and isinstance(resolver, DictImportResolver)
+        # Cache parsed import environments by canonical target + config root
+        # rather than the alias chain: the parsed env is namespace-neutral and
+        # identical regardless of which alias imports it, so a file reachable
+        # via multiple import paths parses exactly once. add_import still
+        # applies the per-edge namespace downstream.
+        target = str(request.target)
+        if is_dict:
+            assert isinstance(resolver, DictImportResolver)
+            canonical = resolver.resolve(target)
+            if canonical is None:
+                raise ImportError(
+                    f"Unable to import file {target}, not resolvable from provided source files."
+                )
+            target = canonical
+        root = None
+        if "." in target:
+            root = target.rsplit(".", 1)[0]
+        env_cache_key: ImportEnvCacheKey = (target, root)
 
         # Cycle detection: a parse currently on the stack re-encounters
         # itself. Break by returning a stub ImportStatement and registering
         # the alias as a deferred namespace; downstream concept lookups in
         # this parser produce partial placeholders via ConceptLookup rather
         # than recursing until max_parse_depth and failing.
-        if target_key in self.in_flight_imports:
+        if env_cache_key in self.in_flight_imports:
             if self.semantic_state is not None:
                 self.semantic_state.add_deferred_import_alias(request.alias)
             if self.closure_stack:
@@ -309,29 +362,20 @@ class ImportHydrationService:
                 path=Path(request.target),
             )
 
-        if request.token_lookup in self.text_lookup:
+        if is_dict:
+            assert isinstance(resolver, DictImportResolver)
+            text = resolver.content[target]
+        elif request.token_lookup in self.text_lookup:
             text = self.text_lookup[request.token_lookup]
         else:
             text = _read_import_text(request.target, environment, request.is_stdlib)
             self.text_lookup[request.token_lookup] = text
+        own_hash = hash(text)
+        own_key = ClosureKey(not is_dict, target)
 
-        # Cache parsed import environments by resolved file + config root rather
-        # than the alias chain: the parsed env is namespace-neutral and identical
-        # regardless of which alias imports it, so a file reachable via multiple
-        # import paths parses exactly once. add_import still applies the per-edge
-        # namespace downstream.
-        root = None
-        if "." in str(request.token_lookup):
-            root = str(request.token_lookup).rsplit(".", 1)[0]
-        env_cache_key: ImportEnvCacheKey = (str(request.target), root)
-
-        # Filesystem/stdlib texts come off disk and are process-stable, so the
-        # parsed env can be shared across parses; dict-resolver texts are
-        # scoped to one environment's resolver.
         use_store = IMPORT_ENV_STORE_ENABLED and (
             request.is_stdlib
-            or self.in_stdlib
-            or isinstance(environment.config.import_resolver, FileSystemImportResolver)
+            or isinstance(resolver, (FileSystemImportResolver, DictImportResolver))
         )
         # The active deployment env is part of the key: its transform rewrites
         # datasource Addresses in place, and those Address objects are shared
@@ -341,8 +385,9 @@ class ImportHydrationService:
 
         activation = active_env()
         store_key = (
-            str(request.target),
+            target,
             root,
+            own_hash if is_dict else None,
             environment.config.allow_duplicate_declaration,
             tuple(str(p) for p in environment.import_paths),
             _params_fingerprint(environment.parameters),
@@ -364,7 +409,9 @@ class ImportHydrationService:
             if local is not None and local.env is new_env:
                 store_entry = local
         elif use_store and (
-            entry := _store_lookup(store_key, hash(text), self.text_lookup)
+            entry := _store_lookup(
+                store_key, own_key, own_hash, self._read_closure_text
+            )
         ):
             store_entry = entry
             new_env = entry.env
@@ -373,17 +420,20 @@ class ImportHydrationService:
             if self.closure_stack:
                 self.closure_stack[-1].deps.update(entry.closure)
         else:
-            self.in_flight_imports.add(target_key)
+            self.in_flight_imports.add(env_cache_key)
             frame = _ClosureFrame(tainted=not use_store)
             self.closure_stack.append(frame)
             try:
                 document = parse_syntax(text)
+                # Parameters are snapshotted: the importer's dict keeps being
+                # written by set_parameters after the parse, and a stored child
+                # env must not observe values its key never fingerprinted.
                 new_env = Environment(
                     working_path=dirname(request.target),
                     import_paths=list(environment.import_paths),
                     env_file_path=request.token_lookup,
                     config=environment.config.copy_for_root(root=root),
-                    parameters=environment.parameters,
+                    parameters=dict(environment.parameters),
                 )
                 child_context = HydrationContext(
                     environment=new_env,
@@ -406,9 +456,9 @@ class ImportHydrationService:
                     f"Unable to import '{request.target}', parsing error: {e}"
                 ) from e
             finally:
-                self.in_flight_imports.discard(target_key)
+                self.in_flight_imports.discard(env_cache_key)
                 self.closure_stack.pop()
-            frame.deps[str(request.target)] = hash(text)
+            frame.deps[own_key] = own_hash
             self.local_closures[env_cache_key] = frame
             if use_store and not frame.tainted:
                 store_entry = _ImportEnvEntry(
@@ -421,9 +471,7 @@ class ImportHydrationService:
                 self.closure_stack[-1].deps.update(frame.deps)
                 self.closure_stack[-1].tainted |= frame.tainted
 
-        is_file_resolver = isinstance(
-            environment.config.import_resolver, FileSystemImportResolver
-        )
+        is_file_resolver = isinstance(resolver, FileSystemImportResolver)
         parsed_path = Path(request.input_path)
         # Aliased imports namespace-copy the whole source env; when it came from
         # the store it is validated-unchanged, so that copy is reusable across

--- a/trilogy/parsing/v2/import_service.py
+++ b/trilogy/parsing/v2/import_service.py
@@ -77,12 +77,14 @@ def _suggest_import_paths(
 
 def _read_import_text(
     address: str, environment: Environment, is_stdlib: bool = False
-) -> str:
+) -> tuple[str, str]:
+    """(canonical target, text): the address itself for a disk read, the
+    resolver's canonical content key for a dict resolver."""
     resolver = environment.config.import_resolver
     if isinstance(resolver, FileSystemImportResolver) or is_stdlib:
         try:
             with safe_open(address) as f:
-                return f.read()
+                return address, f.read()
         except OSError as exc:
             if is_stdlib:
                 raise
@@ -98,7 +100,7 @@ def _read_import_text(
             raise ImportError(
                 f"Unable to import file {address}, not resolvable from provided source files."
             )
-        return resolver.content[key]
+        return key, resolver.content[key]
     raise ImportError(
         f"Unable to import file {address}, resolver type "
         f"{type(resolver)} not supported"
@@ -305,9 +307,11 @@ class ImportHydrationService:
                 self.text_lookup[path] = text
             return text
         resolver = self.environment.config.import_resolver
-        if not isinstance(resolver, DictImportResolver):
-            return None
-        return resolver.content.get(key.target)
+        return (
+            resolver.content.get(key.target)
+            if isinstance(resolver, DictImportResolver)
+            else None
+        )
 
     def execute(self, request: ImportRequest) -> ImportStatement:
         from trilogy.parsing.parse_engine_v2 import parse_syntax
@@ -324,14 +328,15 @@ class ImportHydrationService:
         # via multiple import paths parses exactly once. add_import still
         # applies the per-edge namespace downstream.
         target = str(request.target)
+        # Dict-resolver texts are read straight off the resolver: text_lookup
+        # is keyed by the request target, and a nested `x` is not the top `x`.
         if is_dict:
-            assert isinstance(resolver, DictImportResolver)
-            canonical = resolver.resolve(target)
-            if canonical is None:
-                raise ImportError(
-                    f"Unable to import file {target}, not resolvable from provided source files."
-                )
-            target = canonical
+            target, text = _read_import_text(target, environment)
+        elif request.token_lookup in self.text_lookup:
+            text = self.text_lookup[request.token_lookup]
+        else:
+            _, text = _read_import_text(target, environment, request.is_stdlib)
+            self.text_lookup[request.token_lookup] = text
         root = None
         if "." in target:
             root = target.rsplit(".", 1)[0]
@@ -362,14 +367,6 @@ class ImportHydrationService:
                 path=Path(request.target),
             )
 
-        if is_dict:
-            assert isinstance(resolver, DictImportResolver)
-            text = resolver.content[target]
-        elif request.token_lookup in self.text_lookup:
-            text = self.text_lookup[request.token_lookup]
-        else:
-            text = _read_import_text(request.target, environment, request.is_stdlib)
-            self.text_lookup[request.token_lookup] = text
         own_hash = hash(text)
         own_key = ClosureKey(not is_dict, target)
 


### PR DESCRIPTION
## Why

The import environment store (`_IMPORT_ENV_STORE`) only served filesystem and stdlib parses. The studio resolver service builds a fresh `Environment` with a `DictImportResolver` per request, so every request re-hydrated its whole import tree. The store's validation (closure text re-hash + env integrity stamp) was already content-safe; only the key was address-only. Details and design in `docs/handoff_dict_resolver_import_store.md`.

## What

- **Dict-resolver parses use the store.** Store keys carry `hash(text)` for dict targets so models sharing an address coexist instead of evicting each other. Closure deps are `ClosureKey(on_disk, target)`, validated through a reader callable the service supplies (a key missing from the dict invalidates; never falls through to disk).
- **Canonical import keys.** `DictImportResolver` keeps its full `content` and carries a `prefix` (set by `copy_for_root`); `resolve(address)` returns `prefix + address` if present, else `address`. Relative shadows absolute, like a filesystem import trying the file's directory before `import_paths`. Every parse-local and store key uses the canonical key, so a file reached relatively from one importer and absolutely from another parses once.
  - Fixes a pre-existing collision: a top-level `x` and a nested `nest.x` shared `parsed_environments` / `text_lookup` / `in_flight_imports` keys, and both import orders failed with an undefined concept.
  - That same collision was silently load-bearing for `tests/modeling/geography/test_proper_resolution.py`, whose nested files import top-level modules by absolute name. The fallback is now explicit and order-independent.
- Child envs snapshot `parameters` (a later `set_parameters` on the importer no longer reaches a stored child); `set_import_env_store_max()` sizes the LRU.
- `CTE.dependency_nodes` / `UnionCTE.dependency_nodes` return the parent list directly instead of building and discarding `SourceBinding`s (~430 calls per studio request).
- Version 0.3.345.

## Measured

Studio `pyserver/scripts/benchmark_endpoints.py`, tpch payload, same checkout, store flag off vs on (20 iterations, medians). Note the studio venv imports its own site-packages trilogy, so the script must be run with `PYTHONPATH=<checkout>` to measure a branch.

| case | store off | store on |
|---|---:|---:|
| generate_query | 28.5 ms | 18.7 ms |
| validate_query (no filters) | 5.9 ms | 1.5 ms |
| validate_query (4 filters) | 9.2 ms | 3.9 ms |
| parse_model | 39.5 ms | 21.0 ms |
| format_query | 5.9 ms | 1.5 ms |
| generate_queries x8 | 203 ms | 166 ms |

Warm `generate_query` hydrates zero import files; what remains is the query's own parse and the planner.

## Generation determinism (found on the way)

`zquery29.log` changed a CTE name between runs. Not the store: on main the same query rendered `sparkling` under `PYTHONHASHSEED=0/2` and `sweltering` under seed 1. Planning and the pre-optimization CTE graph were identical across seeds; `query_processor.generate_source_map` dedup'd each provider list with `list(set(v))`, so with two equivalent parent CTEs the list order (which sets the CTE's base alias and the renderer's `used_map`) followed the hash seed and `MergeIrrelevantGroupBy` kept whichever came first. Now an order-preserving dedup, plus the `BuildDatasource` pass sorted by `safe_identifier`. All 132 tpc_ds/tpc_h queries render identically under four hash seeds; `test_q04_generation_determinism.py` is parametrized to cover query29 too.

## Verification

- `tests/parsing/test_import_env_store.py`: 12 new dict-resolver tests (second parse hydrates nothing, transitive invalidation only of the affected closure, same-address models coexist, nested/top-level collision, narrowing and flat `copy_for_root` shapes, absolute fallback, parameters snapshot, 4-thread concurrency, settable max).
- Store off / cold / warm SQL sha256 over all 132 `query*.preql` (tpc_ds_duckdb + tpc_h) plus the tpch dict model, one process: all identical.
- Full suite `-m "not adventureworks_execution and not clickhouse_server"`: 8716 passed.
- ruff / mypy / black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DLxMRcZcy1ZNMrseF4XpXy

