### PR TITLE
[Bug] Drop redundant full-width GROUP BYs around cardinality-preserving joins

### DIFF
--- a/evals/common/cleanup.py
+++ b/evals/common/cleanup.py
@@ -175,6 +175,29 @@ def apply_sweep(plan: Plan, log: Callable[[str], None] = print) -> int:
     return freed
 
 
+def purge_stale_spill(
+    results_dir: Path,
+    log: Callable[[str], None] | None = None,
+    skip_recent_hours: float = 6.0,
+) -> int:
+    """Spill an earlier, hard-killed run left behind, reclaimed as the next starts.
+
+    ``purge_spill`` covers a clean finish and the atexit hook; a kill -9 runs
+    neither, and an ingest that died mid-join can leave tens of GB of
+    ``.duckdb.tmp``. Sweeping the suite's whole ``results/`` at startup means the
+    next run collects it instead of it sitting there until someone notices. The
+    recent-run window keeps a concurrent run untouched."""
+    plan = plan_sweep(results_dir, spill=True, skip_recent_hours=skip_recent_hours)
+    if not plan.targets:
+        return 0
+    freed = apply_sweep(plan, log=log or (lambda _: None))
+    if freed and log is not None:
+        log(
+            f"  reclaimed {human(freed)} of spill left by {len(plan.runs)} earlier run(s)"
+        )
+    return freed
+
+
 def human(num_bytes: float) -> str:
     size = float(num_bytes)
     for unit in ("B", "KB", "MB", "GB", "TB"):

--- a/evals/common/main.py
+++ b/evals/common/main.py
@@ -564,11 +564,15 @@ def run(spec: BenchmarkSpec) -> int:
         args.reasoning_effort,
     )
     run_dir = (args.output_dir or default_run_dir).resolve()
+    # Before anything of ours lands on disk: reclaim spill an earlier run was
+    # killed before it could clear. Runs touched in the last few hours are left
+    # alone, so a concurrent sweep is safe.
+    cleanup.purge_stale_spill(spec.results_dir, log=print)
     workspace = run_dir / "workspace"
     workspace.mkdir(parents=True, exist_ok=True)
     # Safety net for the paths the explicit purges below don't reach: an
-    # exception, or Ctrl-C. (A hard kill runs nothing, so `clean_results.py
-    # --spill` still exists for that.)
+    # exception, or Ctrl-C. (A hard kill runs nothing; the startup sweep above
+    # and `clean_results.py --spill` are what collect that.)
     atexit.register(cleanup.purge_spill, run_dir)
     chart_slug = chart_artifact_slug(run_dir.name)
     dashboard_path = spec.charts_dir / f"dashboard_{chart_slug}.png"

