### PR TITLE
[Bug] Union Datasource Selection Fixes

### DIFF
--- a/tests/core/processing/test_v4_network_search.py
+++ b/tests/core/processing/test_v4_network_search.py
@@ -1243,9 +1243,9 @@ class TestCostAndObligationInvariants:
     def test_axes_covers_every_cost_field(self):
         import dataclasses
 
-        cost = SolutionCost(1, 2, 3, 4, 5, 6, 7, 8)
+        cost = SolutionCost(1, 2, 3, 4, 5, 6, 7, 8, 9)
 
-        assert cost.axes() == (1, 2, 3, 4, 5, 6, 7, 8)
+        assert cost.axes() == (1, 2, 3, 4, 5, 6, 7, 8, 9)
         assert len(cost.axes()) == len(dataclasses.fields(SolutionCost))
 
     def test_obligation_kinds_order_as_their_names_did(self):

--- a/tests/engine/test_duckdb_partition_cover.py
+++ b/tests/engine/test_duckdb_partition_cover.py
@@ -1,0 +1,99 @@
+"""A partition family answers a whole-population request only when its
+`complete where` claims jointly exhaust every discriminator they name.
+
+A claim on `(city, source)` covers city A only together with the arms for
+the other `source` values; on its own it is one cell of the cross product.
+Electing such an arm as the cover for `city = 'A'` silently answered the
+query from a strict subset of the rows, and which subset depended on which
+files happened to exist.
+"""
+
+import pytest
+
+from trilogy import Dialects, Environment
+from trilogy.core.exceptions import UnresolvableQueryException
+
+CONCEPTS = """
+key city enum<string>['A', 'B'];
+key source enum<string>['MUN', 'OSM'];
+key id string;
+property id.x float;
+"""
+
+
+def _rows(city: str, source: str) -> str:
+    return (
+        f"select '{city}-{source}-1' as id, '{city}' as city, '{source}' as source, 1.0 as x"
+        f" union all select '{city}-{source}-2', '{city}', '{source}', 2.0"
+    )
+
+
+def _raw(city: str, source: str, complete_where: str) -> str:
+    return f"""
+root partial datasource raw_{city}_{source} (id: id, city: city, source: source, x: x)
+grain (id) complete where {complete_where}
+query '''{_rows(city, source)}''';
+"""
+
+
+def _pub(city: str) -> str:
+    return f"""
+partial datasource pub_{city} (id: id, city: city, source: source, x: x)
+grain (id) complete where city = '{city}'
+query '''{_rows(city, "MUN")} union all {_rows(city, "OSM")}''';
+"""
+
+
+def _run(model: str, query: str) -> tuple[list[tuple], str]:
+    env = Environment()
+    env.parse(model)
+    executor = Dialects.DUCK_DB.default_executor(environment=env)
+    sql = executor.generate_sql(query)[-1]
+    return executor.execute_text(query)[-1].fetchall(), sql
+
+
+CELLS = [(c, s) for c in ("A", "B") for s in ("MUN", "OSM")]
+FULL_GRID = CONCEPTS + "".join(
+    _raw(c, s, f"city = '{c}' and source = '{s}'") for c, s in CELLS
+)
+
+
+def test_full_cross_product_of_cells_is_a_cover():
+    rows, sql = _run(FULL_GRID, "select id order by id asc;")
+    assert len(rows) == 8
+    assert all(f"raw_{c}_{s}" in sql for c, s in CELLS)
+
+
+def test_a_missing_cell_is_not_covered_by_the_other_arm_for_its_city():
+    model = CONCEPTS + "".join(
+        _raw(c, s, f"city = '{c}' and source = '{s}'")
+        for c, s in CELLS
+        if (c, s) != ("A", "OSM")
+    )
+    with pytest.raises(UnresolvableQueryException):
+        _run(model, "select id order by id asc;")
+
+
+def test_published_partitions_win_over_a_partial_grid():
+    model = (
+        CONCEPTS
+        + "".join(
+            _raw(c, s, f"city = '{c}' and source = '{s}'")
+            for c, s in CELLS
+            if (c, s) != ("B", "OSM")
+        )
+        + _pub("A")
+        + _pub("B")
+    )
+    for query in ("select id order by id asc;", "select city, count(id) -> n;"):
+        rows, sql = _run(model, query)
+        assert "pub_A" in sql and "pub_B" in sql
+        assert not any(f"raw_{c}_{s}" in sql for c, s in CELLS)
+    rows, _ = _run(model, "select id order by id asc;")
+    assert len(rows) == 8
+
+
+def test_city_filter_still_reads_that_city_alone():
+    rows, sql = _run(FULL_GRID, "select id where city = 'A' order by id asc;")
+    assert [r[0] for r in rows] == ["A-MUN-1", "A-MUN-2", "A-OSM-1", "A-OSM-2"]
+    assert "raw_B_MUN" not in sql and "raw_B_OSM" not in sql

