### PR TITLE
[Bug] Carry a derived join axis through filter/union projections; apply datasource `where` on write

### DIFF
--- a/tests/core/processing/test_v4_union_join_key_widening.py
+++ b/tests/core/processing/test_v4_union_join_key_widening.py
@@ -1,0 +1,81 @@
+"""Join-key widening over a UnionNode: a union renders what EVERY arm renders,
+is widened arm by arm, and never descends into its arms one at a time."""
+
+from trilogy import Environment
+from trilogy.core.processing.nodes import SelectNode, UnionNode
+from trilogy.core.processing.v4_helper.projection import (
+    renderable_addresses,
+    widen_projection,
+)
+from trilogy.core.processing.v4_helper.strategy_builder import _widen_scan_chain
+
+MODEL = """
+key id string;
+key part enum<string>['x', 'y'];
+property id.lat float;
+property id.lon float;
+property id.note string;
+
+root partial datasource px (id: id, part: part, lat: lat, lon: lon, note: note)
+grain (id)
+complete where part = 'x'
+query '''select 'a' as id, 'x' as part, 1.0 as lat, 1.0 as lon, 'n' as note''';
+
+root partial datasource py (id: id, part: part, lat: lat, lon: lon)
+grain (id)
+complete where part = 'y'
+query '''select 'b' as id, 'y' as part, 2.0 as lat, 2.0 as lon''';
+
+auto cell <- concat(cast(floor(lat) as string), ':', cast(floor(lon) as string));
+auto tagged <- concat(id, note);
+"""
+
+
+def _union():
+    env = Environment()
+    env.parse(MODEL)
+    build = env.materialize_for_select()
+    projected = [build.concepts["id"], build.concepts["part"]]
+    arms = [
+        SelectNode(
+            input_concepts=projected,
+            output_concepts=projected,
+            environment=build,
+            datasource=build.datasources[name],
+        )
+        for name in ("px", "py")
+    ]
+    union = UnionNode(
+        input_concepts=projected,
+        output_concepts=projected,
+        environment=build,
+        parents=arms,
+    )
+    return build, union
+
+
+def test_union_renders_what_every_arm_binds():
+    _, union = _union()
+    available = renderable_addresses(union)
+    assert {"local.lat", "local.lon"} <= available
+    assert "local.note" not in available
+
+
+def test_scan_chain_widens_union_and_every_arm():
+    build, union = _union()
+    cell = build.concepts["cell"]
+    assert _widen_scan_chain(union, cell)
+    assert cell.address in {o.address for o in union.output_concepts}
+    for arm in union.parents:
+        assert cell.address in {o.address for o in arm.output_concepts}
+    assert "local.lat" not in {i.address for i in union.input_concepts}
+
+
+def test_scan_chain_declines_a_column_one_arm_cannot_render():
+    build, union = _union()
+    tagged = build.concepts["tagged"]
+    assert not _widen_scan_chain(union, tagged)
+    assert not widen_projection(union, [tagged])
+    assert tagged.address not in {o.address for o in union.output_concepts}
+    for arm in union.parents:
+        assert tagged.address not in {o.address for o in arm.output_concepts}

