### PR TITLE
[Bug] Plan a partial target's row gate inside its partition scope; gate rows against a projected aggregate

### DIFF
--- a/local_scripts/fuzzer/README.md
+++ b/local_scripts/fuzzer/README.md
@@ -34,6 +34,11 @@ then LEFT JOIN the leaf dims back on it, so both a backing key leaking into the
 grouped CTE and a join-back that drops subtotal/grand-total rows show up.
 Derived-rowset controls distinguish base-model WHERE enrichment from equivalent
 no-WHERE and rowset-output-WHERE forms.
+The `partition_cover` family reads a column only two `complete where` arms bind,
+so each case must first prove the pair covers the domain. The arms exhaust one
+discriminator and pin the other, which makes the proof depend on the statement's
+row gate; the cases move that gate between stages, since rows reaching any stage
+have passed the ones before it and the read is bounded the same way either way.
 
 Run everything from the repository root:
 

--- a/local_scripts/fuzzer/generate.py
+++ b/local_scripts/fuzzer/generate.py
@@ -3425,6 +3425,96 @@ order by 1 asc nulls first
     return cases
 
 
+def _partition_cover_cases(seed: SeedData) -> list[FuzzCase]:
+    """Two `complete where` arms carrying `tier_amount`, which no other source
+    binds, so every case here has to prove the pair covers the domain before it
+    can read the column at all.
+
+    The arms exhaust `tier` but pin `region` to one of its two values, so the
+    proof only closes once the statement's row gate rules the other region out.
+    Which stage that gate sits in must not matter: rows reaching any stage have
+    passed the ones before it, so a gate in a later row-local stage bounds the
+    read exactly as a leading one does. The oracles are plain reads of the seed
+    rows, so an arm dropped from the union, or a gate honoured against only
+    part of it, shows up as missing rows rather than as an error."""
+    events = seed.events.select_sql()
+
+    def arm(name: str, tier: str, predicate: str) -> str:
+        return f"""
+partial datasource {name} (
+    raw(''' 'NORTH' '''): region,
+    raw(''' '{tier}' '''): tier,
+    eid: event_id,
+    amount: tier_amount
+)
+grain (event_id)
+complete where region = 'NORTH' and tier = '{tier}'
+query '''select eid, amount from ({events}) as e where {predicate}''';
+"""
+
+    preamble = (
+        """
+key region enum<string>['NORTH', 'SOUTH'];
+key tier enum<string>['ALPHA', 'BETA'];
+property event_id.tier_amount int;
+"""
+        + arm("tier_alpha", "ALPHA", "eid % 2 = 0")
+        + arm("tier_beta", "BETA", "eid % 2 = 1")
+    )
+
+    projection = "select event_id, tier_amount order by event_id asc;"
+    all_rows = "select eid, amount from events order by eid"
+    alpha_rows = "select eid, amount from events where eid % 2 = 0 order by eid"
+    specs = (
+        (
+            "region_gate_reads_both_arms",
+            "The gate rules out the uncovered region, so the arms union into "
+            "one complete source and every event row is read.",
+            f"where region = 'NORTH' {projection}",
+            all_rows,
+        ),
+        (
+            "region_gate_in_a_later_stage",
+            "The same gate one stage later. Every row read still passes it, so "
+            "the union is proven the same way and the rows are unchanged.",
+            f"where event_id > 0 then where region = 'NORTH' {projection}",
+            all_rows,
+        ),
+        (
+            "arm_gate_selects_one_partition",
+            "Gating the second discriminator too narrows the read to one arm.",
+            f"where region = 'NORTH' and tier = 'ALPHA' {projection}",
+            alpha_rows,
+        ),
+        (
+            "arm_gate_across_three_stages",
+            "Both discriminators gated from later stages, one per stage.",
+            "where event_id > 0 then where region = 'NORTH'"
+            f" then where tier = 'ALPHA' {projection}",
+            alpha_rows,
+        ),
+        (
+            "aggregate_over_the_covered_union",
+            "An aggregate over the union spans both arms, not the arm the "
+            "planner happened to pick first.",
+            "where region = 'NORTH' select sum(tier_amount) as total;",
+            "select sum(amount) from events",
+        ),
+    )
+    return [
+        _case(
+            seed,
+            "partition_cover",
+            name,
+            description,
+            ("partition", "completeness", "union"),
+            preamble + query,
+            oracle,
+        )
+        for name, description, query, oracle in specs
+    ]
+
+
 def generate_cases(seeds: Iterable[SeedData] = SEEDS) -> list[FuzzCase]:
     cases = []
     builders = (
@@ -3452,6 +3542,7 @@ def generate_cases(seeds: Iterable[SeedData] = SEEDS) -> list[FuzzCase]:
         _distinct_count_cases,
         _composite_membership_cases,
         _padding_provenance_cases,
+        _partition_cover_cases,
     )
     for seed in seeds:
         for builder in builders:

--- a/tests/core/processing/test_staged_where_helpers.py
+++ b/tests/core/processing/test_staged_where_helpers.py
@@ -11,6 +11,7 @@ from trilogy.core.processing.v4_helper.staged_where import (
     hosting_stage_index,
     stage_computes_cross_row,
     stage_lineage_addresses,
+    universal_row_bound,
 )
 
 MODEL = """key id int;
@@ -74,3 +75,41 @@ def test_hosting_stage_index_is_none_for_a_plain_row_arg() -> None:
     built = _stages("where f = 1 then where sum(z) by x > 5 select x;")
     row_args = list(built.where_clauses[0].conditional.concept_arguments)
     assert hosting_stage_index(built.where_clauses, row_args) is None
+
+
+def _bound(select: str) -> str | None:
+    built = _stages(select)
+    bound = universal_row_bound(built.where_clauses, built.where_clause)
+    return str(bound.conditional) if bound is not None else None
+
+
+def test_bound_of_a_flat_row_local_where_is_that_where() -> None:
+    assert _bound("where f = 1 select x;") == "local.f = 1"
+
+
+def test_bound_of_a_flat_cross_row_where_is_nothing() -> None:
+    # the aggregate sees the unfiltered population, so nothing may be narrowed
+    assert _bound("where sum(z) by x > 5 select x;") is None
+
+
+def test_bound_spans_the_whole_leading_row_local_run() -> None:
+    bound = _bound("where f = 1 then where z > 1 then where sum(z) by x > 5 select x;")
+    assert bound is not None
+    assert "local.f = 1" in bound and "local.z > 1" in bound
+
+
+def test_bound_stops_at_the_first_cross_row_stage() -> None:
+    bound = _bound("where f = 1 then where sum(z) by x > 5 then where z > 1 select x;")
+    assert bound == "local.f = 1"
+
+
+def test_bound_does_not_enter_a_stage_that_also_computes_cross_row() -> None:
+    # `z > 1` shares its stage with an aggregate whose population is stage 1,
+    # so honouring it would prune rows that aggregate must read
+    assert _bound("where f = 1 then where z > 1 and sum(z) by x > 5 select x;") == (
+        "local.f = 1"
+    )
+
+
+def test_bound_is_nothing_when_the_first_stage_computes_cross_row() -> None:
+    assert _bound("where sum(z) by x > 5 then where f = 1 select x;") is None

--- a/tests/core/processing/test_v4_network_search.py
+++ b/tests/core/processing/test_v4_network_search.py
@@ -1243,9 +1243,9 @@ class TestCostAndObligationInvariants:
     def test_axes_covers_every_cost_field(self):
         import dataclasses
 
-        cost = SolutionCost(1, 2, 3, 4, 5, 6, 7, 8)
+        cost = SolutionCost(1, 2, 3, 4, 5, 6, 7, 8, 9)
 
-        assert cost.axes() == (1, 2, 3, 4, 5, 6, 7, 8)
+        assert cost.axes() == (1, 2, 3, 4, 5, 6, 7, 8, 9)
         assert len(cost.axes()) == len(dataclasses.fields(SolutionCost))
 
     def test_obligation_kinds_order_as_their_names_did(self):

--- a/tests/engine/test_duckdb_partition_cover.py
+++ b/tests/engine/test_duckdb_partition_cover.py
@@ -1,0 +1,99 @@
+"""A partition family answers a whole-population request only when its
+`complete where` claims jointly exhaust every discriminator they name.
+
+A claim on `(city, source)` covers city A only together with the arms for
+the other `source` values; on its own it is one cell of the cross product.
+Electing such an arm as the cover for `city = 'A'` silently answered the
+query from a strict subset of the rows, and which subset depended on which
+files happened to exist.
+"""
+
+import pytest
+
+from trilogy import Dialects, Environment
+from trilogy.core.exceptions import UnresolvableQueryException
+
+CONCEPTS = """
+key city enum<string>['A', 'B'];
+key source enum<string>['MUN', 'OSM'];
+key id string;
+property id.x float;
+"""
+
+
+def _rows(city: str, source: str) -> str:
+    return (
+        f"select '{city}-{source}-1' as id, '{city}' as city, '{source}' as source, 1.0 as x"
+        f" union all select '{city}-{source}-2', '{city}', '{source}', 2.0"
+    )
+
+
+def _raw(city: str, source: str, complete_where: str) -> str:
+    return f"""
+root partial datasource raw_{city}_{source} (id: id, city: city, source: source, x: x)
+grain (id) complete where {complete_where}
+query '''{_rows(city, source)}''';
+"""
+
+
+def _pub(city: str) -> str:
+    return f"""
+partial datasource pub_{city} (id: id, city: city, source: source, x: x)
+grain (id) complete where city = '{city}'
+query '''{_rows(city, "MUN")} union all {_rows(city, "OSM")}''';
+"""
+
+
+def _run(model: str, query: str) -> tuple[list[tuple], str]:
+    env = Environment()
+    env.parse(model)
+    executor = Dialects.DUCK_DB.default_executor(environment=env)
+    sql = executor.generate_sql(query)[-1]
+    return executor.execute_text(query)[-1].fetchall(), sql
+
+
+CELLS = [(c, s) for c in ("A", "B") for s in ("MUN", "OSM")]
+FULL_GRID = CONCEPTS + "".join(
+    _raw(c, s, f"city = '{c}' and source = '{s}'") for c, s in CELLS
+)
+
+
+def test_full_cross_product_of_cells_is_a_cover():
+    rows, sql = _run(FULL_GRID, "select id order by id asc;")
+    assert len(rows) == 8
+    assert all(f"raw_{c}_{s}" in sql for c, s in CELLS)
+
+
+def test_a_missing_cell_is_not_covered_by_the_other_arm_for_its_city():
+    model = CONCEPTS + "".join(
+        _raw(c, s, f"city = '{c}' and source = '{s}'")
+        for c, s in CELLS
+        if (c, s) != ("A", "OSM")
+    )
+    with pytest.raises(UnresolvableQueryException):
+        _run(model, "select id order by id asc;")
+
+
+def test_published_partitions_win_over_a_partial_grid():
+    model = (
+        CONCEPTS
+        + "".join(
+            _raw(c, s, f"city = '{c}' and source = '{s}'")
+            for c, s in CELLS
+            if (c, s) != ("B", "OSM")
+        )
+        + _pub("A")
+        + _pub("B")
+    )
+    for query in ("select id order by id asc;", "select city, count(id) -> n;"):
+        rows, sql = _run(model, query)
+        assert "pub_A" in sql and "pub_B" in sql
+        assert not any(f"raw_{c}_{s}" in sql for c, s in CELLS)
+    rows, _ = _run(model, "select id order by id asc;")
+    assert len(rows) == 8
+
+
+def test_city_filter_still_reads_that_city_alone():
+    rows, sql = _run(FULL_GRID, "select id where city = 'A' order by id asc;")
+    assert [r[0] for r in rows] == ["A-MUN-1", "A-MUN-2", "A-OSM-1", "A-OSM-2"]
+    assert "raw_B_MUN" not in sql and "raw_B_OSM" not in sql

--- a/tests/engine/test_duckdb_partition_cover.py
+++ b/tests/engine/test_duckdb_partition_cover.py
@@ -97,3 +97,21 @@ def test_city_filter_still_reads_that_city_alone():
     rows, sql = _run(FULL_GRID, "select id where city = 'A' order by id asc;")
     assert [r[0] for r in rows] == ["A-MUN-1", "A-MUN-2", "A-OSM-1", "A-OSM-2"]
     assert "raw_B_MUN" not in sql and "raw_B_OSM" not in sql
+
+
+ROLLUP = """
+datasource rollup (id: id, city: city, source: source, x: x)
+grain (id)
+query '''{rows}''';
+""".format(rows=" union all ".join(_rows(c, s) for c, s in CELLS))
+
+
+@pytest.mark.parametrize(
+    "query", ["select id order by id asc;", "select city, count(id) -> n;"]
+)
+def test_one_complete_source_outranks_a_covering_union(query):
+    model = CONCEPTS + _pub("A") + _pub("B") + ROLLUP
+    rows, sql = _run(model, query)
+    assert "rollup" in sql
+    assert "pub_A" not in sql and "pub_B" not in sql
+    assert len(rows) == (8 if query.startswith("select id") else 2)

--- a/tests/engine/test_partition_source_exclusion.py
+++ b/tests/engine/test_partition_source_exclusion.py
@@ -191,3 +191,116 @@ def test_reduced_domain_recorded_by_address_and_canonical():
     drop_excluded_partials(environment, gate)
     assert set(environment.datasources) == {"web", "catalog"}
     assert environment.excluded_enum_values["local.channel"] == frozenset({"STORE"})
+
+
+CLUSTERED = """
+key city enum<string>['A', 'B'];
+key id string;
+key source enum<string>['municipal', 'community', 'osm'];
+property id.cell string;
+
+root partial datasource municipal (id: id, city: city, source: source, cell: cell)
+grain (id) complete where city = 'A' and source = 'municipal'
+query '''select 'm1' as id, 'A' as city, 'municipal' as source, 'c1' as cell''';
+
+root partial datasource community (id: id, city: city, source: source, cell: cell)
+grain (id) complete where city = 'A' and source = 'community'
+query '''select 'k1' as id, 'A' as city, 'community' as source, 'c2' as cell''';
+
+root partial datasource osm (id: id, city: city, source: source, cell: cell)
+grain (id) complete where city = 'A' and source = 'osm'
+query '''select 'o1' as id, 'A' as city, 'osm' as source, 'c1' as cell
+union all select 'o2' as id, 'A' as city, 'osm' as source, 'c3' as cell''';
+
+auto anchor <- min(id ? source != 'osm') by cell;
+auto cluster_id <- coalesce(anchor, id);
+auto is_primary <- id = cluster_id;
+"""
+
+PRUNE_SPELLINGS = {
+    "target_where": """
+partial datasource pruned (id, city, cluster_id)
+grain (id) complete where city = 'A'
+address pruned_out
+where id = cluster_id;
+""",
+    "claim_predicate": """
+partial datasource pruned (id, city, cluster_id)
+grain (id) complete where city = 'A' and id = cluster_id
+address pruned_out;
+""",
+    "claim_boolean": """
+partial datasource pruned (id, city, is_primary)
+grain (id) complete where city = 'A' and is_primary = true
+address pruned_out;
+""",
+}
+
+
+def _refresh_pruned(executor) -> list[str]:
+    target = executor.environment.datasources["pruned"]
+    executor.update_datasource(target)
+    return [
+        r[0]
+        for r in executor.execute_raw_sql(
+            "select id from pruned_out order by id"
+        ).fetchall()
+    ]
+
+
+def test_unpruned_target_unions_own_partitions():
+    executor = _executor(
+        CLUSTERED,
+        """
+partial datasource pruned (id, city, cluster_id)
+grain (id) complete where city = 'A'
+address pruned_out;
+""",
+    )
+    assert _refresh_pruned(executor) == ["k1", "m1", "o1", "o2"]
+
+
+@pytest.mark.parametrize("spelling", PRUNE_SPELLINGS, ids=list(PRUNE_SPELLINGS))
+def test_row_gate_on_partitioned_target_plans_inside_partition_scope(spelling):
+    """A row gate that depends on an aggregate is evaluated after the union
+    of the arms covering the target's own partition, not against the whole
+    `city` domain: the partials are exhaustive within `city = 'A'` only."""
+    executor = _executor(CLUSTERED, PRUNE_SPELLINGS[spelling])
+    assert _refresh_pruned(executor) == ["k1", "m1", "o2"]
+
+
+def _stages(executor, claim: str, gate: str | None) -> list[str]:
+    from trilogy.core.models.author import WhereClause, prepend_where_stage
+    from trilogy.core.query_processor import _partition_scoped_stages
+
+    env = executor.environment
+
+    def clause(text: str) -> WhereClause:
+        statement = env.parse(f"{text} select id;")[1][-1]
+        assert statement.where_clause is not None
+        return statement.where_clause
+
+    claim_clause = clause(claim)
+    stages = [clause(gate)] if gate else []
+    scoped = _partition_scoped_stages(stages, claim_clause, env)
+    if len(scoped) == 1:
+        assert str(scoped) == str(prepend_where_stage(stages, claim_clause))
+    return [str(s) for s in scoped]
+
+
+def test_scalar_gate_stays_one_stage_with_the_claim():
+    executor = _executor(CLUSTERED)
+    assert len(_stages(executor, "where city = 'A'", None)) == 1
+    assert len(_stages(executor, "where city = 'A'", "where source = 'osm'")) == 1
+
+
+def test_cross_row_gate_follows_the_scalar_claim_as_its_own_stage():
+    executor = _executor(CLUSTERED)
+    stages = _stages(executor, "where city = 'A'", "where id = cluster_id")
+    assert len(stages) == 2 and "city" in stages[0] and "cluster_id" in stages[1]
+    stages = _stages(executor, "where city = 'A' and id = cluster_id", None)
+    assert len(stages) == 2 and "cluster_id" not in stages[0]
+    stages = _stages(
+        executor, "where city = 'A' and is_primary = true", "where source = 'osm'"
+    )
+    assert len(stages) == 2 and "source" in stages[1] and "is_primary" in stages[1]

--- a/tests/engine/test_partition_source_exclusion.py
+++ b/tests/engine/test_partition_source_exclusion.py
@@ -7,8 +7,10 @@ import pytest
 
 from trilogy import Dialects
 from trilogy.core.enums import ComparisonOperator
+from trilogy.core.exceptions import UnresolvableQueryException
 from trilogy.core.models.build import BuildComparison, BuildWhereClause
 from trilogy.core.processing.partial_bridging import drop_excluded_partials
+from trilogy.core.processing.v4_helper.staged_where import universal_row_bound
 
 COMMON = """
 key city enum<string>['A', 'B'];
@@ -133,7 +135,9 @@ def test_drop_excluded_partials_keeps_everything_without_gate():
     assert set(environment.datasources) == before
 
 
-def test_drop_excluded_partials_stands_down_for_cross_row_stage():
+def test_nothing_is_hidden_for_a_cross_row_gate():
+    # the gate's own aggregate sees the unfiltered population, so
+    # `universal_row_bound` yields nothing to narrow by and every source stands
     executor = _executor(
         COMMON, MODEL_A_SOURCES, MODEL_B, "auto tree_count <- count(tree_id) by city;"
     )
@@ -147,8 +151,42 @@ def test_drop_excluded_partials_stands_down_for_cross_row_stage():
             operator=ComparisonOperator.GT,
         )
     )
-    drop_excluded_partials(environment, gate)
+    assert universal_row_bound([], gate) is None
+    drop_excluded_partials(environment, universal_row_bound([], gate))
     assert set(environment.datasources) == before
