### PR TITLE
[Chore] Bump to 0.3.348

### DIFF
--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from trilogy.executor import Executor
     from trilogy.parser import parse
 
-__version__ = "0.3.347"
+__version__ = "0.3.348"
 
 __all__ = [
     "CONFIG",


### PR DESCRIPTION
## Summary

Version bump so the fixes merged in #670 actually get released.

#670 was stacked on #669, so it carried #669's `0.3.346 → 0.3.347` bump along
with its own changes. #669 merged first and published 0.3.347. When #670 was
squashed, the duplicate bump was correctly dropped — leaving `main` on a version
PyPI already has.

The publish workflow only uploads when the local version differs from PyPI, so
on the #670 merge it ran `version-check` and then **skipped** `publish`
(run [33972299933](https://github.com/trilogy-data/pytrilogy/actions/runs/33972299933)).
The partition-coverage and row-gate fixes are on `main` but not on PyPI.

This is a one-line bump to 0.3.348. Merging it triggers the publish.

Nothing from #669 was lost in that de-duplication — `git diff 11d3304e7 9702b377f`
over every file #669 owned is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DurVdK8E5K2aZi43zZcG8Y