--- a/tests/engine/test_duckdb_derived_axis_rejoin.py
+++ b/tests/engine/test_duckdb_derived_axis_rejoin.py
@@ -1,0 +1,124 @@
+"""An aggregate grouped by a DERIVED axis (`min(x) by cell`, cell computed from
+row properties) joined back to the rows it came from.
+
+The FINAL merge re-sources its row contributor to the keys it projects, and the
+join-key carry synthesizes the sibling's axis onto it. That carry widened only
+plain projections and merges: a row-preserving FilterNode (the inline filter's
+CASE projection) and a UnionNode (partitioned `complete where` sources) were
+skipped, so the axis was never rendered on the row side and the merge raised
+the keyless-join guard. Which spelling failed depended on which node kind
+happened to sit at the row side of the merge.
+"""
+
+import pytest
+
+from trilogy import Dialects, Environment
+
+SINGLE = """
+key id string;
+property id.src string;
+property id.lat float;
+property id.lon float;
+
+datasource rows (id: id, src: src, lat: lat, lon: lon)
+grain (id)
+query '''
+select * from (values ('a', 'm', 1.0, 1.0), ('b', 'o', 1.0, 1.0), ('c', 'o', 2.0, 2.0))
+as t(id, src, lat, lon)
+''';
+
+auto cell <- concat(cast(floor(lat) as string), ':', cast(floor(lon) as string));
+auto anchor <- min(id ? src != 'o') by cell;
+auto anchor_any <- min(id) by cell;
+"""
+
+PARTITIONED = """
+key city enum<string>['A'];
+key id string;
+key source enum<string>['municipal', 'community', 'osm'];
+property id.cell string;
+
+root partial datasource municipal (id: id, city: city, source: source, cell: cell)
+grain (id)
+complete where city = 'A' and source = 'municipal'
+query '''select * from (values ('tem-1', 'A', 'municipal', 'c1'), ('tem-2', 'A', 'municipal', 'c2')) as t(id, city, source, cell)''';
+
+root partial datasource community (id: id, city: city, source: source, cell: cell)
+grain (id)
+complete where city = 'A' and source = 'community'
+query '''select * from (values ('community-1', 'A', 'community', 'c2')) as t(id, city, source, cell)''';
+
+root partial datasource osm (id: id, city: city, source: source, cell: cell)
+grain (id)
+complete where city = 'A' and source = 'osm'
+query '''select * from (values ('osm-1', 'A', 'osm', 'c1'), ('osm-2', 'A', 'osm', 'c3')) as t(id, city, source, cell)''';
+
+auto anchor <- min(id ? source != 'osm') by cell;
+auto row_key <- concat(id, '#');
+auto self_by_key <- min(id ? source = 'municipal') by id;
+auto self_by_alias <- min(id ? source = 'municipal') by row_key;
+auto c_by_key <- coalesce(self_by_key, anchor, id);
+auto c_by_alias <- coalesce(self_by_alias, anchor, id);
+auto is_primary <- id = c_by_alias;
+"""
+
+
+def _run(model: str, query: str) -> list[tuple]:
+    env = Environment()
+    env.parse(model)
+    executor = Dialects.DUCK_DB.default_executor(environment=env)
+    return executor.execute_text(query)[-1].fetchall()
+
+
+@pytest.mark.parametrize(
+    "query,expected",
+    [
+        (
+            "select id, anchor order by id asc;",
+            [("a", "a"), ("b", "a"), ("c", None)],
+        ),
+        (
+            "select id, coalesce(anchor, id) as c order by id asc;",
+            [("a", "a"), ("b", "a"), ("c", "c")],
+        ),
+        (
+            "select id, anchor where id != 'zz' order by id asc;",
+            [("a", "a"), ("b", "a"), ("c", None)],
+        ),
+        (
+            "select id, anchor_any order by id asc;",
+            [("a", "a"), ("b", "a"), ("c", "c")],
+        ),
+    ],
+)
+def test_filtered_aggregate_over_derived_axis_rejoins_rows(query, expected):
+    assert _run(SINGLE, query) == expected
+
+
+PARTITIONED_CLUSTERS = [
+    ("community-1", "community-1"),
+    ("osm-1", "tem-1"),
+    ("osm-2", "osm-2"),
+    ("tem-1", "tem-1"),
+    ("tem-2", "tem-2"),
+]
+
+
+@pytest.mark.parametrize("concept", ["c_by_key", "c_by_alias"])
+@pytest.mark.parametrize("where", ["", "where city = 'A'"])
+def test_partitioned_sources_rejoin_on_aliased_axis(concept, where):
+    rows = _run(PARTITIONED, f"select id, {concept} {where} order by id asc;")
+    assert rows == PARTITIONED_CLUSTERS
+
+
+def test_partitioned_sources_rejoin_survivor_flag():
+    rows = _run(PARTITIONED, "select id, is_primary order by id asc;")
+    assert rows == [(i, i == c) for i, c in PARTITIONED_CLUSTERS]
+
+
+def test_partitioned_sources_prune_to_cluster_anchors():
+    rows = _run(
+        PARTITIONED,
+        "select id, c_by_alias where id = c_by_alias order by id asc;",
+    )
+    assert rows == [(i, c) for i, c in PARTITIONED_CLUSTERS if i == c]