+
+
+def test_staging_is_what_lets_an_aggregate_gate_narrow_the_domain():
+    # A flat `where` hands its aggregate the UNFILTERED population, so the
+    # sibling `city = 'A'` cannot narrow the domain the family must exhaust and
+    # the uncovered city makes the query unresolvable. Staging the same two
+    # predicates scopes the aggregate to city A, and the bound applies.
+    agg = "auto tree_count <- count(tree_id) by city;"
+    projection = " select tree_id, dbh order by tree_id asc;"
+    flat = _executor(COMMON, MODEL_A_SOURCES, agg)
+    with pytest.raises(UnresolvableQueryException):
+        flat.execute_text("where city = 'A' and tree_count > 0" + projection)
+    staged = _executor(COMMON, MODEL_A_SOURCES, agg)
+    rows = staged.execute_text(
+        "where city = 'A' then where tree_count > 0" + projection
+    )[-1].fetchall()
+    assert [row[0] for row in rows] == ["a1", "a2"]
+
+
+def test_partition_gate_narrows_from_any_leading_row_local_stage():
+    # the narrowing predicate need not be stage 1: every row the statement
+    # reads passes the whole leading row-local run
+    executor = _executor(COMMON, MODEL_A_SOURCES, MODEL_B)
+    for query in (
+        "where city = 'A' select tree_id, dbh order by tree_id asc;",
+        "where tree_id != 'zzz' then where city = 'A'"
+        " select tree_id, dbh order by tree_id asc;",
+        "where tree_id != 'zzz' then where tree_id != 'yyy' then where city = 'A'"
+        " select tree_id, dbh order by tree_id asc;",
+    ):
+        sql = executor.generate_sql(query)[-1]
+        assert "b_one" not in sql and "b_two" not in sql, sql
+        assert executor.execute_text(query)[-1].fetchall() == [("a1", 1.0), ("a2", 2.0)]
 
 
 THREE_WAY = """

--- a/tests/execution/state/test_schema_refresh.py
+++ b/tests/execution/state/test_schema_refresh.py
@@ -254,7 +254,8 @@ def test_duckdb_normalize_db_type():
     assert dialect.normalize_db_type("DATE") == DataType.DATE
     assert dialect.normalize_db_type("TIMESTAMP") == DataType.DATETIME
     assert dialect.normalize_db_type("TIMESTAMP WITH TIME ZONE") == DataType.TIMESTAMP
-    assert dialect.normalize_db_type("DOUBLE") == DataType.FLOAT
+    assert dialect.normalize_db_type("DOUBLE") == DataType.DOUBLE
+    assert dialect.normalize_db_type("REAL") == DataType.FLOAT
     assert dialect.normalize_db_type("DECIMAL(18,3)") == DataType.NUMERIC
 
 
@@ -301,7 +302,7 @@ def test_postgres_normalize_db_type():
     assert dialect.normalize_db_type("text") == DataType.STRING
     assert dialect.normalize_db_type("boolean") == DataType.BOOL
     assert dialect.normalize_db_type("numeric(10,2)") == DataType.NUMERIC
-    assert dialect.normalize_db_type("double precision") == DataType.FLOAT
+    assert dialect.normalize_db_type("double precision") == DataType.DOUBLE
     assert dialect.normalize_db_type("real") == DataType.FLOAT
     assert dialect.normalize_db_type("date") == DataType.DATE
     assert dialect.normalize_db_type("timestamp without time zone") == DataType.DATETIME

--- a/tests/generators/test_datasource_scoring.py
+++ b/tests/generators/test_datasource_scoring.py
@@ -30,8 +30,9 @@ from trilogy.core.models.core import DataType, EnumType
 from trilogy.core.models.datasource import Address
 from trilogy.core.processing.node_generators.select_helpers.datasource_injection import (
     _best_enum_union,
+    _claim_atoms,
+    _claimed_value,
     _datasource_score,
-    _extract_enum_value_for_key,
 )
 from trilogy.core.processing.node_generators.select_helpers.source_scoring import (
     get_graph_partial_nodes,
@@ -425,12 +426,15 @@ class TestBestEnumUnion:
         }
 
     def test_two_key_condition_discriminates_on_correct_key(self):
-        """When non_partial_for has two enum keys, only the discriminating key produces a union.
+        """Two enum keys in non_partial_for: the same two-arm union is the cover
+        under either key.
 
         city=['USBOS'] (single value) and source=['CITY','ARBORETUM'] (two values).
         Two sources: (city=USBOS, source=CITY) and (city=USBOS, source=ARBORETUM).
-        The city key has all sources sharing the same value → None.
-        The source key correctly discriminates → 2-way union.
+        Under the city key both arms claim USBOS and cover it only jointly,
+        through their residual source claims exhausting the source enum; under
+        the source key each arm covers its own value. Either way the union is
+        the same two arms, so the two families dedupe to one node.
         """
         city_enum = EnumType(type=DataType.STRING, values=["USBOS"])
         source_enum = EnumType(type=DataType.STRING, values=["CITY", "ARBORETUM"])
@@ -442,7 +446,10 @@ class TestBestEnumUnion:
         arb_raw = _make_enum_ds_two_key("USBOS", city, "ARBORETUM", source, shared)
 
         city_result = _best_enum_union([city_raw, arb_raw], city_enum, city)
-        assert city_result is None, f"city key should return None, got {city_result}"
+        assert city_result is not None
+        assert [{ds.name for ds in combo} for combo in city_result] == [
+            {city_raw.name, arb_raw.name}
+        ]
 
         source_result = _best_enum_union([city_raw, arb_raw], source_enum, source)
         assert source_result is not None
@@ -502,12 +509,10 @@ def _reference_best_enum_union(
     for ds in dses:
         if not ds.non_partial_for:
             continue
-        val = _extract_enum_value_for_key(
-            ds.non_partial_for.conditional, merge_key.address
-        )
-        if val is None:
+        claim = _claim_atoms(ds.non_partial_for.conditional)
+        if claim is None or merge_key.address not in claim:
             continue
-        by_value[val].append(ds)
+        by_value[_claimed_value(claim[merge_key.address])].append(ds)
 
     if {str(v) for v in by_value} < set(enum_type.values):
         return None
@@ -613,21 +618,18 @@ class TestBestEnumUnionEquivalence:
         assert elapsed < 1.0, f"union selection took {elapsed:.3f}s"
 
 
-class TestExtractEnumValueForKey:
+class TestClaimAtoms:
     def _concept(self, name: str) -> BuildConcept:
         return _make_concept(name)
 
     def test_parenthetical_wrapping_comparison(self):
-        """Value is extracted when the comparison is wrapped in a BuildParenthetical."""
         key = self._concept("region")
         cmp = BuildComparison(left=key, right="NORTH", operator=ComparisonOperator.EQ)
-        paren = BuildParenthetical(content=cmp)
+        claim = _claim_atoms(BuildParenthetical(content=cmp))
+        assert claim is not None
+        assert _claimed_value(claim[key.address]) == "NORTH"
 
-        result = _extract_enum_value_for_key(paren, key.address)
-        assert result == "NORTH"
-
-    def test_parenthetical_wrapping_conditional(self):
-        """Value is extracted when a parenthetical wraps a compound AND condition."""
+    def test_parenthetical_wrapping_conditional_keeps_every_atom(self):
         key = self._concept("region")
         other = self._concept("other")
         inner = BuildConditional(
@@ -639,18 +641,30 @@ class TestExtractEnumValueForKey:
             ),
             operator=BooleanOperator.AND,
         )
-        paren = BuildParenthetical(content=inner)
+        claim = _claim_atoms(BuildParenthetical(content=inner))
+        assert claim is not None
+        assert _claimed_value(claim[key.address]) == "SOUTH"
+        assert _claimed_value(claim[other.address]) == "X"
 
-        result = _extract_enum_value_for_key(paren, key.address)
-        assert result == "SOUTH"
+    def test_or_and_repeated_atoms_are_not_claims(self):
+        key = self._concept("region")
+        atom = BuildComparison(left=key, right="N", operator=ComparisonOperator.EQ)
+        assert (
+            _claim_atoms(
+                BuildConditional(left=atom, right=atom, operator=BooleanOperator.OR)
+            )
+            is None
+        )
+        assert (
+            _claim_atoms(
+                BuildConditional(left=atom, right=atom, operator=BooleanOperator.AND)
+            )
+            is None
+        )
 
     def test_parenthetical_with_non_condition_content_returns_none(self):
-        """A BuildParenthetical whose content is not a condition type returns None."""
-        key = self._concept("region")
         paren = BuildParenthetical(content="not_a_condition")  # type: ignore[arg-type]
-
-        result = _extract_enum_value_for_key(paren, key.address)
-        assert result is None
+        assert _claim_atoms(paren) is None
 
 
 def _scoped_concept(name: str) -> BuildConcept:

--- a/tests/scripts/test_ingest.py
+++ b/tests/scripts/test_ingest.py
@@ -1668,7 +1668,7 @@ class TestProcessColumn:
         assert rich_import == "std.currency"
         assert isinstance(concept.datatype, TraitDataType)
         assert concept.datatype.traits == ["usd"]
-        assert concept.datatype.type == DataType.FLOAT
+        assert concept.datatype.type == DataType.DOUBLE
 
     def test_rich_type_detection_latitude(self):
         """Test rich type detection for latitude."""

--- a/tests/test_aggregate_axis_bridge.py
+++ b/tests/test_aggregate_axis_bridge.py
@@ -1,0 +1,78 @@
+"""An aggregate grouped by the row grain key must not strand a sibling's axis.
+
+`min(x ? p) by id` at output grain `id` is the most downstream group exposing
+`id`, so the cover election hands it the key and the row-grain projection that
+maps `id` onto a sibling aggregate's axis (`min(y ? q) by cell`) covers no
+mandatory output and is dropped. The merge is then two grouped sides with no
+column in common and the keyless-join guard raises. Both merge layers were
+affected: the FINAL assembly when the aggregates are projected side by side,
+and a consumer group's own parent merge when an expression reads them together.
+"""
+
+import pytest
+
+from trilogy import Dialects
+from trilogy.core.models.environment import Environment
+from trilogy.executor import Executor
+
+MODEL = """
+key id string;
+key source string;
+property id.zone string;
+
+datasource rows (
+  i: id,
+  s: source,
+  z: zone
+)
+grain (id)
+query '''
+select 'tem-1' i, 'municipal' s, 'c1' z union all
+select 'tem-2' i, 'municipal' s, 'c2' z union all
+select 'com-1' i, 'community' s, 'c2' z union all
+select 'osm-1' i, 'osm' s, 'c1' z union all
+select 'osm-2' i, 'osm' s, 'c3' z''';
+
+auto cell <- concat(zone, '-grid');
+auto anchor <- min(id ? source != 'osm') by cell;
+auto self_if_municipal <- min(id ? source = 'municipal') by id;
+auto cluster_id <- coalesce(self_if_municipal, anchor, id);
+"""
+
+
+@pytest.fixture
+def executor() -> Executor:
+    return Dialects.DUCK_DB.default_executor(environment=Environment())
+
+
+def test_grain_key_aggregate_beside_foreign_axis_aggregate(executor: Executor):
+    results = executor.execute_text(
+        MODEL + "select id, self_if_municipal, anchor order by id asc;"
+    )[-1].fetchall()
+    assert results == [
+        ("com-1", None, "com-1"),
+        ("osm-1", None, "tem-1"),
+        ("osm-2", None, None),
+        ("tem-1", "tem-1", "tem-1"),
+        ("tem-2", "tem-2", "com-1"),
+    ]
+
+
+def test_expression_over_both_aggregates(executor: Executor):
+    results = executor.execute_text(MODEL + "select id, cluster_id order by id asc;")[
+        -1
+    ].fetchall()
+    assert results == [
+        ("com-1", "com-1"),
+        ("osm-1", "tem-1"),
+        ("osm-2", "osm-2"),
+        ("tem-1", "tem-1"),
+        ("tem-2", "tem-2"),
+    ]
+
+
+def test_row_gate_on_the_derived_cluster(executor: Executor):
+    results = executor.execute_text(
+        MODEL + "select id where id = cluster_id order by id asc;"
+    )[-1].fetchall()
+    assert results == [("com-1",), ("osm-2",), ("tem-1",), ("tem-2",)]

--- a/tests/test_derived_concepts.py
+++ b/tests/test_derived_concepts.py
@@ -365,3 +365,15 @@ having sum(amount) > 1.2 * avg(sum(amount) by store_id);
     assert not re.search(
         r"\b(sum|avg|min|max|count)\s*\(\s*(sum|avg|min|max|count)\s*\(", joined
     ), joined
+
+
+def test_key_peer_of_by_aggregate_keeps_row_grain():
+    env, _ = parse("""key id string;
+property id.cell string;
+auto anchor <- min(id) by cell;
+auto cluster_id <- coalesce(anchor, id);
+auto cluster_cell <- coalesce(anchor, cell);
+""")
+    build = env.materialize_for_select()
+    assert set(build.concepts["local.cluster_id"].grain.components) == {"local.id"}
+    assert set(build.concepts["local.cluster_cell"].grain.components) == {"local.id"}

--- a/tests/test_where_select_dual_scope.py
+++ b/tests/test_where_select_dual_scope.py
@@ -626,3 +626,39 @@ def test_macro_wrapped_inline_where_aggregate():
         "select x, sum(z) by x as sx where f = 1 and @bigsum(z) > 5;",
     )
     assert rows == AGG_EXPECTED, rows