--- a/tests/core/processing/test_v4_derived_key_join_back_grain.py
+++ b/tests/core/processing/test_v4_derived_key_join_back_grain.py
@@ -1,0 +1,232 @@
+"""An aggregate keyed on a concept derived from the row (`cluster_id <-
+coalesce(min(...) by cell, tree_id)`) joined back onto the rows that produced
+it is 1:1 by construction, so the FINAL merge must not regroup."""
+
+from decimal import Decimal
+
+from trilogy import Dialects, Environment
+from trilogy.core.processing.v4_helper.group_graph import _lineage_pinned_grain
+
+_MODEL = """
+key tree_id string;
+property tree_id.city string;
+property tree_id.raw_latitude float;
+property tree_id.raw_longitude float;
+property tree_id.source_label string;
+property city.cell_lat_deg float;
+property city.cell_lon_deg float;
+
+datasource dedup_cells (
+    city: city,
+    cell_lat_deg: cell_lat_deg,
+    cell_lon_deg: cell_lon_deg,
+)
+grain (city)
+query '''
+SELECT * FROM (VALUES
+    ('USBOS', 0.00008983, 0.00012155),
+    ('USSFO', 0.00008983, 0.00011361)
+) AS t(city, cell_lat_deg, cell_lon_deg)
+''';
+
+datasource trees (
+    tree_id: tree_id,
+    city: city,
+    source_label: source_label,
+    raw_latitude: raw_latitude,
+    raw_longitude: raw_longitude,
+)
+grain (tree_id)
+query '''
+SELECT * FROM (VALUES
+    ('t1', 'USBOS', 'MUNI', 42.3601, -71.0589),
+    ('t2', 'USBOS', 'OSM',  42.3601, -71.0589),
+    ('t3', 'USBOS', 'MUNI', 42.3700, -71.0600)
+) AS t(tree_id, city, source_label, raw_latitude, raw_longitude)
+''';
+
+auto cell_a <- concat(
+    cast(floor(raw_longitude / cell_lon_deg) as string), ':',
+    cast(floor(raw_latitude / cell_lat_deg) as string)
+);
+auto anchor_a <- min(tree_id ? source_label = 'MUNI') by cell_a;
+auto cluster_id <- coalesce(anchor_a, tree_id);
+auto merged_lat <- max(raw_latitude) by cluster_id;
+"""
+
+
+def _executor():
+    env = Environment()
+    env.parse(_MODEL)
+    return Dialects.DUCK_DB.default_executor(environment=env)
+
+
+def test_derived_key_basic_pins_its_row_grain():
+    env = Environment()
+    env.parse(_MODEL)
+    build = env.materialize_for_select()
+    pinned = _lineage_pinned_grain({"local.cluster_id"}, build)
+    assert "local.tree_id" in pinned
+    assert "local.cell_a" in pinned
+
+
+def test_join_back_on_derived_key_has_no_final_group():
+    executor = _executor()
+    query = "select tree_id, cluster_id, merged_lat order by tree_id asc;"
+    sql = executor.generate_sql(query)[-1]
+    final_select = sql[sql.rfind("\nSELECT\n") :]
+    assert "GROUP BY" not in final_select, sql
+    assert sql.count("GROUP BY") == 2, sql
+    rows = executor.execute_text(query)[-1].fetchall()
+    assert rows == [
+        ("t1", "t1", Decimal("42.3601")),
+        ("t2", "t1", Decimal("42.3601")),
+        ("t3", "t3", Decimal("42.3700")),
+    ]
+
+
+def test_join_back_without_row_key_still_dedupes():
+    executor = _executor()
+    query = "select cluster_id, merged_lat, raw_latitude order by cluster_id asc;"
+    rows = executor.execute_text(query)[-1].fetchall()
+    assert rows == [
+        ("t1", Decimal("42.3601"), Decimal("42.3601")),
+        ("t3", Decimal("42.3700"), Decimal("42.3700")),
+    ]
+
+
+_PARTITION_MODEL = """
+key tree_id string;
+key city string;
+property tree_id.raw_latitude float;
+property tree_id.raw_longitude float;
+key source_label enum<string>['MUNI','OSM'];
+property city.cell_lat_deg float;
+property city.cell_lon_deg float;
+
+datasource dedup_cells (
+    city: city,
+    cell_lat_deg: cell_lat_deg,
+    cell_lon_deg: cell_lon_deg,
+)
+grain (city)
+query '''
+SELECT * FROM (VALUES
+    ('USBOS', 0.00008983, 0.00012155),
+    ('USSFO', 0.00008983, 0.00011361)
+) AS t(city, cell_lat_deg, cell_lon_deg)
+''';
+
+root partial datasource trees_muni (
+    tree_id: tree_id,
+    city: city,
+    source_label: source_label,
+    raw_latitude: raw_latitude,
+    raw_longitude: raw_longitude,
+)
+grain (tree_id)
+complete where source_label = 'MUNI'
+query '''
+SELECT * FROM (VALUES
+    ('t1', 'USBOS', 'MUNI', 42.3601, -71.0589),
+    ('t3', 'USBOS', 'MUNI', 42.3700, -71.0600)
+) AS t(tree_id, city, source_label, raw_latitude, raw_longitude)
+''';
+
+root partial datasource trees_osm (
+    tree_id: tree_id,
+    city: city,
+    source_label: source_label,
+    raw_latitude: raw_latitude,
+    raw_longitude: raw_longitude,
+)
+grain (tree_id)
+complete where source_label = 'OSM'
+query '''
+SELECT * FROM (VALUES
+    ('t2', 'USBOS', 'OSM', 42.3601, -71.0589),
+    ('t4', 'USSFO', 'OSM', 37.7700, -122.4100)
+) AS t(tree_id, city, source_label, raw_latitude, raw_longitude)
+''';
+
+auto cell_a <- concat(
+    cast(floor(raw_longitude / cell_lon_deg) as string), ':',
+    cast(floor(raw_latitude / cell_lat_deg) as string)
+);
+"""
+
+
+def test_key_filter_determined_by_grain_has_no_group():
+    env = Environment()
+    env.parse(_PARTITION_MODEL)
+    executor = Dialects.DUCK_DB.default_executor(environment=env)
+    query = "select tree_id, cell_a where city = 'USBOS' order by tree_id asc;"
+    sql = executor.generate_sql(query)[-1]
+    assert "GROUP BY" not in sql, sql
+    rows = executor.execute_text(query)[-1].fetchall()
+    assert [row[0] for row in rows] == ["t1", "t2", "t3"]
+
+
+_REDUNDANT_GRAIN_MODEL = """
+key tree_id string;
+key city string;
+key species string;
+property tree_id.raw_latitude float;
+property tree_id.raw_longitude float;
+property tree_id.source_label string;
+property tree_id.raw_species string;
+property city.cell_lat_deg float;
+property city.cell_lon_deg float;
+
+datasource dedup_cells (
+    city: city,
+    cell_lat_deg: cell_lat_deg,
+    cell_lon_deg: cell_lon_deg,
+)
+grain (city)
+address dedup_cells;
+
+datasource trees (
+    tree_id: tree_id,
+    city: city,
+    source_label: source_label,
+    raw_latitude: raw_latitude,
+    raw_longitude: raw_longitude,
+    raw_species: raw_species,
+)
+grain (tree_id)
+address trees;
+
+auto cell_a <- concat(
+    cast(floor(raw_longitude / cell_lon_deg) as string), ':',
+    cast(floor(raw_latitude / cell_lat_deg) as string)
+);
+auto anchor_a <- min(tree_id ? source_label = 'MUNI') by cell_a;
+auto cluster_id <- coalesce(anchor_a, tree_id);
+auto merged_species <- max(raw_species) by cluster_id;
+merge merged_species into species;
+
+datasource merged_trees (
+    tree_id: tree_id,
+    cluster_id: cluster_id,
+    species: species,
+)
+grain (tree_id, cluster_id)
+address merged_trees;
+"""
+
+
+def test_group_check_uses_fd_closure_over_upstream_grain():
+    from trilogy.core.processing.discovery_utility import check_if_group_required
+
+    env = Environment()
+    env.parse(_REDUNDANT_GRAIN_MODEL)
+    build = env.materialize_for_select()
+    parent = build.datasources["merged_trees"]
+    assert set(parent.grain.components) == {"local.tree_id", "local.cluster_id"}
+    # Raw keys reach past the grain (the cells), so only FD closure sees that
+    # tree_id determines cluster_id.
+    assert not build.concepts["local.cluster_id"].keys <= set(parent.grain.components)
+    downstream = [build.concepts["local.tree_id"], build.concepts["local.species"]]
+    result = check_if_group_required(downstream, [parent], build)
+    assert result.required is False

