### PR TITLE
[Chore] Bump to 0.3.351 so #676 reaches PyPI

### DIFF
--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from trilogy.executor import Executor
     from trilogy.parser import parse
 
-__version__ = "0.3.350"
+__version__ = "0.3.351"
 
 __all__ = [
     "CONFIG",


### PR DESCRIPTION
## Problem

The atomic staged-write fix (#676, `trilogy/execution/staged_write.py`) is on `main` with no release carrying it.

#675 bumped `__version__` to 0.3.350 and merged at 15:58; the publish workflow uploaded 0.3.350 to PyPI at 16:04. #676 merged at 16:54 — on top of an already-consumed version string. `staged_write.py` does not exist at the 0.3.350 commit (`97c62d2d`), only at HEAD.

Downstream (trilogy-cloud) pins a released version on five files at once — the worker image, the worker floor, the e2e CLI, the model checker's PEP 723 floor, and `trilogy-parser` on crates.io — and CI asserts all five name the same release. So #676 cannot reach a worker image until it has a version of its own. It is currently blocking a corrupt-parquet fix from reaching production jobs.

## Change

One line: `__version__` 0.3.350 → 0.3.351.

Nothing else needs touching — `.scripts/sync_version.py` rewrites `trilogy/scripts/dependency/Cargo.toml` and `crates/trilogy-io/Cargo.toml` from `__version__` at build time, so merging publishes the wheels and both crates on the same stream.

Same shape as #671 ("Bump to 0.3.348 so #670 reaches PyPI").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLXVv7S7cNg8i9UsE1LR99