+
+
+CELL_ANCHOR_SCHEMA = """key id string;
+property id.cell string;
+property id.kind string;
+datasource rows (id: id, cell: cell, kind: kind) grain (id)
+query '''select 'm1' as id, 'c1' as cell, 'muni' as kind
+union all select 'o1' as id, 'c1' as cell, 'osm' as kind
+union all select 'o2' as id, 'c3' as cell, 'osm' as kind''';
+auto anchor <- min(id ? kind != 'osm') by cell;
+auto plain_anchor <- min(id) by cell;
+auto cluster_id <- coalesce(anchor, id);
+auto is_primary <- id = cluster_id;
+"""
+# Population values: anchor {c1: m1, c3: null}, plain_anchor {c1: m1, c3: o2},
+# cluster_id {m1: m1, o1: m1, o2: o2}. A row gate against them must drop o1
+# even when the gated concept is also projected and recomputed in select scope.
+
+
+def test_row_key_gated_by_projected_aggregate_drops_failing_rows():
+    rows = _rows(CELL_ANCHOR_SCHEMA, "where id = plain_anchor select id, plain_anchor;")
+    assert rows == [("m1", "m1"), ("o2", "o2")], rows
+    rows = _rows(CELL_ANCHOR_SCHEMA, "where id = anchor select id, anchor;")
+    assert rows == [("m1", "m1")], rows
+
+
+def test_row_key_gated_by_aggregate_coalesced_with_key_drops_failing_rows():
+    rows = _rows(CELL_ANCHOR_SCHEMA, "where id = cluster_id select id, cluster_id;")
+    assert rows == [("m1", "m1"), ("o2", "o2")], rows
+    rows = _rows(CELL_ANCHOR_SCHEMA, "where id != cluster_id select id;")
+    assert rows == [("o1",)], rows
+
+
+def test_row_flag_derived_from_aggregate_gates_projected_rows():
+    rows = _rows(CELL_ANCHOR_SCHEMA, "where is_primary = true select id, is_primary;")
+    assert rows == [("m1", True), ("o2", True)], rows

--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from trilogy.executor import Executor
     from trilogy.parser import parse
 