--- a/tests/evals/test_cleanup_sweeps.py
+++ b/tests/evals/test_cleanup_sweeps.py
@@ -108,6 +108,28 @@ def test_purge_spill_takes_a_workers_leftovers_and_nothing_else(tmp_path):
     assert cleanup.purge_spill(worker, log=lines.append) == 0 and not lines
 
 
+def test_purge_stale_spill_collects_a_killed_run_at_startup(tmp_path):
+    """The kill -9 path: neither the run's own purge nor its atexit hook fired."""
+    results = tmp_path / "results"
+    dead = make_run(results, "20260101-000000_ingest")
+    live = make_run(results, "20260102-000000_enriched", age_hours=0)
+    lines: list[str] = []
+    assert cleanup.purge_stale_spill(results, log=lines.append) == 5000
+    assert not list(dead.rglob("*.duckdb.tmp"))
+    assert (dead / "workspace" / "_worker_0" / "warehouse.duckdb").exists()
+    assert (dead / "agent_log.q05.jsonl").exists()
+    assert list(live.rglob("*.duckdb.tmp"))  # in flight, untouched
+    assert any("earlier run" in line for line in lines)
+
+
+def test_purge_stale_spill_is_quiet_when_there_is_nothing(tmp_path):
+    results = tmp_path / "results"
+    make_run(results, "20260102-000000_enriched", age_hours=0)
+    lines: list[str] = []
+    assert cleanup.purge_stale_spill(results, log=lines.append) == 0 and not lines
+    assert cleanup.purge_stale_spill(tmp_path / "never_ran", log=lines.append) == 0
+
+
 def test_purge_spill_ignores_a_run_with_none(tmp_path):
     run = tmp_path / "results" / "clean_run"
     run.mkdir(parents=True)