--- a/tests/persistence/test_datasource_where_on_write.py
+++ b/tests/persistence/test_datasource_where_on_write.py
@@ -1,0 +1,89 @@
+"""A datasource's own `where` is a row contract: every read of the datasource is
+filtered by it, so a build that skipped it would write rows the datasource then
+denies. The build select must AND it in, beside the incremental key filter and
+a partial target's `complete where`.
+"""
+
+from trilogy import Dialects, Environment
+from trilogy.core.enums import PersistMode
+from trilogy.core.statements.author import PersistStatement, SelectStatement
+
+MODEL = """
+key id int;
+property id.flag bool;
+property id.region string;
+
+datasource rows (id: id, flag: flag, region: region)
+grain (id)
+query '''
+select * from (values (1, true, 'east'), (2, false, 'east'), (3, true, 'west'))
+as t(id, flag, region)
+''';
+
+datasource kept (id: id, flag: flag, region: region)
+grain (id)
+address kept_rows
+where flag = true;
+
+partial datasource kept_east (id: id, flag: flag, region: region)
+grain (id)
+complete where region = 'east'
+address kept_east_rows
+where flag = true;
+"""
+
+
+def _env() -> Environment:
+    env = Environment()
+    env.parse(MODEL)
+    return env
+
+
+def test_build_select_carries_the_datasource_where():
+    env = _env()
+    kept = env.datasources["kept"]
+    statement = kept.create_update_statement(env, None, line_no=None)
+    assert str(statement.where_clause) == str(kept.where)
+
+
+def test_build_select_ands_the_datasource_where_with_the_incremental_filter():
+    env = _env()
+    kept = env.datasources["kept"]
+    incremental = env.parse("select id where id > 1;")[-1][-1]
+    assert isinstance(incremental, SelectStatement)
+    statement = kept.create_update_statement(
+        env, incremental.where_clause, line_no=None
+    )
+    rendered = str(statement.where_clause)
+    assert str(kept.where) in rendered
+    assert str(incremental.where_clause) in rendered
+
+
+def test_refresh_writes_only_rows_the_datasource_admits():
+    env = _env()
+    executor = Dialects.DUCK_DB.default_executor(environment=env)
+    executor.update_datasource(env.datasources["kept"])
+    rows = executor.execute_raw_sql("select id from kept_rows order by id").fetchall()
+    assert rows == [(1,), (3,)]
+
+
+def test_partial_target_applies_both_complete_where_and_where():
+    env = _env()
+    target = env.datasources["kept_east"]
+    statement = PersistStatement(
+        datasource=target,
+        select=target.create_update_statement(env, None, line_no=None),
+        persist_mode=PersistMode.OVERWRITE,
+    )
+    renderer = Dialects.DUCK_DB.default_renderer()
+    (processed,) = renderer.generate_queries(env, [statement])
+    sql = "\n".join(renderer.compile_statements(processed))
+    assert "'east'" in sql
+    assert "flag" in sql.split("WHERE", 1)[1]
+    executor = Dialects.DUCK_DB.default_executor(environment=env)
+    executor.update_datasource(env.datasources["kept"])
+    executor.update_datasource(target)
+    rows = executor.execute_raw_sql(
+        "select id from kept_east_rows order by id"
+    ).fetchall()
+    assert rows == [(1,)]

--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from trilogy.executor import Executor
     from trilogy.parser import parse
 