--- a/tests/engine/test_duckdb_partition_cover.py
+++ b/tests/engine/test_duckdb_partition_cover.py
@@ -97,3 +97,21 @@ def test_city_filter_still_reads_that_city_alone():
     rows, sql = _run(FULL_GRID, "select id where city = 'A' order by id asc;")
     assert [r[0] for r in rows] == ["A-MUN-1", "A-MUN-2", "A-OSM-1", "A-OSM-2"]
     assert "raw_B_MUN" not in sql and "raw_B_OSM" not in sql
+
+
+ROLLUP = """
+datasource rollup (id: id, city: city, source: source, x: x)
+grain (id)
+query '''{rows}''';
+""".format(rows=" union all ".join(_rows(c, s) for c, s in CELLS))
+
+
+@pytest.mark.parametrize(
+    "query", ["select id order by id asc;", "select city, count(id) -> n;"]
+)
+def test_one_complete_source_outranks_a_covering_union(query):
+    model = CONCEPTS + _pub("A") + _pub("B") + ROLLUP
+    rows, sql = _run(model, query)
+    assert "rollup" in sql
+    assert "pub_A" not in sql and "pub_B" not in sql
+    assert len(rows) == (8 if query.startswith("select id") else 2)

--- a/tests/generators/test_datasource_scoring.py
+++ b/tests/generators/test_datasource_scoring.py
@@ -30,8 +30,9 @@ from trilogy.core.models.core import DataType, EnumType
 from trilogy.core.models.datasource import Address
 from trilogy.core.processing.node_generators.select_helpers.datasource_injection import (
     _best_enum_union,
+    _claim_atoms,
+    _claimed_value,
     _datasource_score,
-    _extract_enum_value_for_key,
 )
 from trilogy.core.processing.node_generators.select_helpers.source_scoring import (
     get_graph_partial_nodes,
@@ -425,12 +426,15 @@ class TestBestEnumUnion:
         }
 
     def test_two_key_condition_discriminates_on_correct_key(self):
-        """When non_partial_for has two enum keys, only the discriminating key produces a union.
+        """Two enum keys in non_partial_for: the same two-arm union is the cover
+        under either key.
 
         city=['USBOS'] (single value) and source=['CITY','ARBORETUM'] (two values).
         Two sources: (city=USBOS, source=CITY) and (city=USBOS, source=ARBORETUM).
