### PR TITLE
[Bug] Stamp an UNNEST's carried-through parent columns partial

### DIFF
--- a/local_scripts/fuzzer/generate.py
+++ b/local_scripts/fuzzer/generate.py
@@ -3468,15 +3468,19 @@ property event_id.tier_amount int;
     specs = (
         (
             "region_gate_reads_both_arms",
-            "The gate rules out the uncovered region, so the arms union into "
-            "one complete source and every event row is read.",
+            (
+                "The gate rules out the uncovered region, so the arms union into "
+                "one complete source and every event row is read."
+            ),
             f"where region = 'NORTH' {projection}",
             all_rows,
         ),
         (
             "region_gate_in_a_later_stage",
-            "The same gate one stage later. Every row read still passes it, so "
-            "the union is proven the same way and the rows are unchanged.",
+            (
+                "The same gate one stage later. Every row read still passes it, so "
+                "the union is proven the same way and the rows are unchanged."
+            ),
             f"where event_id > 0 then where region = 'NORTH' {projection}",
             all_rows,
         ),
@@ -3489,14 +3493,18 @@ property event_id.tier_amount int;
         (
             "arm_gate_across_three_stages",
             "Both discriminators gated from later stages, one per stage.",
-            "where event_id > 0 then where region = 'NORTH'"
-            f" then where tier = 'ALPHA' {projection}",
+            (
+                "where event_id > 0 then where region = 'NORTH'"
+                f" then where tier = 'ALPHA' {projection}"
+            ),
             alpha_rows,
         ),
         (
             "aggregate_over_the_covered_union",
-            "An aggregate over the union spans both arms, not the arm the "
-            "planner happened to pick first.",
+            (
+                "An aggregate over the union spans both arms, not the arm the "
+                "planner happened to pick first."
+            ),
             "where region = 'NORTH' select sum(tier_amount) as total;",
             "select sum(amount) from events",
         ),

--- a/tests/core/processing/test_unnest_partial_stamp.py
+++ b/tests/core/processing/test_unnest_partial_stamp.py
@@ -1,0 +1,125 @@
+"""An UNNEST drops the parent rows whose array is empty or NULL, so the parent
+columns it carries through bind a subset of the parent's rows. Stamping them
+partial keeps a join onto the unnested side row-preserving toward the fact
+whatever other source for the fact's key is in scope."""
+
+import pytest
+
+from trilogy import Dialects
+from trilogy.core.enums import JoinType, SourceType
+from trilogy.core.models.execute import BaseJoin, QueryDatasource
+from trilogy.core.query_processor import get_query_datasources
+from trilogy.parser import parse_text
+
+MODEL = """
+key tree_id string;
+property tree_id.city string;
+key species string;
+
+property species.native_ecoregions list<int>;
+auto tree_eco_region <- unnest(native_ecoregions);
+merge tree_eco_region into ecoregion_id;
+
+key ecoregion_id int;
+property ecoregion_id.biome string;
+
+property native_locality_bucket <- CASE
+    WHEN ecoregion_id = 423 THEN 'Native'
+    WHEN biome = 'Mediterranean Forests' THEN 'Same biome, non-native'
+  ELSE 'Non-Native, Different Biome'
+END::string;
+
+root partial datasource city_trees (
+    tree_id: tree_id,
+    city: city,
+    species: species,
+)
+grain (tree_id)
+complete where city = 'USSFO'
+query '''
+select 't1' as tree_id, 'USSFO' as city, 'Quercus agrifolia' as species
+union all select 't2', 'USSFO', 'Platanus x hispanica'
+union all select 't3', 'USSFO', 'Unknown'
+''';
+
+root datasource species_enrichment (
+    species: species,
+    native_ecoregions: native_ecoregions,
+)
+grain (species)
+query '''
+select 'Quercus agrifolia' as species, [423] as native_ecoregions
+union all select 'Platanus x hispanica', [664]
+''';
+
+root datasource ecoregions (
+    ecoregion_id: ecoregion_id,
+    biome: biome,
+)
+grain (ecoregion_id)
+query '''
+select 423 as ecoregion_id, 'Mediterranean Forests' as biome
+union all select 664, 'Temperate Broadleaf & Mixed Forests'
+''';
+"""
+
+# the same rows unpartitioned; never named by the query
+SECOND_SOURCE = """
+root datasource all_trees (
+    tree_id: tree_id,
+    city: city,
+    species: species,
+)
+grain (tree_id)
+query '''
+select 't1' as tree_id, 'USSFO' as city, 'Quercus agrifolia' as species
+union all select 't2', 'USSFO', 'Platanus x hispanica'
+union all select 't3', 'USSFO', 'Unknown'
+union all select 't4', 'USNYC', 'Acer rubrum'
+''';
+"""
+
+QUERY = """
+select count(tree_id) -> tree_count
+where city = 'USSFO' and native_locality_bucket = 'Non-Native, Different Biome';
+"""
+
+
+def _nodes(qds: QueryDatasource) -> list[QueryDatasource]:
+    out: list[QueryDatasource] = []
+    stack = [qds]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, QueryDatasource):
+            out.append(current)
+            stack.extend(current.datasources)
+    return out
+
+
+def _tree_join(qds: QueryDatasource) -> BaseJoin:
+    for node in _nodes(qds):
+        for join in node.joins:
+            if isinstance(join, BaseJoin) and any(
+                pair.right.address == "local.species" for pair in join.concept_pairs
+            ):
+                return join
+    raise AssertionError("no join on species")
+
+
+@pytest.mark.parametrize("extra", ["", SECOND_SOURCE], ids=["one", "two"])
+def test_unnested_dimension_join_preserves_trees(extra: str):
+    executor = Dialects.DUCK_DB.default_executor()
+    executor.parse_text(MODEL + extra)
+    _, statements = parse_text(QUERY, executor.environment)
+    final = get_query_datasources(executor.environment, statements[-1])
+
+    unnest = next(n for n in _nodes(final) if n.source_type == SourceType.UNNEST)
+    assert "local.species" in {c.address for c in unnest.partial_concepts}
+    assert "local.tree_eco_region" not in {c.address for c in unnest.partial_concepts}
+
+    join = _tree_join(final)
+    trees = join.right_datasource.identifier
+    assert trees.startswith(("city_trees", "all_trees")), trees
+    assert join.join_type in (JoinType.RIGHT_OUTER, JoinType.FULL)
+
+    assert executor.execute_text(QUERY)[-1].fetchall() == [(2,)]