-__version__ = "0.3.346"
+__version__ = "0.3.347"
 
 __all__ = [
     "CONFIG",

--- a/trilogy/core/models/author.py
+++ b/trilogy/core/models/author.py
@@ -1414,6 +1414,11 @@ class Concept(Addressable, DataTyped, ConceptArgs, ReferenceReplaceable, Namespa
                     _, _, parent_keys = x.get_select_grain_and_keys(grain, environment)
                     if parent_keys:
                         pkeys.update(parent_keys)
+                    elif x.purpose == Purpose.KEY:
+                        # A bare key peer has no keys of its own; its row
+                        # identity is itself (`coalesce(min(id) by cell, id)`
+                        # varies per id, not per cell).
+                        pkeys.add(x.address)
                 final_grain = Grain.from_concepts(pkeys, environment)
                 keys = final_grain.components
             else:

--- a/trilogy/core/processing/node_generators/select_helpers/datasource_injection.py
+++ b/trilogy/core/processing/node_generators/select_helpers/datasource_injection.py
@@ -1,8 +1,8 @@
 from collections import defaultdict
+from dataclasses import dataclass
 
 from trilogy.core.enums import (
     AddressType,
-    BooleanOperator,
     ComparisonOperator,
     Modifier,
 )
@@ -12,12 +12,14 @@ from trilogy.core.models.build import (
     BuildConcept,
     BuildConditional,
     BuildDatasource,
+    BuildFunction,
     BuildParenthetical,
 )
 from trilogy.core.models.core import EnumType
 from trilogy.core.models.datasource import Address
 from trilogy.core.processing.condition_utility import (
     ExcludedEnumValues,
+    decompose_condition,
     effective_enum_domain,
     simplify_conditions,
 )
@@ -36,40 +38,235 @@ def _datasource_score(ds: BuildDatasource) -> int:
     return 2
 
 
-def _extract_enum_value_for_key(
-    conditional: BoolExpr,
-    key_address: str,
-) -> object | None:
-    """Extract the literal value for a specific concept key from a (compound) condition."""
-    if isinstance(conditional, BuildComparison):
-        if conditional.operator not in (ComparisonOperator.EQ, ComparisonOperator.IS):
-            return None
-        if (
-            isinstance(conditional.left, BuildConcept)
-            and conditional.left.address == key_address
-            and not isinstance(conditional.right, BuildConcept)
+@dataclass(frozen=True)
+class _CoverUnit:
+    """A set of arms that jointly cover one discriminator value.
+
+    ``score`` sums the members' materialization scores and ``width`` counts
+    them, so among equally materialized covers the one with fewer scans wins.
+    ``cols`` is the column overlap every member binds."""
+
+    members: tuple[BuildDatasource, ...]
+    cols: frozenset[str]
+    score: int
+    width: int
+
+
+_Claim = dict[str, BuildComparison]
+_Arm = tuple[BuildDatasource, _Claim]
+
+
+def _claim_atoms(conditional: BoolExpr) -> _Claim | None:
+    """A `complete where` as ``{concept address: its equality atom}``.
+
+    Only a pure conjunction of ``concept = literal`` atoms is a partition
+    claim the cover proof can reason about exactly; anything else (an OR, a
+    range, a concept-to-concept comparison, a repeated concept) returns None
+    and the arm stays out of enum-family election."""
+    out: _Claim = {}
+    for chunk in decompose_condition(conditional):
+        atom: object = chunk
+        while isinstance(atom, BuildParenthetical):
+            atom = atom.content
+        if isinstance(atom, BuildConditional):
+            nested = _claim_atoms(atom)
+            if nested is None or set(nested) & set(out):
+                return None
+            out.update(nested)
+            continue
+        if not isinstance(atom, BuildComparison) or atom.operator not in (
+            ComparisonOperator.EQ,
+            ComparisonOperator.IS,
         ):
-            return conditional.right
-        if (
-            isinstance(conditional.right, BuildConcept)
-            and conditional.right.address == key_address
-            and not isinstance(conditional.left, BuildConcept)
-        ):
-            return conditional.left
-        return None
-    elif isinstance(conditional, BuildConditional):
-        if conditional.operator == BooleanOperator.OR:
             return None
-        if isinstance(conditional.left, BoolExpr):
-            left_val = _extract_enum_value_for_key(conditional.left, key_address)
-            if left_val is not None:
-                return left_val
-        if isinstance(conditional.right, BoolExpr):
-            return _extract_enum_value_for_key(conditional.right, key_address)
-    elif isinstance(conditional, BuildParenthetical):
-        if isinstance(conditional.content, BoolExpr):
-            return _extract_enum_value_for_key(conditional.content, key_address)
-    return None
+        if isinstance(atom.left, BuildConcept) and not isinstance(
+            atom.right, BuildConcept
+        ):
+            concept = atom.left
+        elif isinstance(atom.right, BuildConcept) and not isinstance(
+            atom.left, BuildConcept
+        ):
+            concept = atom.right
+        else:
+            return None
+        if concept.address in out:
+            return None
+        out[concept.address] = atom
+    return out
+
+
+def _claimed_value(atom: BuildComparison) -> str:
+    literal: object = atom.right if isinstance(atom.left, BuildConcept) else atom.left
+    if isinstance(literal, BuildFunction) and literal.arguments:
+        literal = literal.arguments[0]
+    return str(literal)
+
+
+def _claimed_concept(atom: BuildComparison) -> BuildConcept:
+    concept = atom.left if isinstance(atom.left, BuildConcept) else atom.right
+    assert isinstance(concept, BuildConcept)
+    return concept
+
+
+def _columns(ds: BuildDatasource) -> frozenset[str]:
+    return frozenset(col.concept.address for col in ds.columns)
+
+
+def _cover_units(
+    arms: list[_Arm],
+    excluded: ExcludedEnumValues | None,
+) -> list[_CoverUnit]:
+    """The arm sets that jointly cover the population these arms were asked
+    to cover, best per column overlap.
+
+    An arm whose residual claim is empty covers by itself. Arms that still
+    claim other discriminators cover only jointly: they are partitioned on
+    one of those discriminators and every value of it must be covered in
+    turn, recursively. A claim on ``(city, source)`` therefore never covers
+    ``city`` by itself; it covers it together with the arms for the other
+    ``source`` values."""
+    units = [
+        _CoverUnit(
+            members=(ds,), cols=_columns(ds), score=_datasource_score(ds), width=1
+        )
+        for ds, claim in arms
+        if not claim
+    ]
+    constrained = [(ds, claim) for ds, claim in arms if claim]
+    if not constrained:
+        return units
+    counts: dict[str, int] = defaultdict(int)
+    for _, claim in constrained:
+        for address in claim:
+            counts[address] += 1
+    key_address = max(sorted(counts), key=lambda a: counts[a])
+    key = next(
+        _claimed_concept(claim[key_address])
+        for _, claim in constrained
+        if key_address in claim
+    )
+    if isinstance(key.datatype, EnumType):
+        units.extend(_enum_cover_units(constrained, key, excluded))
+        return units
+    # A non-enum residual is provable only as a range/boolean cover, one atom
+    # per arm.
+    if all(len(claim) == 1 for _, claim in constrained) and simplify_conditions(
+        [claim[key_address] for _, claim in constrained if key_address in claim],
+        excluded,
+    ):
+        members = tuple(ds for ds, _ in constrained)
+        units.append(
+            _CoverUnit(
+                members=members,
+                cols=frozenset.intersection(*(_columns(ds) for ds in members)),
+                score=sum(_datasource_score(ds) for ds in members),
+                width=len(members),
+            )
+        )
+    return units
+
+
+_State = tuple[int, int, tuple[BuildDatasource, ...], tuple[int, ...], tuple[int, ...]]
+
+
+def _enum_cover_units(
+    arms: list[_Arm],
+    key: BuildConcept,
+    excluded: ExcludedEnumValues | None,
+) -> list[_CoverUnit]:
+    """Best covering combinations over an enum discriminator, one per column
+    overlap signature.
+
+    Each value of the effective domain (values the statement's row gate rules
+    out need no arm) must have a cover: the arms claiming that value with the
+    claim stripped, plus arms silent on this discriminator (their claim applies
+    to every value), reduced by `_cover_units`. A dynamic program over values
+    whose state is the combo's column overlap so far (minus the discriminator)
+    keeps the highest-scoring combo per signature; the score is separable and
+    the overlap is the only coupling, so this is exhaustive over achievable
+    signatures without enumerating the product. One combo per overlap lets
+    parallel partitionings (sales vs. returns vs. dim, all keyed by one channel
+    enum) each contribute their own union. Ties break to the first
+    max-scoring combo in product order; signatures order by their first
+    achieving combo."""
+    domain = effective_enum_domain(key.datatype, key, excluded)
+    assert isinstance(domain, EnumType)
+    required = [str(v) for v in domain.values]
+    silent = [(ds, claim) for ds, claim in arms if key.address not in claim]
+    by_value: dict[str, list[_Arm]] = defaultdict(list)
+    for ds, claim in arms:
+        atom = claim.get(key.address)
+        if atom is None:
+            continue
+        value = _claimed_value(atom)
+        if value in required:
+            residual = {a: c for a, c in claim.items() if a != key.address}
+            by_value[value].append((ds, residual))
+    per_value: list[list[_CoverUnit]] = []
+    for value in required:
+        candidates = by_value.get(value, []) + silent
+        units = _cover_units(candidates, excluded) if candidates else []
+        if not units:
+            return []
+        per_value.append(units)
+
+    states: dict[frozenset[str], _State] = {}
+    for idx, unit in enumerate(per_value[0]):
+        sig = unit.cols - {key.address}
+        if not sig:
+            continue
+        existing = states.get(sig)
+        if existing is None:
+            states[sig] = (unit.score, unit.width, unit.members, (idx,), (idx,))
+        elif (unit.score, -unit.width) > (existing[0], -existing[1]):
+            states[sig] = (unit.score, unit.width, unit.members, (idx,), existing[4])
+    for units in per_value[1:]:
+        next_states: dict[frozenset[str], _State] = {}
+        for sig, (score, width, members, combo_key, min_key) in states.items():
+            for idx, unit in enumerate(units):
+                new_sig = sig & unit.cols
+                if not new_sig:
+                    continue
+                new: _State = (
+                    score + unit.score,
+                    width + unit.width,
+                    _dedupe_members(members + unit.members),
+                    combo_key + (idx,),
+                    min_key + (idx,),
+                )
+                existing = next_states.get(new_sig)
+                if existing is None:
+                    next_states[new_sig] = new
+                    continue
+                new_min_key = min(existing[4], new[4])
+                if (new[0], -new[1]) > (existing[0], -existing[1]) or (
+                    (new[0], new[1]) == (existing[0], existing[1])
+                    and new[3] < existing[3]
+                ):
+                    next_states[new_sig] = (*new[:4], new_min_key)
+                else:
+                    next_states[new_sig] = (*existing[:4], new_min_key)
+        states = next_states
+        if not states:
+            return []
+    return [
+        _CoverUnit(members=members, cols=sig, score=score, width=width)
+        for sig, (score, width, members, _, _) in sorted(
+            states.items(), key=lambda kv: kv[1][4]
+        )
+    ]
+
+
+def _dedupe_members(
+    members: tuple[BuildDatasource, ...],
+) -> tuple[BuildDatasource, ...]:
+    seen: set[str] = set()
+    out: list[BuildDatasource] = []
+    for ds in members:
+        if ds.identifier not in seen:
+            seen.add(ds.identifier)
+            out.append(ds)
+    return tuple(out)
 
 
 def _best_enum_union(
@@ -78,131 +275,34 @@ def _best_enum_union(
     merge_key: BuildConcept,
     excluded: ExcludedEnumValues | None = None,
 ) -> list[list[BuildDatasource]] | None:
-    """Find the best minimal covering combinations for an enum-partitioned key.
-
-    Groups by covered enum value, then searches one-source-per-value combos via
-    a dynamic program over values whose state is the combo's concept overlap so
-    far (minus the merge key), keeping the highest-scoring combo per distinct
-    overlap signature. The score is separable (a per-source sum) and the
-    overlap is the only coupling between values, so this is exhaustive over
-    achievable signatures without enumerating the k^V combo product. Returning
-    one combo per overlap lets parallel partitionings (e.g., sales vs.
-    returns vs. dim, all keyed by the same channel enum) each contribute
-    their own union datasource instead of collapsing into the single best.
-    Materialized table sources score higher than script/query sources.
-    Coverage is judged over the effective domain: values the statement's row
-    gate rules out (``excluded``) need no arm, and an arm for such a value
-    cannot contribute.
-    """
-    required = {
-        str(v) for v in effective_enum_domain(enum_type, merge_key, excluded).values
-    }
-    by_value: dict[object, list[BuildDatasource]] = defaultdict(list)
+    """The minimal covering unions for an enum-partitioned key: every value of
+    the effective domain covered, with a multi-discriminator claim covering its
+    value only jointly with the arms for the other discriminators' values
+    (`_cover_units`). One union per maximal column overlap; None when no
+    complete cover exists or the only cover is a single source (not a union)."""
+    arms: list[_Arm] = []
     for ds in dses:
         if not ds.non_partial_for:
             continue
-        val = _extract_enum_value_for_key(
-            ds.non_partial_for.conditional, merge_key.address
-        )
-        if val is None or str(val) not in required:
-            continue
-        by_value[val].append(ds)
-
-    # Every value that can still occur must have at least one candidate source
-    if not required <= {str(v) for v in by_value}:
-        return None
-
-    values = list(by_value.keys())
-    # A union requires at least 2 distinct sources; a single source is not a union
-    if len(values) < 2:
-        return None
-
-    cols: dict[int, frozenset[str]] = {}
-    scores: dict[int, int] = {}
-    for candidates in by_value.values():
-        for ds in candidates:
-            cols[id(ds)] = frozenset(col.concept.address for col in ds.columns)
-            scores[id(ds)] = _datasource_score(ds)
-
-    # Members MAY disagree on intrinsic (~) partiality of a shared column (a
-    # mixed-family combo): such a union is a legitimate provider of the columns
-    # it binds complete, and union partial propagation keeps its ~-partial keys
-    # from outranking a pure family, so it is not rejected here. An empty
-    # overlap beyond the merge key IS rejected at the first step it appears:
-    # intersection only shrinks. Ties are deterministic: per signature the
-    # winner is the first max-scoring combo in product order (`combo_key` =
-    # candidate index tuple), and signatures order by their first-achieving
-    # combo (`min_key`, tracked over ALL combos reaching a signature).
-    merge_key_addr = merge_key.address
-    # signature -> (score, combo, combo_key, min_key)
-    states: dict[
-        frozenset[str],
-        tuple[int, list[BuildDatasource], tuple[int, ...], tuple[int, ...]],
-    ] = {}
-    for idx, ds in enumerate(by_value[values[0]]):
-        sig = cols[id(ds)] - {merge_key_addr}
-        if not sig:
-            continue
-        existing = states.get(sig)
-        if existing is None:
-            states[sig] = (scores[id(ds)], [ds], (idx,), (idx,))
-        elif scores[id(ds)] > existing[0]:
-            states[sig] = (scores[id(ds)], [ds], (idx,), existing[3])
-
-    for v in values[1:]:
-        next_states: dict[
-            frozenset[str],
-            tuple[int, list[BuildDatasource], tuple[int, ...], tuple[int, ...]],
-        ] = {}
-        for sig, (score, combo, combo_key, min_key) in states.items():
-            for idx, ds in enumerate(by_value[v]):
-                new_sig = sig & cols[id(ds)]
-                if not new_sig:
-                    continue
-                new_score = score + scores[id(ds)]
-                new_key = combo_key + (idx,)
-                existing = next_states.get(new_sig)
-                if existing is None:
-                    next_states[new_sig] = (
-                        new_score,
-                        combo + [ds],
-                        new_key,
-                        min_key + (idx,),
-                    )
-                    continue
-                new_min_key = min(existing[3], min_key + (idx,))
-                if new_score > existing[0] or (
-                    new_score == existing[0] and new_key < existing[2]
-                ):
-                    next_states[new_sig] = (
-                        new_score,
-                        combo + [ds],
-                        new_key,
-                        new_min_key,
-                    )
-                else:
-                    next_states[new_sig] = (
-                        existing[0],
-                        existing[1],
-                        existing[2],
-                        new_min_key,
-                    )
-        states = next_states
-        if not states:
-            return None
-
-    best_per_overlap: dict[frozenset[str], tuple[list[BuildDatasource], int]] = {
-        sig: (state[1], state[0])
-        for sig, state in sorted(states.items(), key=lambda kv: kv[1][3])
-    }
-    if not best_per_overlap:
+        claim = _claim_atoms(ds.non_partial_for.conditional)
+        if claim is not None and merge_key.address in claim:
+            arms.append((ds, claim))
+    units = [
+        unit
+        for unit in _enum_cover_units(arms, merge_key, excluded)
+        if len(unit.members) >= 2
+    ]
+    if not units:
         return None
     # Keep only maximal overlap signatures: a mixed combo whose overlap is a
     # strict subset of a pure-family combo's is dropped, while parallel
     # partitionings remain incomparable and all survive.
-    sigs = list(best_per_overlap.keys())
-    maximal = [s for s in sigs if not any(s < other for other in sigs)]
-    return [best_per_overlap[s][0] for s in maximal]
+    sigs = [unit.cols for unit in units]
+    return [
+        list(unit.members)
+        for unit in units
+        if not any(unit.cols < other for other in sigs)
+    ]
 
 
 def _partition_families(

--- a/trilogy/core/processing/node_generators/select_helpers/datasource_injection.py
+++ b/trilogy/core/processing/node_generators/select_helpers/datasource_injection.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 
 from trilogy.core.enums import (
     AddressType,
+    BooleanOperator,
     ComparisonOperator,
     Modifier,
 )
@@ -69,6 +70,11 @@ def _claim_atoms(conditional: BoolExpr) -> _Claim | None:
         while isinstance(atom, BuildParenthetical):
             atom = atom.content
         if isinstance(atom, BuildConditional):
+            # `decompose_condition` splits every AND it can; a conditional it
+            # handed back is an OR (or an AND over non-conditions). Only one
+            # freshly unwrapped from parentheses still has an AND to split.
+            if atom is chunk or atom.operator != BooleanOperator.AND:
+                return None
             nested = _claim_atoms(atom)
             if nested is None or set(nested) & set(out):
                 return None

--- a/trilogy/core/processing/partial_bridging.py
+++ b/trilogy/core/processing/partial_bridging.py
@@ -42,7 +42,6 @@ from trilogy.core.processing.condition_utility import (
     gate_allowed_values,
 )
 from trilogy.core.processing.v4_helper.functional_dependency import build_fd_closure
-from trilogy.core.processing.v4_helper.staged_where import stage_computes_cross_row
 
 
 def _spellings(concept: BuildConcept) -> set[str]:
@@ -251,15 +250,16 @@ def _gate_excluded_enum_values(
 def drop_excluded_partials(
     environment: BuildEnvironment, stage: BuildWhereClause | None
 ) -> None:
-    """Hide every ``complete where`` source the first WHERE stage rules out.
+    """Hide every ``complete where`` source the statement's row bound rules out.
 
-    ``stage`` is the statement's stage-1 row gate: every row the statement
-    reads passes it, so a source whose partition predicate contradicts it holds
-    no usable row. A stage that itself computes an aggregate or window sees the
-    full population, so nothing is hidden for it. Removal is from the
-    per-statement mapping only; shared build-cache objects are untouched.
+    ``stage`` is ``universal_row_bound``: the predicate every row the statement
+    reads satisfies, so a source whose partition predicate contradicts it holds
+    no usable row. Deciding which stages that bound may draw on belongs to the
+    staging rules, not here; None means the statement has no such bound and
+    nothing is hidden. Removal is from the per-statement mapping only; shared
+    build-cache objects are untouched.
     """
-    if stage is None or stage_computes_cross_row(stage):
+    if stage is None:
         return
     environment.excluded_enum_values = _gate_excluded_enum_values(environment, stage)
     excluded = [

--- a/trilogy/core/processing/v4_helper/condition_placement.py
+++ b/trilogy/core/processing/v4_helper/condition_placement.py
@@ -31,6 +31,7 @@ from trilogy.core.processing.node_generators.presence_probe import is_presence_p
 from .concept_graph import computed_origin_relation_members
 from .constants import FINAL_NODE_ID, GROUPING_DERIVATIONS, DepthLabel, EdgeKind
 from .edges import EdgeMap, lineage_subgraph, subgraph_of_kinds
+from .functional_dependency import build_fd_determines
 from .models import ConceptAttrs, GroupBucket
 from .staged_where import (
     CROSS_ROW_DERIVATIONS,
@@ -425,6 +426,7 @@ def _uncovered_exposing_output_contributor(
     buckets: dict[str, GroupBucket],
     group_graph: nx.DiGraph,
     mandatory_addrs: set[str],
+    environment: BuildEnvironment,
 ) -> bool:
     """Whether some select-phase group producing a mandatory output sits outside
     the chosen hosts' downstream cover AND can expose every atom input, i.e. an
@@ -451,7 +453,30 @@ def _uncovered_exposing_output_contributor(
     covered: set[str] = set(chosen_groups)
     for gid in chosen_groups:
         covered |= nx.descendants(group_graph, gid)
-    uncovered_exposing = False
+    # Inputs FINAL can read off its own contributors, condition-phase groups
+    # included: a population twin merges into FINAL keyed by its grain.
+    final_exposable: set[str] = set()
+    for gid in group_graph.predecessors(FINAL_NODE_ID):
+        b = buckets.get(gid)
+        if b is not None:
+            final_exposable |= set(b.primary_members) | set(b.secondary_members)
+    collapsing_hosts = [
+        buckets[gid]
+        for gid in chosen_groups
+        if gid in buckets and buckets[gid].derivation in _EMITS_GROUP_BY
+    ]
+    # Outputs the filtered branch itself supplies: the hosts' own columns and
+    # what their descendants compute. A descendant's grain keys are not
+    # counted, since they may ride through from an unfiltered parent.
+    covered_members: set[str] = set()
+    for gid in covered:
+        if gid not in buckets:
+            continue
+        covered_members |= set(buckets[gid].primary_members)
+        if gid in chosen_groups:
+            covered_members |= set(buckets[gid].secondary_members) | set(
+                buckets[gid].grain_components
+            )
     for gid, b in buckets.items():
         if gid in covered:
             continue
@@ -461,9 +486,62 @@ def _uncovered_exposing_output_contributor(
         if not (members & mandatory_addrs):
             continue
         if row_inputs <= members:
-            uncovered_exposing = True
-            break
-    return uncovered_exposing
+            return True
+        # The atom is hosted at an aggregate as a pre-aggregation filter, and
+        # that filter reaches this contributor's rows only through a join on
+        # the host's grain. When the contributor must reach FINAL (it alone
+        # supplies a mandatory output) and the atom is not decided per group
+        # (a row key compared against a population twin, a row-grain flag
+        # derived from an aggregate), the join fans the surviving groups back
+        # out to every row, so re-apply at FINAL, which can read the inputs
+        # off its other contributors. A dimension projection whose outputs
+        # the host grain determines is pinned by that join and needs none.
+        own_outputs = (members & mandatory_addrs) - covered_members
+        if (
+            collapsing_hosts
+            and len(collapsing_hosts) == len(chosen_groups)
+            and own_outputs
+            and not any(
+                all(
+                    build_fd_determines(environment, host.grain_components, addr)
+                    for addr in own_outputs
+                )
+                for host in collapsing_hosts
+            )
+            and row_inputs <= final_exposable
+            and not all(
+                _decided_per_group(row_inputs, host, buckets)
+                for host in collapsing_hosts
+            )
+        ):
+            return True
+    return False
+
+
+def _decided_per_group(
+    row_inputs: set[str], host: GroupBucket, buckets: dict[str, GroupBucket]
+) -> bool:
+    """Whether every row input of an atom is fixed within one of `host`'s
+    groups: a column of the host itself, or produced at a grain the host's
+    grain covers. A ROOT-produced input (no grain of its own) counts only as
+    a host column."""
+    host_columns = set(host.grain_components) | set(host.primary_members)
+    for addr in row_inputs:
+        if addr in host_columns:
+            continue
+        producers = [
+            b
+            for b in buckets.values()
+            if b is not host
+            and addr in b.primary_members
+            and b.derivation != Derivation.ROOT
+        ]
+        if not producers or not all(
+            b.grain_components and set(b.grain_components) <= set(host.grain_components)
+            for b in producers
+        ):
+            return False
+    return True
 
 
 def _preserved_final_branch(
@@ -1295,6 +1373,7 @@ def plan_condition_placements(
                     buckets,
                     group_graph,
                     {c.address for c in mandatory_list},
+                    environment,
                 )
             ):
                 placements.append(

--- a/trilogy/core/processing/v4_helper/group_graph.py
+++ b/trilogy/core/processing/v4_helper/group_graph.py
@@ -2904,7 +2904,9 @@ def build_group_graph(
     _merge_basic_into_window_parent(
         group_graph, group_edges, attrs, buckets, concept_attrs
     )
-    _regraft_group_sources(group_graph, group_edges, attrs, buckets, concept_attrs)
+    _regraft_group_sources(
+        group_graph, group_edges, attrs, buckets, concept_attrs, concept_edges
+    )
     condition_group_ids = _inject_conditions(
         group_graph,
         group_edges,
@@ -3111,6 +3113,7 @@ def _terminal_basic_grouping_provider(
     group_graph: nx.DiGraph,
     attrs: dict[str, GroupAttrs],
     gid: str,
+    lineage_parents: dict[str, set[str]],
 ) -> str | None:
     """Choose a shaped provider for a terminal scalar projection.
 
@@ -3118,6 +3121,9 @@ def _terminal_basic_grouping_provider(
     as a grain-only input even when its expression needs only a grouping key.
     When the projection feeds only FINAL, place it at the deepest grouping
     provider that covers its expression inputs and adopt that provider's grain.
+    The expression inputs are the member's own lineage parents: a grain key
+    the expression reads (`coalesce(min(id) by cell, id)`) is a genuine input
+    that keeps the projection at row grain, not a grain-only passenger.
     """
     current = attrs[gid]
     if current.derivation != Derivation.BASIC or current.condition_atoms:
@@ -3126,7 +3132,7 @@ def _terminal_basic_grouping_provider(
         return None
     if any(successor != FINAL_NODE_ID for successor in group_graph.successors(gid)):
         return None
-    expression_inputs = set(current.input_concepts) - set(current.grain_components)
+    expression_inputs = set(lineage_parents.get(current.primary_members[0], set()))
     if not expression_inputs:
         return None
     my_ancestors = nx.ancestors(group_graph, gid)
@@ -3365,6 +3371,7 @@ def _regraft_group_sources(
     attrs: dict[str, GroupAttrs],
     buckets: dict[str, GroupBucket],
     concept_attrs: dict[str, ConceptAttrs],
+    concept_edges: EdgeMap,
 ) -> None:
     """Topology-only repair for groups whose best row source is already built.
 
@@ -3373,12 +3380,15 @@ def _regraft_group_sources(
     but concrete datasource selection remains in `source_planning` and
     StrategyNode construction remains in `strategy_builder`.
     """
+    lineage_parents = _lineage_parents_by_address(concept_edges, concept_attrs)
     for gid in list(group_graph.nodes):
         if gid == FINAL_NODE_ID:
             continue
         if attrs[gid].derivation not in _REGRAFTABLE_DERIVATIONS:
             continue
-        provider_gid = _terminal_basic_grouping_provider(group_graph, attrs, gid)
+        provider_gid = _terminal_basic_grouping_provider(
+            group_graph, attrs, gid, lineage_parents
+        )
         parent_gid = None
         if provider_gid is not None:
             attrs[gid].grain_components = attrs[provider_gid].grain_components

--- a/trilogy/core/processing/v4_helper/group_graph.py
+++ b/trilogy/core/processing/v4_helper/group_graph.py
@@ -2905,7 +2905,7 @@ def build_group_graph(
         group_graph, group_edges, attrs, buckets, concept_attrs
     )
     _regraft_group_sources(
-        group_graph, group_edges, attrs, buckets, concept_attrs, concept_edges
+        group_graph, group_edges, attrs, buckets, concept_attrs, environment
     )
     condition_group_ids = _inject_conditions(
         group_graph,
@@ -3113,7 +3113,7 @@ def _terminal_basic_grouping_provider(
     group_graph: nx.DiGraph,
     attrs: dict[str, GroupAttrs],
     gid: str,
-    lineage_parents: dict[str, set[str]],
+    environment: BuildEnvironment,
 ) -> str | None:
     """Choose a shaped provider for a terminal scalar projection.
 
@@ -3121,9 +3121,9 @@ def _terminal_basic_grouping_provider(
     as a grain-only input even when its expression needs only a grouping key.
     When the projection feeds only FINAL, place it at the deepest grouping
     provider that covers its expression inputs and adopt that provider's grain.
-    The expression inputs are the member's own lineage parents: a grain key
-    the expression reads (`coalesce(min(id) by cell, id)`) is a genuine input
-    that keeps the projection at row grain, not a grain-only passenger.
+    A grain key the expression itself reads (`coalesce(min(id) by cell, id)`)
+    is a genuine input that keeps the projection at row grain, not a
+    grain-only passenger, so it stays in the inputs the provider must cover.
     """
     current = attrs[gid]
     if current.derivation != Derivation.BASIC or current.condition_atoms:
@@ -3132,7 +3132,15 @@ def _terminal_basic_grouping_provider(
         return None
     if any(successor != FINAL_NODE_ID for successor in group_graph.successors(gid)):
         return None
-    expression_inputs = set(lineage_parents.get(current.primary_members[0], set()))
+    member = environment.concepts.get(current.primary_members[0])
+    read_by_expression = (
+        {c.address for c in member.lineage.concept_arguments}
+        if member is not None and member.lineage is not None
+        else set()
+    )
+    expression_inputs = (
+        set(current.input_concepts) - set(current.grain_components)
+    ) | (read_by_expression & set(current.grain_components))
     if not expression_inputs:
         return None
     my_ancestors = nx.ancestors(group_graph, gid)
@@ -3371,7 +3379,7 @@ def _regraft_group_sources(
     attrs: dict[str, GroupAttrs],
     buckets: dict[str, GroupBucket],
     concept_attrs: dict[str, ConceptAttrs],
-    concept_edges: EdgeMap,
+    environment: BuildEnvironment,
 ) -> None:
     """Topology-only repair for groups whose best row source is already built.
 
@@ -3380,14 +3388,13 @@ def _regraft_group_sources(
     but concrete datasource selection remains in `source_planning` and
     StrategyNode construction remains in `strategy_builder`.
     """
-    lineage_parents = _lineage_parents_by_address(concept_edges, concept_attrs)
     for gid in list(group_graph.nodes):
         if gid == FINAL_NODE_ID:
             continue
         if attrs[gid].derivation not in _REGRAFTABLE_DERIVATIONS:
             continue
         provider_gid = _terminal_basic_grouping_provider(
-            group_graph, attrs, gid, lineage_parents
+            group_graph, attrs, gid, environment
         )
         parent_gid = None
         if provider_gid is not None:

--- a/trilogy/core/processing/v4_helper/network_model.py
+++ b/trilogy/core/processing/v4_helper/network_model.py
@@ -481,6 +481,10 @@ class SolutionCost:
     blend_joins: int
     fanout_sources: int
     sources: int
+    # Physical relations read: a partition-family union is ONE source (no
+    # join) but N scans, so at equal source count a single complete table
+    # outranks the union of partials that jointly cover the same rows.
+    scans: int
     connectors: int
     derived_joins: int
 

--- a/trilogy/core/processing/v4_helper/network_search.py
+++ b/trilogy/core/processing/v4_helper/network_search.py
@@ -37,7 +37,11 @@ from __future__ import annotations
 from _preql_import_resolver import enumerate_network_covers
 
 from trilogy.core.graph_models import ReferenceGraph
-from trilogy.core.models.build import BuildConcept, BuildWhereClause
+from trilogy.core.models.build import (
+    BuildConcept,
+    BuildUnionDatasource,
+    BuildWhereClause,
+)
 from trilogy.core.models.build_environment import BuildEnvironment
 from trilogy.core.processing.v4_helper.network_build import build_source_network
 from trilogy.core.processing.v4_helper.network_model import (
@@ -329,6 +333,7 @@ def _solution_for(
             if network.fans_out(node, assignments[node] or joined_on[node])
         ),
         sources=len(sources),
+        scans=sum(_scan_count(network.candidates[node]) for node in sources),
         connectors=len(connectors),
         derived_joins=derived_joins,
     )
@@ -341,6 +346,14 @@ def _solution_for(
         connectors=frozenset(connectors),
         cost=cost,
     )
+
+
+def _scan_count(candidate: SourceCandidate) -> int:
+    """Relations a candidate reads: each arm of a union, none for a derived
+    connector (its subplan is costed where it is materialized)."""
+    if isinstance(candidate.datasource, BuildUnionDatasource):
+        return len(candidate.datasource.children)
+    return 0 if candidate.datasource is None else 1
 
 
 def _split_terminals(network: SourceNetwork, targets: list[str]) -> frozenset[str]:

--- a/trilogy/core/processing/v4_helper/staged_where.py
+++ b/trilogy/core/processing/v4_helper/staged_where.py
@@ -10,8 +10,12 @@ them when it re-sources such a computation standalone
 rules live here rather than drifting apart in two modules.
 """
 
+from collections.abc import Sequence
+from itertools import takewhile
+
 from trilogy.core.enums import Derivation
 from trilogy.core.models.build import BuildConcept, BuildWhereClause
+from trilogy.core.processing.condition_utility import combine_where_clauses
 
 # The derivations that read across rows, and so are what a stage bound has to
 # be delivered INTO rather than merely ANDed alongside.
@@ -81,3 +85,28 @@ def hosting_stage_index(
         if cross_row & stage_lineage_addresses(clause):
             return index
     return None
+
+
+def universal_row_bound(
+    stages: Sequence[BuildWhereClause],
+    flat: BuildWhereClause | None,
+) -> BuildWhereClause | None:
+    """The predicate EVERY row this statement reads satisfies, or None.
+
+    Stage 1 is applied to the raw rows and each later stage sees only what the
+    stages before it kept, so the leading run of stages that do not themselves
+    compute across rows bounds every row any node in the plan reads. That run
+    is what a completeness proof may narrow a domain by; stage 1 alone is
+    merely its shortest case.
+
+    The run stops AT the first cross-row stage rather than descending into it.
+    A stage's aggregate computes over the population its predecessors left, so
+    a row-local conjunct sharing that stage (`where a then where b and sum(x)
+    by k > 5`) would, if honoured, prune rows the aggregate must read. Same
+    reason a flat `where` returns nothing once it computes across rows: its
+    aggregate sees the unfiltered population.
+    """
+    if not stages:
+        return None if flat is None or stage_computes_cross_row(flat) else flat
+    prefix = list(takewhile(lambda stage: not stage_computes_cross_row(stage), stages))
+    return combine_where_clauses(prefix) if prefix else None

--- a/trilogy/core/processing/v4_helper/strategy_builder.py
+++ b/trilogy/core/processing/v4_helper/strategy_builder.py
@@ -90,6 +90,7 @@ from .models import (
     FinalContributorContract,
     GroupAttrs,
     InputChannel,
+    nulls_grouping_keys,
 )
 from .projection import (
     concept_satisfiable,
@@ -515,15 +516,28 @@ def _accumulated_atoms_above(
     attrs: dict[str, GroupAttrs],
     gid: str,
 ) -> list[BoolExpr]:
-    """Atoms applied at any STRICT ancestor of `gid`. Threaded into the node
-    as `preexisting_conditions` so nullable inference (and any later
-    optimizer) knows which rows the parent already filtered, without
-    re-emitting the same WHERE on this CTE."""
+    """Atoms applied at any STRICT ancestor of `gid` that still hold on this
+    group's rows. Threaded into the node as `preexisting_conditions` so
+    nullable inference (and any later optimizer) knows which rows the parent
+    already filtered, without re-emitting the same WHERE on this CTE.
+
+    A standard grouping ancestor applies its atom to the rows it aggregates;
+    the groups it emits are filtered only when the atom is decided per group
+    (every row arg among the group's own columns). Otherwise a descendant that
+    joins those groups back onto a row stream re-admits rows the atom
+    rejects, so the atom is not preexisting for it."""
     accumulated: list[BoolExpr] = []
     for anc in nx.ancestors(group_graph, gid):
         if anc == FINAL_NODE_ID:
             continue
-        for atom in attrs[anc].condition_atoms:
+        anc_attrs = attrs[anc]
+        collapsing = anc_attrs.derivation in GROUPING_DERIVATIONS and not (
+            nulls_grouping_keys(anc_attrs.grouping_mode)
+        )
+        columns = set(anc_attrs.members) | set(anc_attrs.grain_components)
+        for atom in anc_attrs.condition_atoms:
+            if collapsing and not ({c.address for c in atom.row_arguments} <= columns):
+                continue
             if atom not in accumulated:
                 accumulated.append(atom)
     return accumulated
@@ -3336,13 +3350,26 @@ def _subtree_applies_conditions(node: StrategyNode, where: BuildWhereClause) -> 
     best redundant; for a ROLLUP contributor it is destructive: the feeder
     re-join pairs on grouping keys the ROLLUP NULLs at subtotal rows, so the
     subtotal/total rows drop."""
+    row_args = {c.address for c in condition_row_args(where)}
     stack: list[StrategyNode] = [node]
     while stack:
         current = stack.pop()
         for applied in (current.conditions, current.preexisting_conditions):
             if applied is not None and condition_implies(applied, where.conditional):
                 return True
-        stack.extend(current.parents)
+        for parent in current.parents:
+            # A standard GroupNode applies its WHERE to the rows it aggregates.
+            # The groups it emits are gated only when the atom is decided per
+            # group, i.e. every row arg is one of its outputs; otherwise a row
+            # stream merged back onto those groups re-admits rows the atom
+            # rejects, so nothing applied at or below it counts for `node`.
+            if (
+                isinstance(parent, GroupNode)
+                and not node_nulls_grouping_keys(parent)
+                and not row_args <= {o.address for o in parent.output_concepts}
+            ):
+                continue
+            stack.append(parent)
     return False
 
 

--- a/trilogy/core/processing/v4_helper/strategy_builder.py
+++ b/trilogy/core/processing/v4_helper/strategy_builder.py
@@ -2132,6 +2132,8 @@ def _pre_merge_parents(
     environment: BuildEnvironment,
     join_key_addresses: frozenset[str] = frozenset(),
     needed: set[str] | None = None,
+    group_graph: nx.DiGraph | None = None,
+    built: dict[str, StrategyNode] | None = None,
 ) -> list[StrategyNode]:
     """Collapse a multi-parent set into a single MergeNode that auto-joins
     on shared output concepts. Non-merging generators (GroupNode for
@@ -2152,6 +2154,10 @@ def _pre_merge_parents(
     if len(parents) <= 1:
         return parents
     _widen_merge_join_keys(parents, environment, join_key_addresses)
+    # After widening, not before: a parent that has just been handed the join
+    # key it was missing needs no bridge.
+    if group_graph is not None and built is not None:
+        parents = _bridge_unpaired_parents(parents, group_graph, built, environment)
     seen: set[str] = set()
     all_outputs: list[BuildConcept] = []
     for p in parents:
@@ -3117,6 +3123,79 @@ def _wrap_for_grain(
     return wraps
 
 
+def _pairing_addresses(node: StrategyNode, environment: BuildEnvironment) -> set[str]:
+    """Addresses a merge can pair this parent on, as join resolution sees them:
+    its outputs plus every alias of the same axis. Two sides of an authored
+    relation (`subset join kb = ka`) name one axis under two addresses, so a raw
+    address comparison reads them as sharing nothing."""
+    addresses: set[str] = set()
+    for concept in node.output_concepts:
+        addresses.add(concept.address)
+        for pseudonym in concept.pseudonyms:
+            addresses.add(pseudonym)
+            origin = environment.alias_origin_lookup.get(pseudonym)
+            if origin is not None:
+                addresses.add(origin.address)
+    for canonical, members in environment.scoped_join_key_groups.items():
+        relation = {canonical, *members}
+        if addresses & relation:
+            addresses |= relation
+    return addresses
+
+
+def _bridge_unpaired_parents(
+    parents: list[StrategyNode],
+    group_graph: nx.DiGraph,
+    built: dict[str, StrategyNode],
+    environment: BuildEnvironment,
+) -> list[StrategyNode]:
+    """Pull in the built group that pairs a contributor sharing no column with
+    any sibling, so the merge below joins on an axis instead of `ON 1=1`.
+
+    `select id, min(x) by id, min(y) by cell` leaves two aggregates, one keyed
+    on `id` and one on `cell`, with nothing that maps between them: the
+    row-grain projection of `{id, cell}` that fed the cell aggregate covers no
+    mandatory output, so neither the cover election nor a consumer's parent
+    dedup keeps it. Add it back as a join-only parent.
+
+    A contributor that genuinely cross joins (a global aggregate) is untouched:
+    nothing else renders its column, so it has no candidate."""
+    if len(parents) < 2:
+        return parents
+    outputs = [_pairing_addresses(parent, environment) for parent in parents]
+    exposed = {
+        gid: _pairing_addresses(node, environment) for gid, node in built.items()
+    }
+    present = {id(parent) for parent in parents}
+    added: list[StrategyNode] = []
+    for index, own in enumerate(outputs):
+        others: set[str] = set()
+        for other_index, other in enumerate(outputs):
+            if other_index != index:
+                others |= other
+        if own & others:
+            continue
+        candidates = [
+            gid
+            for gid, node in built.items()
+            if id(node) not in present and exposed[gid] & own and exposed[gid] & others
+        ]
+        if not candidates:
+            continue
+        candidates.sort(
+            key=lambda gid: (
+                sum(1 for a in nx.ancestors(group_graph, gid) if a in built),
+                gid,
+            ),
+            reverse=True,
+        )
+        bridge = built[candidates[0]]
+        present.add(id(bridge))
+        added.append(bridge)
+        outputs.append(exposed[candidates[0]])
+    return parents + added
+
+
 def _filter_arg_parents(
     group_graph: nx.DiGraph,
     built: dict[str, StrategyNode],
@@ -3927,6 +4006,7 @@ def _assemble_final_node(
         {id(built[gid]) for gid, concepts in per_group.items() if concepts},
         {id(built[gid]) for gid in ownership.owner_by_span.values() if gid in built},
     )
+    parents = _bridge_unpaired_parents(parents, group_graph, built, environment)
     _raise_if_rowset_islanded(parents, mandatory_list, environment, graph)
 
     available: set[str] = set()
@@ -4248,6 +4328,8 @@ def build_strategy_node(
             environment,
             join_key_addresses=join_key_addresses,
             needed=needed,
+            group_graph=group_graph,
+            built=built,
         )
         # ROOT scans source columns from datasources directly, not from their
         # group-graph predecessors. A `constraint`-edge predecessor (e.g. a

--- a/trilogy/core/query_processor.py
+++ b/trilogy/core/query_processor.py
@@ -104,7 +104,10 @@ from trilogy.core.processing.partial_bridging import (
     heal_pinned_partials,
 )
 from trilogy.core.processing.utility import unrenderable_outputs
-from trilogy.core.processing.v4_helper.staged_where import CROSS_ROW_DERIVATIONS
+from trilogy.core.processing.v4_helper.staged_where import (
+    CROSS_ROW_DERIVATIONS,
+    universal_row_bound,
+)
 from trilogy.core.scope_diagnostics import (
     DerivedValueScope,
     extract_derived_value_scopes,
@@ -1189,10 +1192,8 @@ def get_query_node(
     if isinstance(build_statement, BuildSelectLineage):
         drop_excluded_partials(
             build_environment,
-            (
-                build_statement.where_clauses[0]
-                if build_statement.where_clauses
-                else build_statement.where_clause
+            universal_row_bound(
+                build_statement.where_clauses, build_statement.where_clause
             ),
         )
 

--- a/trilogy/core/query_processor.py
+++ b/trilogy/core/query_processor.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict, defaultdict
+from collections.abc import Sequence
 from dataclasses import replace
 from math import ceil
 from typing import Any
@@ -25,6 +26,7 @@ from trilogy.core.graph_models import ReferenceGraph
 from trilogy.core.models.author import (
     Concept,
     ConceptRef,
+    Conditional,
     Function,
     HavingClause,
     MultiSelectLineage,
@@ -32,6 +34,7 @@ from trilogy.core.models.author import (
     RowsetItem,
     SelectLineage,
     WhereClause,
+    combine_staged_wheres,
     prepend_where_stage,
 )
 from trilogy.core.models.build import (
@@ -101,6 +104,7 @@ from trilogy.core.processing.partial_bridging import (
     heal_pinned_partials,
 )
 from trilogy.core.processing.utility import unrenderable_outputs
+from trilogy.core.processing.v4_helper.staged_where import CROSS_ROW_DERIVATIONS
 from trilogy.core.scope_diagnostics import (
     DerivedValueScope,
     extract_derived_value_scopes,
@@ -1289,6 +1293,63 @@ def _validate_persist_projection(
     )
 
 
+def _computes_cross_row(refs: Sequence[ConceptRef], environment: Environment) -> bool:
+    """Whether any of `refs` computes an aggregate, group-to or window,
+    directly or anywhere in its lineage."""
+    pending = [ref.address for ref in refs]
+    seen: set[str] = set()
+    while pending:
+        address = pending.pop()
+        if address in seen:
+            continue
+        seen.add(address)
+        concept = environment.concepts.get(address)
+        if concept is None:
+            continue
+        if concept.derivation in CROSS_ROW_DERIVATIONS:
+            return True
+        pending.extend(source.address for source in concept.sources)
+    return False
+
+
+def _partition_scoped_stages(
+    stages: Sequence[WhereClause], claim: WhereClause, environment: Environment
+) -> list[WhereClause]:
+    """Gate a partial datasource's build by its `complete where` claim.
+
+    The claim's scalar atoms name the slice of the domain the target holds, and
+    the unfiltered build already computes every projected aggregate inside that
+    slice. A row gate that computes across rows, whether authored on the
+    datasource or inside the claim itself, is evaluated in the same slice: the
+    scalar atoms lead as their own stage and the cross-row conjuncts follow,
+    so partition arms are proven complete over the slice rather than over the
+    whole discriminator domain. A purely scalar gate is one conjunct either way
+    and stays ANDed into stage 1."""
+    conjuncts = (
+        claim.conditional.decompose()
+        if isinstance(claim.conditional, Conditional)
+        else [claim.conditional]
+    )
+    cross_row = [
+        c for c in conjuncts if _computes_cross_row(c.row_arguments, environment)
+    ]
+    if not cross_row and not (
+        stages and _computes_cross_row(stages[0].row_arguments, environment)
+    ):
+        return prepend_where_stage(stages, claim)
+    scalar = [c for c in conjuncts if not any(c is x for x in cross_row)]
+    result = list(stages)
+    if cross_row:
+        gate = combine_staged_wheres([WhereClause(conditional=c) for c in cross_row])
+        assert gate is not None
+        result = prepend_where_stage(result, gate)
+    if scalar:
+        scope = combine_staged_wheres([WhereClause(conditional=c) for c in scalar])
+        assert scope is not None
+        result = [scope, *result]
+    return result
+
+
 def process_persist(
     environment: Environment,
     statement: PersistStatement,
@@ -1308,13 +1369,10 @@ def process_persist(
     # condition in its SELECT, and injecting again would duplicate it (and push
     # its HAVING atoms into a pre-aggregation WHERE).
     if ds.non_partial_for and not ds.non_partial_for_embedded:
-        # AND into stage 1: the partition condition gates every row the persist
-        # writes, so it belongs ahead of any `then where` staging, and every
-        # later stage's input population narrows with it.
         select_stmt = replace(
             select_stmt,
-            where_clauses=prepend_where_stage(
-                select_stmt.where_clauses, ds.non_partial_for
+            where_clauses=_partition_scoped_stages(
+                select_stmt.where_clauses, ds.non_partial_for, environment
             ),
         )
     # set to unpublished to avoid circular refs

--- a/trilogy/dialect/base.py
+++ b/trilogy/dialect/base.py
@@ -469,10 +469,10 @@ DB_COLUMN_TYPE_MAP: dict[str, DataType] = {
     # float
     "float": DataType.FLOAT,
     "float4": DataType.FLOAT,
-    "float8": DataType.FLOAT,
+    "float8": DataType.DOUBLE,
     "real": DataType.FLOAT,
-    "double": DataType.FLOAT,
-    "double precision": DataType.FLOAT,
+    "double": DataType.DOUBLE,
+    "double precision": DataType.DOUBLE,
     # numeric / decimal
     "numeric": DataType.NUMERIC,
     "decimal": DataType.NUMERIC,

--- a/trilogy/dialect/duckdb.py
+++ b/trilogy/dialect/duckdb.py
@@ -469,9 +469,9 @@ class DuckDBDialect(BaseDialect):
         "timestamptz": DataType.TIMESTAMP,
         "float4": DataType.FLOAT,
         "real": DataType.FLOAT,
-        "double": DataType.FLOAT,
-        "float8": DataType.FLOAT,
-        "double precision": DataType.FLOAT,
+        "double": DataType.DOUBLE,
+        "float8": DataType.DOUBLE,
+        "double precision": DataType.DOUBLE,
         "decimal": DataType.NUMERIC,
     }
 

--- a/trilogy/scripts/ingest.py
+++ b/trilogy/scripts/ingest.py
@@ -219,7 +219,9 @@ def _check_column_combination_uniqueness(
 
 
 # Decimal/float types are measures; their sample uniqueness is a coincidence.
-_MEASURE_TYPES = frozenset({DataType.FLOAT, DataType.NUMERIC, DataType.NUMBER})
+_MEASURE_TYPES = frozenset(
+    {DataType.FLOAT, DataType.DOUBLE, DataType.NUMERIC, DataType.NUMBER}
+)
 # Temporal columns lose to a non-temporal partner: a fact's grain is its entity
 # + transaction number, not when it happened. Caught by type, or by name for a
 # surrogate key whose stem carries a date/time token (``returned_date_sk``).


### PR DESCRIPTION
## Summary

A batch of bug fixes from upstream reports, all in the same area: how the
planner decides which partitioned sources can answer a query, and how row
filters behave when they compare against a calculated value. Grouped into one
release because they overlap — several were only reachable once an earlier one
was fixed.

## What was wrong

**Partition selection could answer from incomplete data.** When a model splits
a table across several partitioned sources, the planner could answer from a
subset of them and quietly return too few rows. No error, no warning.

**It could also refuse queries it should have answered.** The mirror image:
valid, answerable queries were rejected with "no complete sources" because of
details that shouldn't have mattered — most notably *which step* of a
multi-step filter the partition condition happened to be written in.

**Filters comparing a row to a calculated value could be ignored.** A filter
like "keep only rows whose id matches the group's chosen id" could return rows
that plainly didn't match it. Related shapes failed to plan at all, with an
internal error about a missing join.

**Filters weren't applied when writing to a partitioned target**, so a
materialized table could come out with rows its own definition excluded.

**DuckDB `double` columns were read as 32-bit floats**, so values lost
precision on a round-trip and column types changed on write.

## What changed

Each was fixed where the wrong decision was made rather than patched where it
surfaced, and the pieces now share one rule instead of several near-copies. New
tests cover each report, plus a new fuzzer family that checks partition
coverage against independent reference queries.

**One deliberate behavior change worth calling out:** a small number of queries
that previously returned an answer now report a clear error instead. These are
cases where the model genuinely cannot cover the data the query asks for, and
the old answer was drawn from whatever partitions happened to exist. The error
explains what's missing and how to resolve it.

## Testing

- Full test suite green; new tests for every report above.
- Fuzzer: 238 cases, plus 714 across six randomized datasets.
- Generated SQL for all 172 benchmark and modeling queries is byte-for-byte
  unchanged, so the fixes are confined to the shapes they target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DurVdK8E5K2aZi43zZcG8Y