--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from trilogy.executor import Executor
     from trilogy.parser import parse
 
-__version__ = "0.3.349"
+__version__ = "0.3.350"
 
 __all__ = [
     "CONFIG",

--- a/trilogy/core/processing/discovery_utility.py
+++ b/trilogy/core/processing/discovery_utility.py
@@ -116,6 +116,11 @@ def check_if_group_required(
     environment: BuildEnvironment,
     depth: int = 0,
 ) -> GroupRequiredResponse:
+    # Local: v4_helper imports the node package, which imports this module.
+    from trilogy.core.processing.v4_helper.functional_dependency import (
+        build_fd_determines,
+    )
+
     padding = "\t" * depth
     target_grain = BuildGrain.from_concepts(
         downstream_concepts,
@@ -160,13 +165,17 @@ def check_if_group_required(
         return GroupRequiredResponse(target_grain, comp_grain, False)
     # FD closure: an upstream grain component the target functionally
     # determines is constant within each output row, so the rows are already
-    # unique at the target grain. Same rule as `grain_satisfied_by_pregrain`;
-    # the one-level `keys` checks below cannot see past a derived key whose
-    # raw keys reach outside the grain (cluster_id keyed on tree_id AND the
-    # grid cells tree_id determines).
-    graph = environment.domain_graph
-    if graph.fd_edges and all(
-        graph.determines(target_coverage, component)
+    # unique at the target grain. The one-level `keys` checks below cannot see
+    # past a derived key whose raw keys reach outside the grain (cluster_id
+    # keyed on tree_id AND the grid cells tree_id determines). Declared
+    # keys/grains only, never the domain graph: an authored scoped-join
+    # equality (`subset join fut.period + 53 = agg.period`) merges its ends
+    # into one ≡-class there, but it holds only on matched rows, and treating
+    # it as an FD elides the re-aggregation and flips the join preserving.
+    if all(
+        build_fd_determines(
+            environment, target_coverage, component, include_empty_grain=False
+        )
         for component in comp_grain.components - target_coverage
     ):
         logger.info(

--- a/trilogy/core/processing/discovery_utility.py
+++ b/trilogy/core/processing/discovery_utility.py
@@ -158,6 +158,21 @@ def check_if_group_required(
             f"{padding}{LOGGER_PREFIX} Group requirement check:  {comp_grain} covered by target coverage {target_coverage}, no group node required"
         )
         return GroupRequiredResponse(target_grain, comp_grain, False)
+    # FD closure: an upstream grain component the target functionally
+    # determines is constant within each output row, so the rows are already
+    # unique at the target grain. Same rule as `grain_satisfied_by_pregrain`;
+    # the one-level `keys` checks below cannot see past a derived key whose
+    # raw keys reach outside the grain (cluster_id keyed on tree_id AND the
+    # grid cells tree_id determines).
+    graph = environment.domain_graph
+    if graph.fd_edges and all(
+        graph.determines(target_coverage, component)
+        for component in comp_grain.components - target_coverage
+    ):
+        logger.info(
+            f"{padding}{LOGGER_PREFIX} Group requirement check: {comp_grain} functionally determined by target {target_grain}, no group node required"
+        )
+        return GroupRequiredResponse(target_grain, comp_grain, False)
     difference = [
         environment.concepts[c] for c in (comp_grain - target_grain).components
     ]

--- a/trilogy/core/processing/grain_utility.py
+++ b/trilogy/core/processing/grain_utility.py
@@ -797,7 +797,11 @@ def has_condition_key_outside_grain(
     grain: BuildGrain,
     environment: BuildEnvironment,
 ) -> bool:
+    """A WHERE on a key the grain neither contains nor functionally determines
+    reaches that key through a finer relation, so the merge must regroup. A key
+    the grain determines (`city` under a `tree_id` grain) is constant per
+    output row: the filter only removes rows and adds no grain."""
     condition_grain = condition_key_grain(condition, environment)
     if not condition_grain.components:
         return False
-    return not condition_grain.issubset(rowset_source_grain(grain, environment))
+    return not grain_satisfied_by_pregrain(condition_grain, grain, environment)

--- a/trilogy/core/processing/v4_helper/group_graph.py
+++ b/trilogy/core/processing/v4_helper/group_graph.py
@@ -1666,9 +1666,16 @@ def _lineage_pinned_grain(
     (`buyers_b.cust_id as b_cust`): its join axis is what the body value is
     keyed by (`id`), which sibling contributors expose. The walk stops at each
     barrier; grains BELOW it are pre-aggregation / body row grains, not join
-    axes. Members of an AUTHORED scoped-join relation are skipped: the
-    authored keys are the axis there, and pairing on internal grain too would
-    silently narrow the authored fan-out."""
+    axes. A row-level ROOT reached BESIDE a barrier is part of the pin: a
+    derivation over an aggregate and a row key (`cluster_id <-
+    coalesce(min(x) by cell, tree_id)`) varies per row, so its rows are unique
+    at the row grain, not the aggregate's; pinning only the barrier claims a
+    coarser grain than the rows have and the FINAL merge regroups a 1:1 join
+    back onto those rows. With no barrier anywhere nothing is pinned: a plain
+    BASIC over row columns regenerates at any grain. Members of an AUTHORED
+    scoped-join relation are skipped: the authored keys are the axis there,
+    and pairing on internal grain too would silently narrow the authored
+    fan-out."""
     scoped_members = environment.all_scoped_join_group_members()
     stack: list[BuildConcept] = []
     for addr in addresses:
@@ -1678,6 +1685,7 @@ def _lineage_pinned_grain(
         if concept is not None:
             stack.append(concept)
     grain: set[str] = set()
+    row_grain: set[str] = set()
     seen: set[str] = set()
     while stack:
         concept = stack.pop()
@@ -1708,7 +1716,9 @@ def _lineage_pinned_grain(
             continue
         if concept.lineage is not None:
             stack.extend(concept.lineage.concept_arguments)
-    return frozenset(grain)
+        elif concept.derivation == Derivation.ROOT and concept.grain:
+            row_grain |= set(concept.grain.components)
+    return frozenset(grain | row_grain) if grain else frozenset()
 
 
 def _final_host_count(


### PR DESCRIPTION
## Problem

Handoff from sf_tree_reporting (`upstream_repro/redundant_group_by`): joining a by-cluster aggregate back onto the rows that produced `cluster_id <- coalesce(min(x) by cell, tree_id)` wrapped the result in a no-aggregate `GROUP BY` over every column. The Boston refresh had 18 grouped CTEs, 4 of them with no aggregate; two were a DISTINCT over ~300k wide string rows, twice per city build.

## Cause

Three separate grain checks compared by set containment or one level of `keys`, never by FD closure:

1. `_lineage_pinned_grain` pinned a BASIC over an aggregate *and* a row key at the aggregate's grain alone, so the FINAL merge grain read coarser than its `{tree_id}` pregrain. A ROOT reached beside a barrier now adds its own grain; with no barrier nothing is pinned, as before.
2. `has_condition_key_outside_grain` forced a regroup for `where city = 'USBOS'` under a `{tree_id}` grain even though `tree_id` determines `city`. It now routes through `grain_satisfied_by_pregrain`.
3. `check_if_group_required` saw upstream `{cluster_id, tree_id}` against `{species, tree_id}` and could not get past `cluster_id`'s raw keys reaching the grid cells. An FD-closure branch follows the coverage check, using `build_fd_determines` (declared keys/grains and pseudonyms only). The domain graph's closure was tried first and broke the scoped derived-rowset join matrix: an authored `subset join fut.period + 53 = agg.period` merges its ends into one equivalence class, which only holds on matched rows.

## Result

- Small repro: every no-aggregate GROUP BY gone from both `repro.preql` and `repro_union.preql`; row counts unchanged.
- Boston dry run: 18 grouped CTEs -> 14. `late`, `sweltering` and FINAL are gone. The remaining narrow one dedupes an aggregate input to `{cluster_id, imputed_dbh}`, which is the metric-grain contract (sum/count verified correct).
- Not addressed: anchor `min()`s still computed twice under `_wscope` names for the target-side gate.

## Tests

`tests/core/processing/test_v4_derived_key_join_back_grain.py`: unit + end-to-end for each mechanism plus a dedupe guard; all failed before the fix. Full local suite green (`-m "not adventureworks_execution and not clickhouse_server"`).

This branch also carries the earlier spill-reclaim chore commit that was already on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016L7uzhCA813xg8a7kpKr2Y