--- a/tests/engine/test_partition_source_exclusion.py
+++ b/tests/engine/test_partition_source_exclusion.py
@@ -179,10 +179,14 @@ def test_partition_gate_narrows_from_any_leading_row_local_stage():
     executor = _executor(COMMON, MODEL_A_SOURCES, MODEL_B)
     for query in (
         "where city = 'A' select tree_id, dbh order by tree_id asc;",
-        "where tree_id != 'zzz' then where city = 'A'"
-        " select tree_id, dbh order by tree_id asc;",
-        "where tree_id != 'zzz' then where tree_id != 'yyy' then where city = 'A'"
-        " select tree_id, dbh order by tree_id asc;",
+        (
+            "where tree_id != 'zzz' then where city = 'A'"
+            " select tree_id, dbh order by tree_id asc;"
+        ),
+        (
+            "where tree_id != 'zzz' then where tree_id != 'yyy' then where city = 'A'"
+            " select tree_id, dbh order by tree_id asc;"
+        ),
     ):
         sql = executor.generate_sql(query)[-1]
         assert "b_one" not in sql and "b_two" not in sql, sql

--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from trilogy.executor import Executor
     from trilogy.parser import parse
 
-__version__ = "0.3.348"
+__version__ = "0.3.349"
 
 __all__ = [
     "CONFIG",

--- a/trilogy/core/processing/nodes/unnest_node.py
+++ b/trilogy/core/processing/nodes/unnest_node.py
@@ -2,6 +2,7 @@ from trilogy.core.enums import SourceType
 from trilogy.core.models.build import BuildConcept, BuildFunction
 from trilogy.core.models.execute import QueryDatasource, UnnestJoin
 from trilogy.core.processing.nodes.base_node import StrategyNode
+from trilogy.utility import unique
 
 
 class UnnestNode(StrategyNode):
@@ -44,6 +45,14 @@ class UnnestNode(StrategyNode):
         for unnest_concept in self.unnest_concepts:
             base.source_map[unnest_concept.address] = {unnest}
             base.join_derived_concepts = [unnest_concept]
+        # A parent row whose array is empty or NULL yields no unnested row, so
+        # the carried-through parent columns bind a subset of the parent's rows.
+        unnested = {c.address for c in self.unnest_concepts}
+        base.partial_concepts = unique(
+            base.partial_concepts
+            + [c for c in base.output_concepts if c.address not in unnested],
+            "address",
+        )
         return base
 
     def copy(self) -> "UnnestNode":


### PR DESCRIPTION
## Summary

An `UNNEST` yields no row for a parent whose array is empty or `NULL`, so the parent columns the unnest node carries through bind a **subset** of the parent's rows. The node stamped them complete, so a fact joined onto the unnested side on that key read as EQUAL-domain and rendered `INNER`, dropping every fact row whose key had no array to unnest.

Before #664 a stale `~` column stamp on a partition source masked this on the single-source path (`RIGHT OUTER` by accident); once #664 made the stamps truthful, both the single- and two-source paths collapsed to `INNER`. This is `sf_tree_reporting/upstream_repro/join_type_varies_by_source`: a tree whose species has no enrichment row must still reach the bucket's `ELSE`, and the answer must not depend on which source for the fact's key is in scope.

## Fix

`UnnestNode._resolve` now stamps its non-unnested outputs partial. The merge onto the fact types row-preserving toward the fact and narrows to `RIGHT OUTER`; both configurations return 2.

## Verification

- New `tests/core/processing/test_unnest_partial_stamp.py` covers both README configurations (stamp, join type, executed rows); fails without the stamp, passes with it.
- All 43 test files that use `unnest` pass (971 tests), plus TPC-DS query08 and adhoc01.
- Full local suite (excluding adventureworks/clickhouse) run before merge.

Bumps version to 0.3.349.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153jb1eXaKE2QhTs4afrcWd