-        The city key has all sources sharing the same value → None.
-        The source key correctly discriminates → 2-way union.
+        Under the city key both arms claim USBOS and cover it only jointly,
+        through their residual source claims exhausting the source enum; under
+        the source key each arm covers its own value. Either way the union is
+        the same two arms, so the two families dedupe to one node.
         """
         city_enum = EnumType(type=DataType.STRING, values=["USBOS"])
         source_enum = EnumType(type=DataType.STRING, values=["CITY", "ARBORETUM"])
@@ -442,7 +446,10 @@ class TestBestEnumUnion:
         arb_raw = _make_enum_ds_two_key("USBOS", city, "ARBORETUM", source, shared)
 
         city_result = _best_enum_union([city_raw, arb_raw], city_enum, city)
-        assert city_result is None, f"city key should return None, got {city_result}"
+        assert city_result is not None
+        assert [{ds.name for ds in combo} for combo in city_result] == [
+            {city_raw.name, arb_raw.name}
+        ]
 
         source_result = _best_enum_union([city_raw, arb_raw], source_enum, source)
         assert source_result is not None
@@ -502,12 +509,10 @@ def _reference_best_enum_union(
     for ds in dses:
         if not ds.non_partial_for:
             continue
-        val = _extract_enum_value_for_key(
-            ds.non_partial_for.conditional, merge_key.address
-        )
-        if val is None:
+        claim = _claim_atoms(ds.non_partial_for.conditional)
+        if claim is None or merge_key.address not in claim:
             continue
-        by_value[val].append(ds)
+        by_value[_claimed_value(claim[merge_key.address])].append(ds)
 
     if {str(v) for v in by_value} < set(enum_type.values):
         return None
@@ -613,21 +618,18 @@ class TestBestEnumUnionEquivalence:
         assert elapsed < 1.0, f"union selection took {elapsed:.3f}s"
 
 
-class TestExtractEnumValueForKey:
+class TestClaimAtoms:
     def _concept(self, name: str) -> BuildConcept:
         return _make_concept(name)
 
     def test_parenthetical_wrapping_comparison(self):
-        """Value is extracted when the comparison is wrapped in a BuildParenthetical."""
         key = self._concept("region")
         cmp = BuildComparison(left=key, right="NORTH", operator=ComparisonOperator.EQ)
-        paren = BuildParenthetical(content=cmp)
+        claim = _claim_atoms(BuildParenthetical(content=cmp))
+        assert claim is not None
+        assert _claimed_value(claim[key.address]) == "NORTH"
 
-        result = _extract_enum_value_for_key(paren, key.address)
-        assert result == "NORTH"
-
-    def test_parenthetical_wrapping_conditional(self):
-        """Value is extracted when a parenthetical wraps a compound AND condition."""
+    def test_parenthetical_wrapping_conditional_keeps_every_atom(self):
         key = self._concept("region")
         other = self._concept("other")
         inner = BuildConditional(
@@ -639,18 +641,30 @@ class TestExtractEnumValueForKey:
             ),
             operator=BooleanOperator.AND,
         )
-        paren = BuildParenthetical(content=inner)
+        claim = _claim_atoms(BuildParenthetical(content=inner))
+        assert claim is not None
+        assert _claimed_value(claim[key.address]) == "SOUTH"
+        assert _claimed_value(claim[other.address]) == "X"
 
-        result = _extract_enum_value_for_key(paren, key.address)
-        assert result == "SOUTH"
+    def test_or_and_repeated_atoms_are_not_claims(self):
+        key = self._concept("region")
+        atom = BuildComparison(left=key, right="N", operator=ComparisonOperator.EQ)
+        assert (
+            _claim_atoms(
+                BuildConditional(left=atom, right=atom, operator=BooleanOperator.OR)
+            )
+            is None
+        )
+        assert (
+            _claim_atoms(
+                BuildConditional(left=atom, right=atom, operator=BooleanOperator.AND)
+            )
+            is None
+        )
 
     def test_parenthetical_with_non_condition_content_returns_none(self):
-        """A BuildParenthetical whose content is not a condition type returns None."""
-        key = self._concept("region")
         paren = BuildParenthetical(content="not_a_condition")  # type: ignore[arg-type]
-
-        result = _extract_enum_value_for_key(paren, key.address)
-        assert result is None
+        assert _claim_atoms(paren) is None
 
 
 def _scoped_concept(name: str) -> BuildConcept:

--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from trilogy.executor import Executor
     from trilogy.parser import parse
 
-__version__ = "0.3.346"
+__version__ = "0.3.347"
 
 __all__ = [
     "CONFIG",

--- a/trilogy/core/processing/node_generators/select_helpers/datasource_injection.py
+++ b/trilogy/core/processing/node_generators/select_helpers/datasource_injection.py
@@ -1,8 +1,8 @@
 from collections import defaultdict
+from dataclasses import dataclass
 
 from trilogy.core.enums import (
     AddressType,
-    BooleanOperator,
     ComparisonOperator,
     Modifier,
 )
@@ -12,12 +12,14 @@ from trilogy.core.models.build import (
     BuildConcept,
     BuildConditional,
     BuildDatasource,
+    BuildFunction,
     BuildParenthetical,
 )
 from trilogy.core.models.core import EnumType
 from trilogy.core.models.datasource import Address
 from trilogy.core.processing.condition_utility import (
     ExcludedEnumValues,
+    decompose_condition,
     effective_enum_domain,
     simplify_conditions,
 )
@@ -36,40 +38,235 @@ def _datasource_score(ds: BuildDatasource) -> int:
     return 2
 
 
-def _extract_enum_value_for_key(
-    conditional: BoolExpr,
-    key_address: str,
-) -> object | None:
-    """Extract the literal value for a specific concept key from a (compound) condition."""
-    if isinstance(conditional, BuildComparison):
-        if conditional.operator not in (ComparisonOperator.EQ, ComparisonOperator.IS):
-            return None
-        if (
-            isinstance(conditional.left, BuildConcept)
-            and conditional.left.address == key_address
-            and not isinstance(conditional.right, BuildConcept)
+@dataclass(frozen=True)
+class _CoverUnit:
+    """A set of arms that jointly cover one discriminator value.
+
+    ``score`` sums the members' materialization scores and ``width`` counts
+    them, so among equally materialized covers the one with fewer scans wins.
+    ``cols`` is the column overlap every member binds."""
+
+    members: tuple[BuildDatasource, ...]
+    cols: frozenset[str]
+    score: int
+    width: int
+
+
+_Claim = dict[str, BuildComparison]
+_Arm = tuple[BuildDatasource, _Claim]
+
+
+def _claim_atoms(conditional: BoolExpr) -> _Claim | None:
+    """A `complete where` as ``{concept address: its equality atom}``.
+
+    Only a pure conjunction of ``concept = literal`` atoms is a partition
+    claim the cover proof can reason about exactly; anything else (an OR, a
+    range, a concept-to-concept comparison, a repeated concept) returns None
+    and the arm stays out of enum-family election."""
+    out: _Claim = {}
+    for chunk in decompose_condition(conditional):
+        atom: object = chunk
+        while isinstance(atom, BuildParenthetical):
+            atom = atom.content
+        if isinstance(atom, BuildConditional):
+            nested = _claim_atoms(atom)
+            if nested is None or set(nested) & set(out):
+                return None
+            out.update(nested)
+            continue
+        if not isinstance(atom, BuildComparison) or atom.operator not in (
+            ComparisonOperator.EQ,
+            ComparisonOperator.IS,
         ):
-            return conditional.right
-        if (
-            isinstance(conditional.right, BuildConcept)
-            and conditional.right.address == key_address
-            and not isinstance(conditional.left, BuildConcept)
-        ):
-            return conditional.left
-        return None
-    elif isinstance(conditional, BuildConditional):
-        if conditional.operator == BooleanOperator.OR:
             return None
-        if isinstance(conditional.left, BoolExpr):
-            left_val = _extract_enum_value_for_key(conditional.left, key_address)
-            if left_val is not None:
-                return left_val
-        if isinstance(conditional.right, BoolExpr):
-            return _extract_enum_value_for_key(conditional.right, key_address)
-    elif isinstance(conditional, BuildParenthetical):
-        if isinstance(conditional.content, BoolExpr):
-            return _extract_enum_value_for_key(conditional.content, key_address)
-    return None
+        if isinstance(atom.left, BuildConcept) and not isinstance(
+            atom.right, BuildConcept
+        ):
+            concept = atom.left
+        elif isinstance(atom.right, BuildConcept) and not isinstance(
+            atom.left, BuildConcept
+        ):
+            concept = atom.right
+        else:
+            return None
+        if concept.address in out:
+            return None
+        out[concept.address] = atom
+    return out
+
+
+def _claimed_value(atom: BuildComparison) -> str:
+    literal: object = atom.right if isinstance(atom.left, BuildConcept) else atom.left
+    if isinstance(literal, BuildFunction) and literal.arguments:
+        literal = literal.arguments[0]
+    return str(literal)
+
+
+def _claimed_concept(atom: BuildComparison) -> BuildConcept:
+    concept = atom.left if isinstance(atom.left, BuildConcept) else atom.right
+    assert isinstance(concept, BuildConcept)
+    return concept
+
+
+def _columns(ds: BuildDatasource) -> frozenset[str]:
+    return frozenset(col.concept.address for col in ds.columns)
+
+
+def _cover_units(
+    arms: list[_Arm],
+    excluded: ExcludedEnumValues | None,
+) -> list[_CoverUnit]:
+    """The arm sets that jointly cover the population these arms were asked
+    to cover, best per column overlap.
+
+    An arm whose residual claim is empty covers by itself. Arms that still
+    claim other discriminators cover only jointly: they are partitioned on
+    one of those discriminators and every value of it must be covered in
+    turn, recursively. A claim on ``(city, source)`` therefore never covers
+    ``city`` by itself; it covers it together with the arms for the other
+    ``source`` values."""
+    units = [
+        _CoverUnit(
+            members=(ds,), cols=_columns(ds), score=_datasource_score(ds), width=1
+        )
+        for ds, claim in arms
+        if not claim
+    ]
+    constrained = [(ds, claim) for ds, claim in arms if claim]
+    if not constrained:
+        return units
+    counts: dict[str, int] = defaultdict(int)
+    for _, claim in constrained:
+        for address in claim:
+            counts[address] += 1
+    key_address = max(sorted(counts), key=lambda a: counts[a])
+    key = next(
+        _claimed_concept(claim[key_address])
+        for _, claim in constrained
+        if key_address in claim
+    )
+    if isinstance(key.datatype, EnumType):
+        units.extend(_enum_cover_units(constrained, key, excluded))
+        return units
+    # A non-enum residual is provable only as a range/boolean cover, one atom
+    # per arm.
+    if all(len(claim) == 1 for _, claim in constrained) and simplify_conditions(
+        [claim[key_address] for _, claim in constrained if key_address in claim],
+        excluded,
+    ):
+        members = tuple(ds for ds, _ in constrained)
+        units.append(
+            _CoverUnit(
+                members=members,
+                cols=frozenset.intersection(*(_columns(ds) for ds in members)),
+                score=sum(_datasource_score(ds) for ds in members),
+                width=len(members),
+            )
+        )
+    return units
+
+
+_State = tuple[int, int, tuple[BuildDatasource, ...], tuple[int, ...], tuple[int, ...]]
+
+
+def _enum_cover_units(
+    arms: list[_Arm],
+    key: BuildConcept,
+    excluded: ExcludedEnumValues | None,
+) -> list[_CoverUnit]:
+    """Best covering combinations over an enum discriminator, one per column
+    overlap signature.
+
+    Each value of the effective domain (values the statement's row gate rules
+    out need no arm) must have a cover: the arms claiming that value with the
+    claim stripped, plus arms silent on this discriminator (their claim applies
+    to every value), reduced by `_cover_units`. A dynamic program over values
+    whose state is the combo's column overlap so far (minus the discriminator)
+    keeps the highest-scoring combo per signature; the score is separable and
+    the overlap is the only coupling, so this is exhaustive over achievable
+    signatures without enumerating the product. One combo per overlap lets
+    parallel partitionings (sales vs. returns vs. dim, all keyed by one channel
+    enum) each contribute their own union. Ties break to the first
+    max-scoring combo in product order; signatures order by their first
+    achieving combo."""
+    domain = effective_enum_domain(key.datatype, key, excluded)
+    assert isinstance(domain, EnumType)
+    required = [str(v) for v in domain.values]
+    silent = [(ds, claim) for ds, claim in arms if key.address not in claim]
+    by_value: dict[str, list[_Arm]] = defaultdict(list)
+    for ds, claim in arms:
+        atom = claim.get(key.address)
+        if atom is None:
+            continue
+        value = _claimed_value(atom)
+        if value in required:
+            residual = {a: c for a, c in claim.items() if a != key.address}
+            by_value[value].append((ds, residual))
+    per_value: list[list[_CoverUnit]] = []
+    for value in required:
+        candidates = by_value.get(value, []) + silent
+        units = _cover_units(candidates, excluded) if candidates else []
+        if not units:
+            return []
+        per_value.append(units)
+
+    states: dict[frozenset[str], _State] = {}
+    for idx, unit in enumerate(per_value[0]):
+        sig = unit.cols - {key.address}
+        if not sig:
+            continue
+        existing = states.get(sig)
+        if existing is None:
+            states[sig] = (unit.score, unit.width, unit.members, (idx,), (idx,))
+        elif (unit.score, -unit.width) > (existing[0], -existing[1]):
+            states[sig] = (unit.score, unit.width, unit.members, (idx,), existing[4])
+    for units in per_value[1:]:
+        next_states: dict[frozenset[str], _State] = {}
+        for sig, (score, width, members, combo_key, min_key) in states.items():
+            for idx, unit in enumerate(units):
+                new_sig = sig & unit.cols
+                if not new_sig:
+                    continue
+                new: _State = (
+                    score + unit.score,
+                    width + unit.width,
+                    _dedupe_members(members + unit.members),
+                    combo_key + (idx,),
+                    min_key + (idx,),
+                )
+                existing = next_states.get(new_sig)
+                if existing is None:
+                    next_states[new_sig] = new
+                    continue
+                new_min_key = min(existing[4], new[4])
+                if (new[0], -new[1]) > (existing[0], -existing[1]) or (
+                    (new[0], new[1]) == (existing[0], existing[1])
+                    and new[3] < existing[3]
+                ):
+                    next_states[new_sig] = (*new[:4], new_min_key)
+                else:
+                    next_states[new_sig] = (*existing[:4], new_min_key)
+        states = next_states
+        if not states:
+            return []
+    return [
+        _CoverUnit(members=members, cols=sig, score=score, width=width)
+        for sig, (score, width, members, _, _) in sorted(
+            states.items(), key=lambda kv: kv[1][4]
+        )
+    ]
+
+
+def _dedupe_members(
+    members: tuple[BuildDatasource, ...],
+) -> tuple[BuildDatasource, ...]:
+    seen: set[str] = set()
+    out: list[BuildDatasource] = []
+    for ds in members:
+        if ds.identifier not in seen:
+            seen.add(ds.identifier)
+            out.append(ds)
+    return tuple(out)
 
 
 def _best_enum_union(
@@ -78,131 +275,34 @@ def _best_enum_union(
     merge_key: BuildConcept,
     excluded: ExcludedEnumValues | None = None,
 ) -> list[list[BuildDatasource]] | None:
-    """Find the best minimal covering combinations for an enum-partitioned key.
-
-    Groups by covered enum value, then searches one-source-per-value combos via
-    a dynamic program over values whose state is the combo's concept overlap so
-    far (minus the merge key), keeping the highest-scoring combo per distinct
-    overlap signature. The score is separable (a per-source sum) and the
-    overlap is the only coupling between values, so this is exhaustive over
-    achievable signatures without enumerating the k^V combo product. Returning
-    one combo per overlap lets parallel partitionings (e.g., sales vs.
-    returns vs. dim, all keyed by the same channel enum) each contribute
-    their own union datasource instead of collapsing into the single best.
-    Materialized table sources score higher than script/query sources.
-    Coverage is judged over the effective domain: values the statement's row
-    gate rules out (``excluded``) need no arm, and an arm for such a value
-    cannot contribute.
-    """
-    required = {
-        str(v) for v in effective_enum_domain(enum_type, merge_key, excluded).values
-    }
-    by_value: dict[object, list[BuildDatasource]] = defaultdict(list)
+    """The minimal covering unions for an enum-partitioned key: every value of
+    the effective domain covered, with a multi-discriminator claim covering its
+    value only jointly with the arms for the other discriminators' values
+    (`_cover_units`). One union per maximal column overlap; None when no
+    complete cover exists or the only cover is a single source (not a union)."""
+    arms: list[_Arm] = []
     for ds in dses:
         if not ds.non_partial_for:
             continue
-        val = _extract_enum_value_for_key(
-            ds.non_partial_for.conditional, merge_key.address
-        )
-        if val is None or str(val) not in required:
-            continue
-        by_value[val].append(ds)
-
-    # Every value that can still occur must have at least one candidate source
-    if not required <= {str(v) for v in by_value}:
-        return None
-
-    values = list(by_value.keys())
-    # A union requires at least 2 distinct sources; a single source is not a union
-    if len(values) < 2:
-        return None
-
-    cols: dict[int, frozenset[str]] = {}
-    scores: dict[int, int] = {}
-    for candidates in by_value.values():
-        for ds in candidates:
-            cols[id(ds)] = frozenset(col.concept.address for col in ds.columns)
-            scores[id(ds)] = _datasource_score(ds)
-
-    # Members MAY disagree on intrinsic (~) partiality of a shared column (a
-    # mixed-family combo): such a union is a legitimate provider of the columns
-    # it binds complete, and union partial propagation keeps its ~-partial keys
-    # from outranking a pure family, so it is not rejected here. An empty
-    # overlap beyond the merge key IS rejected at the first step it appears:
-    # intersection only shrinks. Ties are deterministic: per signature the
-    # winner is the first max-scoring combo in product order (`combo_key` =
-    # candidate index tuple), and signatures order by their first-achieving
-    # combo (`min_key`, tracked over ALL combos reaching a signature).
-    merge_key_addr = merge_key.address
-    # signature -> (score, combo, combo_key, min_key)
-    states: dict[
-        frozenset[str],
-        tuple[int, list[BuildDatasource], tuple[int, ...], tuple[int, ...]],
-    ] = {}
-    for idx, ds in enumerate(by_value[values[0]]):
-        sig = cols[id(ds)] - {merge_key_addr}
-        if not sig:
-            continue
-        existing = states.get(sig)
-        if existing is None:
-            states[sig] = (scores[id(ds)], [ds], (idx,), (idx,))
-        elif scores[id(ds)] > existing[0]:
-            states[sig] = (scores[id(ds)], [ds], (idx,), existing[3])
-
-    for v in values[1:]:
-        next_states: dict[
-            frozenset[str],
-            tuple[int, list[BuildDatasource], tuple[int, ...], tuple[int, ...]],
-        ] = {}
-        for sig, (score, combo, combo_key, min_key) in states.items():
-            for idx, ds in enumerate(by_value[v]):
-                new_sig = sig & cols[id(ds)]
-                if not new_sig:
-                    continue
-                new_score = score + scores[id(ds)]
-                new_key = combo_key + (idx,)
-                existing = next_states.get(new_sig)
-                if existing is None:
-                    next_states[new_sig] = (
-                        new_score,
-                        combo + [ds],
-                        new_key,
-                        min_key + (idx,),
-                    )
-                    continue
-                new_min_key = min(existing[3], min_key + (idx,))
-                if new_score > existing[0] or (
-                    new_score == existing[0] and new_key < existing[2]
-                ):
-                    next_states[new_sig] = (
-                        new_score,
-                        combo + [ds],
-                        new_key,
-                        new_min_key,
-                    )
-                else:
-                    next_states[new_sig] = (
-                        existing[0],
-                        existing[1],
-                        existing[2],
-                        new_min_key,
-                    )
-        states = next_states
-        if not states:
-            return None
-
-    best_per_overlap: dict[frozenset[str], tuple[list[BuildDatasource], int]] = {
-        sig: (state[1], state[0])
-        for sig, state in sorted(states.items(), key=lambda kv: kv[1][3])
-    }
-    if not best_per_overlap:
+        claim = _claim_atoms(ds.non_partial_for.conditional)
+        if claim is not None and merge_key.address in claim:
+            arms.append((ds, claim))
+    units = [
+        unit
+        for unit in _enum_cover_units(arms, merge_key, excluded)
+        if len(unit.members) >= 2
+    ]
+    if not units:
         return None
     # Keep only maximal overlap signatures: a mixed combo whose overlap is a
     # strict subset of a pure-family combo's is dropped, while parallel
     # partitionings remain incomparable and all survive.
-    sigs = list(best_per_overlap.keys())
-    maximal = [s for s in sigs if not any(s < other for other in sigs)]
-    return [best_per_overlap[s][0] for s in maximal]
+    sigs = [unit.cols for unit in units]
+    return [
+        list(unit.members)
+        for unit in units
+        if not any(unit.cols < other for other in sigs)
+    ]
 
 
 def _partition_families(

--- a/trilogy/core/processing/node_generators/select_helpers/datasource_injection.py
+++ b/trilogy/core/processing/node_generators/select_helpers/datasource_injection.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 
 from trilogy.core.enums import (
     AddressType,
+    BooleanOperator,
     ComparisonOperator,
     Modifier,
 )
@@ -69,6 +70,11 @@ def _claim_atoms(conditional: BoolExpr) -> _Claim | None:
         while isinstance(atom, BuildParenthetical):
             atom = atom.content
         if isinstance(atom, BuildConditional):
+            # `decompose_condition` splits every AND it can; a conditional it
+            # handed back is an OR (or an AND over non-conditions). Only one
+            # freshly unwrapped from parentheses still has an AND to split.
+            if atom is chunk or atom.operator != BooleanOperator.AND:
+                return None
             nested = _claim_atoms(atom)
             if nested is None or set(nested) & set(out):
                 return None

--- a/trilogy/core/processing/v4_helper/network_model.py
+++ b/trilogy/core/processing/v4_helper/network_model.py
@@ -481,6 +481,10 @@ class SolutionCost:
     blend_joins: int
     fanout_sources: int
     sources: int
+    # Physical relations read: a partition-family union is ONE source (no
+    # join) but N scans, so at equal source count a single complete table
+    # outranks the union of partials that jointly cover the same rows.
+    scans: int
     connectors: int
     derived_joins: int
 

--- a/trilogy/core/processing/v4_helper/network_search.py
+++ b/trilogy/core/processing/v4_helper/network_search.py
@@ -37,7 +37,11 @@ from __future__ import annotations
 from _preql_import_resolver import enumerate_network_covers
 
 from trilogy.core.graph_models import ReferenceGraph
-from trilogy.core.models.build import BuildConcept, BuildWhereClause
+from trilogy.core.models.build import (
+    BuildConcept,
+    BuildUnionDatasource,
+    BuildWhereClause,
+)
 from trilogy.core.models.build_environment import BuildEnvironment
 from trilogy.core.processing.v4_helper.network_build import build_source_network
 from trilogy.core.processing.v4_helper.network_model import (
@@ -329,6 +333,7 @@ def _solution_for(
             if network.fans_out(node, assignments[node] or joined_on[node])
         ),
         sources=len(sources),
+        scans=sum(_scan_count(network.candidates[node]) for node in sources),
         connectors=len(connectors),
         derived_joins=derived_joins,
     )
@@ -341,6 +346,14 @@ def _solution_for(
         connectors=frozenset(connectors),
         cost=cost,
     )
+
+
+def _scan_count(candidate: SourceCandidate) -> int:
+    """Relations a candidate reads: each arm of a union, none for a derived
+    connector (its subplan is costed where it is materialized)."""
+    if isinstance(candidate.datasource, BuildUnionDatasource):
+        return len(candidate.datasource.children)
+    return 0 if candidate.datasource is None else 1
 
 
 def _split_terminals(network: SourceNetwork, targets: list[str]) -> frozenset[str]:


### PR DESCRIPTION
## Summary

Fixes selecting a union over a materialized aggregate.

Fixes selecting a covering union when the union arms have additional predicates that are not themselves covering.

### Finding 1: a query with no partition filter answered from a strict subset of the rows

`_best_enum_union` (`datasource_injection.py`) extracted the family key's value out of a conjunctive `complete where` and treated the arm as covering that value outright. So `complete where city = 'A' and source = 'MUN_A'` was elected as the cover for `city = 'A'`, and the OSM rows silently vanished; with the municipal file absent the OSM arm was elected instead. `merge_conditions` judges coverage per concept independently, so it could not catch a cross-product hole either.

**Fix: exact cover election.** A claim is a conjunction of `concept = literal` atoms. An arm covers a value of the family key by itself only when its residual claim is empty. Otherwise it covers only jointly with the arms whose residuals exhaust the other discriminators' domains, recursively (`_cover_units` / `_enum_cover_units`). A claim on `(city, source)` therefore never covers `city` alone; it covers it together with the arms for every other `source` value.

The per-value dynamic program keeps its shape (best combo per column-overlap signature, parallel partitionings each get their own union); its candidates are covering sets rather than single arms, scored by summed materialization, then by fewer scans. Arms whose claim the proof cannot reason about exactly (an OR, a range, a concept-to-concept comparison) stay out of enum-family election.

Note the reporter's six raw `(city, source)` arms are **not** a provable cover: nothing in the model says city A rows only carry two of the six `source` values. A two-discriminator grid IS a cover when every cell is present (pinned by a new test and by the existing `multi_enum_union.preql`).

### Finding 2: a complete source lost to a union of partials

The source search costs a partition-family union as one source, the same as a single complete table, so `rollup` and `pub_a ∪ pub_b ∪ pub_c` tied on every cost axis and the union won on the node-name tiebreak. A new `scans` axis (physical relations read; each union arm counts) sits right after `sources` in `SolutionCost`, so a union still outranks a join but loses to one table covering the same population.

On the reporter's model every scenario now returns all 12 rows and reads only `rollup`.

## Gates

- New `tests/engine/test_duckdb_partition_cover.py`: a full 2x2 grid covers; a missing cell is not covered by its city's other arm (unresolvable, not a subset); published partitions win over a partial grid; a city filter still reads that city alone; one complete source outranks the covering union for both query shapes.
- `tests/generators/test_datasource_scoring.py`: the product-enumeration oracle and the parenthetical/OR cases now exercise the claim helpers directly; the two-key case pins that both family keys elect the same two-arm union.
- tpc_ds + tpc_h corpus render: 132/132 byte-identical vs main (PYTHONPATH-shadow A/B).
- Differential fuzzer: 228/228.
- engine / core/processing / join_matrix / generators / persistence / geography / non-benchmark tpc-ds / validators: 1944 passed.
- ruff / mypy / black clean. Version bump 0.3.346 -> 0.3.347.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjSgsiGSJmX5vhem2CFk3e