-__version__ = "0.3.345"
+__version__ = "0.3.346"
 
 __all__ = [
     "CONFIG",

--- a/trilogy/core/models/datasource.py
+++ b/trilogy/core/models/datasource.py
@@ -26,6 +26,7 @@ from trilogy.core.models.author import (
     LooseConceptList,
     Namespaced,
     WhereClause,
+    combine_staged_wheres,
 )
 
 LOGGER_PREFIX = "[MODELS_DATASOURCE]"
@@ -455,6 +456,11 @@ class Datasource(HasUUID, Namespaced, BaseModel):
         # can never be written even when source-selection is wrong. Blocked on first
         # fixing source-selection to prefer the exact-matching partial source automatically.
 
+        # The datasource's own `where` is a row contract: every read of it is
+        # filtered by it, so a build that skipped it would write rows the
+        # datasource then denies. AND it into the build gate alongside any
+        # incremental filter.
+        where = combine_staged_wheres([w for w in (self.where, where) if w])
         return SelectStatement.from_inputs(
             environment=environment,
             selection=[

--- a/trilogy/core/processing/v4_helper/projection.py
+++ b/trilogy/core/processing/v4_helper/projection.py
@@ -21,10 +21,16 @@ def parent_output_addresses(node: StrategyNode) -> set[str]:
 def renderable_addresses(node: StrategyNode) -> set[str]:
     """Addresses `node` can project: its parents' visible outputs plus, for a leaf
     scan, every column its datasource binds (a leaf has no parent nodes, so
-    `parent_output_addresses` alone reports nothing)."""
+    `parent_output_addresses` alone reports nothing). A union's columns are the
+    stack of its arms', so it can render whatever EVERY arm can (the
+    all-or-nothing rule `widen_projection` applies when widening one)."""
     available = parent_output_addresses(node)
     if isinstance(node, SelectNode) and node.datasource is not None:
         available |= {c.address for c in node.datasource.output_concepts}
+    if isinstance(node, UnionNode) and node.parents:
+        available |= set.intersection(
+            *(renderable_addresses(arm) for arm in node.parents)
+        )
     return available
 
 
@@ -177,6 +183,11 @@ def widen_projection(
                 available_addresses=available,
                 rebuild=rebuild,
             )
+        # The arms compute the column from THEIR inputs; the union itself only
+        # reads what the arms now stack. Its inputs are the widened outputs,
+        # never the arms' source columns.
+        input_candidates = arm_outputs
+        available_addresses = parent_output_addresses(node)
     in_addrs = {concept.address for concept in node.input_concepts}
     out_addrs = {concept.address for concept in node.output_concepts}
     for concept in input_candidates:

--- a/trilogy/core/processing/v4_helper/strategy_builder.py
+++ b/trilogy/core/processing/v4_helper/strategy_builder.py
@@ -62,6 +62,7 @@ from trilogy.core.processing.nodes import (
     MultiSelectMergeNode,
     SelectNode,
     StrategyNode,
+    UnionNode,
     WindowNode,
 )
 from trilogy.core.processing.v4_node_generators import build_node
@@ -1451,6 +1452,13 @@ def _parents_already_at_input_grain(
 _JOIN_KEY_CHAIN_LIMIT = 4
 
 
+# Node kinds whose projection can be widened with a column derived from their
+# own row inputs without changing which rows they emit: plain projections,
+# non-grouping merges, virt-filter/WHERE projections (a FilterNode restricts
+# rows, never regroups them) and unions (widened arm-by-arm, all or nothing).
+_WIDENABLE_PROJECTIONS = (SelectNode, MergeNode, FilterNode, UnionNode)
+
+
 def _widen_scan_chain(
     node: StrategyNode, concept: BuildConcept, depth: int = 0
 ) -> bool:
@@ -1465,20 +1473,25 @@ def _widen_scan_chain(
     cross-joins ON 1=1."""
     if concept.address in {o.address for o in node.output_concepts}:
         return True
-    if not isinstance(node, (SelectNode, MergeNode)):
+    if not isinstance(node, _WIDENABLE_PROJECTIONS):
         return False
     available = renderable_addresses(node)
     if not concept_satisfiable(concept, available):
         if depth >= _JOIN_KEY_CHAIN_LIMIT:
             return False
-        # A SelectNode projects ONE stream, so descending a fan-in would change
-        # what the widened column means; a MergeNode joins its parents, so any
-        # arm that binds the key can supply it. A grain-collapsing parent is
-        # never widened: that would move its grouping key.
-        if isinstance(node, SelectNode) and len(node.parents) != 1:
+        # A single-stream projection (SelectNode, FilterNode) would change what
+        # the widened column means if it descended a fan-in; a MergeNode joins
+        # its parents, so any arm that binds the key can supply it. A union is
+        # widened only from what every arm already renders: descending its arms
+        # one by one could leave some carrying a column the stack lacks. A
+        # grain-collapsing parent is never widened: that would move its
+        # grouping key.
+        if isinstance(node, UnionNode):
+            return False
+        if isinstance(node, (SelectNode, FilterNode)) and len(node.parents) != 1:
             return False
         if not any(
-            isinstance(below, (SelectNode, MergeNode))
+            isinstance(below, _WIDENABLE_PROJECTIONS)
             and not below.force_group
             and _widen_scan_chain(below, concept, depth + 1)
             for below in node.parents
@@ -1705,7 +1718,7 @@ def _carry_join_keys(
             ):
                 _widen_passthrough_group(parent, join_key_concepts)
             continue
-        if parent.force_group or not isinstance(parent, (SelectNode, MergeNode)):
+        if parent.force_group or not isinstance(parent, _WIDENABLE_PROJECTIONS):
             continue
         # A leaf datasource scan can still emit any column its datasource binds,
         # so a partial merge key (a fact's `?d1` column that canonicalizes to the


### PR DESCRIPTION
## Summary

Fixes the field report "Planner: keyless join when a per-cell aggregate meets the row's key; target `where` not applied on materialise". Three findings, two root causes.

### 1. Keyless join on an aggregate grouped by a derived axis (findings 1 and 3)

Minimal shape, single datasource:

```sql
auto cell <- concat(cast(floor(lat) as string), ':', cast(floor(lon) as string));
auto anchor <- min(id ? src != 'o') by cell;
select id, anchor;   -- raised "Planner emitted a keyless join ..."
```

The FINAL merge re-sources its row contributor to the keys it projects, and the join-key carry (`_carry_join_keys` / `_widen_scan_chain`) synthesizes a sibling's grouping axis onto it. That carry only widened `SelectNode`/`MergeNode` parents and the chain descent stopped at the same two kinds, so a row side that happened to be a `FilterNode` (the inline filter's CASE projection) or a `UnionNode` (partitioned `complete where` sources) never rendered the axis and the merge fell through to the guard. That is why the report saw different spellings of the same derivation fail in different contexts: it was about which node kind sat at the row side of the merge, not the derivation.

- `_WIDENABLE_PROJECTIONS`: `FilterNode` and `UnionNode` are row-preserving projections, widened the same way.
- `renderable_addresses`: a union renders what every arm renders (mirrors `widen_projection`'s existing all-or-nothing arm rule); a union's own inputs stay the arms' stacked outputs.

### 2. Managed datasource `where` silently ignored on write (finding 2)

A datasource's `where` was pushed into every read but never into the build select, so a managed target declaring `where id = cluster_id` materialised every row. `create_update_statement` now ANDs the datasource's own `where` into the build gate beside the incremental key filter (the persist path already injects `complete where`). Read and write now agree on the row contract.

### Not changed

`complete where` stays a completeness contract, not a filter (a partial datasource may legitimately hold rows outside its complete region). The report's finding 3 is answered by the datasource `where` now working; its "3 rows expected" figure was a miscount of its own fixture (with that data every row is its own anchor, and the predicate is applied).

## Gates

- New tests: `tests/engine/test_duckdb_derived_axis_rejoin.py` (row-verified on DuckDB: single source, and the three-arm partitioned model with key / aliased-key / survivor-flag / prune spellings, filtered and unfiltered) and `tests/persistence/test_datasource_where_on_write.py`.
- tpc_ds + tpc_h corpus render: 132/132 byte-identical against HEAD (PYTHONPATH-shadow A/B).
- Differential fuzzer: 228/228.
- ruff / mypy / black clean.
- Version bump 0.3.345 -> 0.3.346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjSgsiGSJmX5vhem2CFk3e
