### PR TITLE
[Bug] Stage object-store writes too; a killed publish must not truncate the target

### DIFF
--- a/tests/execution/test_staged_write.py
+++ b/tests/execution/test_staged_write.py
@@ -169,6 +169,66 @@ def test_non_object_store_scheme_writes_in_place():
     assert _remote_filesystem("file", "file:///tmp/out.parquet") is None
 
 
+def test_cleanup_failure_is_logged_and_never_fails_a_good_publish(fake_remote, caplog):
+    """A staged key we cannot collect costs storage; the next writer sweeps it.
+    Losing the cleanup must not lose the publish."""
+
+    class Undeletable(FakeRemote):
+        def delete_file(self, path: str) -> None:
+            raise OSError("permission denied")
+
+    remote = fake_remote(Undeletable(("bucket/trees/out.parquet",)))
+    with caplog.at_level("WARNING"):
+        with staged_write("gcs://bucket/trees/out.parquet") as staged:
+            remote.objects[staged.split("://", 1)[1]] = b"new"
+    assert remote.objects["bucket/trees/out.parquet"] == b"new"
+    assert "Could not remove staged object" in caplog.text
+
+
+def test_sweep_tolerates_a_listing_failure(fake_remote):
+    """A store that will not list is no reason to refuse the write."""
+
+    class Unlistable(FakeRemote):
+        def get_file_info(self, selector):
+            raise OSError("listing denied")
+
+    remote = fake_remote(Unlistable(("bucket/trees/out.parquet",)))
+    with staged_write("gcs://bucket/trees/out.parquet") as staged:
+        remote.objects[staged.split("://", 1)[1]] = b"new"
+    assert remote.objects["bucket/trees/out.parquet"] == b"new"
+
+
+def test_s3_is_resolved_through_pyarrow_from_uri(monkeypatch: pytest.MonkeyPatch):
+    """S3 carries no bespoke credential handling -- unlike GCS, its ambient
+    configuration is what pyarrow already reads."""
+    from trilogy.execution.staged_write import _remote_filesystem
+
+    sentinel = object()
+    seen: list[str] = []
+
+    class DummyFileSystem:
+        @staticmethod
+        def from_uri(uri: str):
+            seen.append(uri)
+            return sentinel, "bucket/out.parquet"
+
+    monkeypatch.setattr("pyarrow.fs.FileSystem", DummyFileSystem)
+    assert _remote_filesystem("s3", "s3://bucket/out.parquet") is sentinel
+    assert seen == ["s3://bucket/out.parquet"]
+
+
+def test_a_uri_pyarrow_rejects_writes_in_place(monkeypatch: pytest.MonkeyPatch):
+    from trilogy.execution.staged_write import _remote_filesystem
+
+    class RefusingFileSystem:
+        @staticmethod
+        def from_uri(uri: str):
+            raise ValueError("unparseable")
+
+    monkeypatch.setattr("pyarrow.fs.FileSystem", RefusingFileSystem)
+    assert _remote_filesystem("s3", "s3://bucket/out.parquet") is None
+
+
 def test_gcs_credentials_build_an_s3_endpoint_filesystem(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/execution/test_staged_write.py
+++ b/tests/execution/test_staged_write.py
@@ -58,12 +58,132 @@ def test_stale_leftover_for_same_target_is_swept(tmp_path: Path):
     assert staging.exists()
 
 
-def test_remote_target_yields_itself(tmp_path: Path):
+def test_remote_target_without_credentials_writes_in_place(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """No credentials loses the protection, never the write."""
+    monkeypatch.delenv("GOOGLE_HMAC_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_HMAC_SECRET", raising=False)
     with staged_write("gs://bucket/out.parquet") as staged:
         assert staged == "gs://bucket/out.parquet"
     assert list(tmp_path.iterdir()) == []
     assert is_remote_target("s3://bucket/x")
     assert not is_remote_target("C:/data/out.parquet")
+
+
+class FakeRemote:
+    """The three operations ``staged_write`` asks an object store for."""
+
+    def __init__(self, existing: tuple[str, ...] = ()):
+        self.objects = {name: b"old" for name in existing}
+        self.copied: list[tuple[str, str]] = []
+        self.deleted: list[str] = []
+
+    def copy_file(self, src: str, dst: str) -> None:
+        if src not in self.objects:
+            raise FileNotFoundError(src)
+        self.objects[dst] = self.objects[src]
+        self.copied.append((src, dst))
+
+    def delete_file(self, path: str) -> None:
+        self.deleted.append(path)
+        self.objects.pop(path, None)
+
+    def get_file_info(self, selector):
+        from types import SimpleNamespace
+
+        return [
+            SimpleNamespace(path=name)
+            for name in sorted(self.objects)
+            if name.startswith(selector.base_dir.rstrip("/") + "/")
+        ]
+
+
+@pytest.fixture()
+def fake_remote(monkeypatch: pytest.MonkeyPatch):
+    def install(remote: FakeRemote) -> FakeRemote:
+        monkeypatch.setattr(
+            "trilogy.execution.staged_write._remote_filesystem",
+            lambda scheme, uri: remote,
+        )
+        return remote
+
+    return install
+
+
+def test_remote_success_stages_then_copies_over_the_target(fake_remote):
+    remote = fake_remote(FakeRemote(("bucket/trees/out.parquet",)))
+    target = "gcs://bucket/trees/out.parquet"
+    with staged_write(target) as staged:
+        assert staged.startswith(f"gcs://bucket/trees/{STAGING_DIR}/out.parquet.")
+        assert staged.endswith(".tmp")
+        # The real object is untouched while the write is in flight.
+        assert remote.objects["bucket/trees/out.parquet"] == b"old"
+        remote.objects[staged.split("://", 1)[1]] = b"new"
+    assert remote.objects["bucket/trees/out.parquet"] == b"new"
+    assert len(remote.copied) == 1
+    # The staged key is always cleaned up, success or not.
+    assert remote.deleted and remote.deleted[-1].startswith(
+        f"bucket/trees/{STAGING_DIR}/out.parquet."
+    )
+
+
+def test_remote_failure_leaves_the_previous_object_intact(fake_remote):
+    """The exact regression: a killed writer must not truncate the target."""
+    remote = fake_remote(FakeRemote(("bucket/trees/out.parquet",)))
+    with pytest.raises(RuntimeError), staged_write(
+        "gcs://bucket/trees/out.parquet"
+    ) as staged:
+        remote.objects[staged.split("://", 1)[1]] = b"PAR1-partial-no-footer"
+        raise RuntimeError("OOM")
+    assert remote.objects["bucket/trees/out.parquet"] == b"old"
+    assert remote.copied == []
+    assert not [k for k in remote.objects if STAGING_DIR in k]
+
+
+def test_remote_failure_on_a_fresh_target_publishes_nothing(fake_remote):
+    remote = fake_remote(FakeRemote())
+    with pytest.raises(RuntimeError), staged_write(
+        "gcs://bucket/trees/new.parquet"
+    ) as staged:
+        remote.objects[staged.split("://", 1)[1]] = b"partial"
+        raise RuntimeError("boom")
+    assert remote.objects == {}
+
+
+def test_remote_sweeps_what_an_earlier_killed_writer_staged(fake_remote):
+    stale = f"bucket/trees/{STAGING_DIR}/out.parquet.deadbeef.tmp"
+    sibling = f"bucket/trees/{STAGING_DIR}/other.parquet.cafe1234.tmp"
+    remote = fake_remote(FakeRemote((stale, sibling)))
+    with staged_write("gcs://bucket/trees/out.parquet") as staged:
+        remote.objects[staged.split("://", 1)[1]] = b"new"
+    assert stale in remote.deleted
+    # Another target's staged object is not ours to collect.
+    assert sibling not in remote.deleted
+
+
+def test_non_object_store_scheme_writes_in_place():
+    """``file://`` paths are platform-shaped and never staged remotely."""
+    from trilogy.execution.staged_write import _remote_filesystem
+
+    assert _remote_filesystem("file", "file:///tmp/out.parquet") is None
+
+
+def test_gcs_credentials_build_an_s3_endpoint_filesystem(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """GCS is finalized with the same HMAC pair DuckDB writes with."""
+    from trilogy.execution.staged_write import _remote_filesystem
+
+    monkeypatch.setenv("GOOGLE_HMAC_KEY", "key")
+    monkeypatch.setenv("GOOGLE_HMAC_SECRET", "secret")
+    filesystem = _remote_filesystem("gcs", "gcs://bucket/out.parquet")
+    assert filesystem is not None
+    # Not pyarrow's GcsFileSystem, which would authenticate as ADC instead.
+    assert type(filesystem).__name__ == "S3FileSystem"
+    options = filesystem.__reduce__()[1][0]
+    assert options["endpoint_override"] == "storage.googleapis.com"
+    assert options["access_key"] == "key"
 
 
 def test_missing_parent_directory_is_reported(tmp_path: Path):

--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from trilogy.executor import Executor
     from trilogy.parser import parse
 
-__version__ = "0.3.352"
+__version__ = "0.3.353"
 
 __all__ = [
     "CONFIG",

--- a/trilogy/execution/staged_write.py
+++ b/trilogy/execution/staged_write.py
@@ -15,8 +15,24 @@ directory on the same filesystem as the target, keeping every scratch file in
 one place. A rename is only atomic within one filesystem, which is why the
 sibling directory remains the fallback rather than the other way round.
 
-Remote targets (``gs://`` and friends) write in place. Object stores expose
-no rename, and their uploads are already all-or-nothing.
+Remote targets stage the same way, under a ``.trilogy-staging`` key prefix,
+and finalize with a server-side copy followed by a delete. Object stores
+expose no rename, but a copy is atomic in the only sense that matters here:
+the destination is replaced whole or not at all.
+
+They are not all-or-nothing on their own, which is what this module first
+assumed. DuckDB writes ``gcs://`` through its S3-compatible multipart
+uploader, and a writer that dies part-way can still finalize the parts it
+had already sent -- observed as a 143 MB parquet carrying a ``PAR1`` header,
+page data and no footer, sitting under the real object name and breaking
+every multi-file scan that read it.
+
+GCS is reached through its S3-compatible endpoint with the same
+``GOOGLE_HMAC_KEY``/``GOOGLE_HMAC_SECRET`` pair DuckDB writes with, not
+through pyarrow's GcsFileSystem: the write and the swap have to be one
+identity, or a pipeline authorised to publish cannot finalize what it wrote.
+A target we cannot build a filesystem for writes in place, as before -- no
+credentials is a reason to lose the protection, never the write.
 """
 
 from __future__ import annotations
@@ -78,6 +94,72 @@ def _shared_root(staging_root: str | None, parent: Path) -> Path | None:
     return root if _same_filesystem(root, parent) else None
 
 
+_GCS_SCHEMES = ("gs", "gcs")
+_GCS_S3_ENDPOINT = "storage.googleapis.com"
+# Schemes whose ``<scheme>://<rest>`` splits cleanly into the ``bucket/key``
+# path pyarrow addresses objects by, so the staged key round-trips back into a
+# URI the writer can be handed. Anything else -- ``file://`` most of all, whose
+# path is platform-shaped -- keeps the old write-in-place behaviour.
+_OBJECT_STORE_SCHEMES = (*_GCS_SCHEMES, "s3")
+
+
+def split_remote(uri: str) -> tuple[str, str]:
+    """``gcs://bucket/a/b`` -> ``("gcs", "bucket/a/b")``."""
+    scheme, _, rest = uri.partition("://")
+    return scheme, rest
+
+
+def _remote_filesystem(scheme: str, uri: str):
+    """A pyarrow filesystem able to copy and delete at ``uri``, or None.
+
+    None means "write in place": the caller keeps the pre-staging behaviour
+    rather than failing a write it could otherwise complete.
+    """
+    from pyarrow import fs as pafs
+
+    if scheme in _GCS_SCHEMES:
+        key = os.environ.get("GOOGLE_HMAC_KEY")
+        secret = os.environ.get("GOOGLE_HMAC_SECRET")
+        if not key or not secret:
+            return None
+        return pafs.S3FileSystem(
+            access_key=key,
+            secret_key=secret,
+            endpoint_override=_GCS_S3_ENDPOINT,
+            scheme="https",
+        )
+    if scheme not in _OBJECT_STORE_SCHEMES:
+        return None
+    try:
+        filesystem, _ = pafs.FileSystem.from_uri(uri)
+    except Exception:
+        return None
+    return filesystem
+
+
+def _delete_remote(filesystem, path: str) -> None:
+    try:
+        filesystem.delete_file(path)
+    except Exception:
+        pass
+
+
+def _sweep_remote(filesystem, prefix: str, name: str) -> None:
+    """Drop what an earlier, killed writer of this same target left staged."""
+    from pyarrow import fs as pafs
+
+    try:
+        entries = filesystem.get_file_info(
+            pafs.FileSelector(prefix, allow_not_found=True)
+        )
+    except Exception:
+        return
+    for entry in entries:
+        base = entry.path.rsplit("/", 1)[-1]
+        if base.startswith(f"{name}.") and base.endswith(".tmp"):
+            _delete_remote(filesystem, entry.path)
+
+
 def _remove_if_empty(staging: Path) -> None:
     try:
         staging.rmdir()
@@ -91,12 +173,29 @@ def staged_write(target: str, staging_root: str | None = None) -> Iterator[str]:
 
     On a clean exit the target is replaced by the staged file in one rename;
     on any exception the staged file is deleted and the target is untouched.
-    A remote target yields itself. ``staging_root`` is a per-process scratch
+    A remote target stages under a key prefix and is finalized by a
+    server-side copy. ``staging_root`` is a per-process scratch
     directory (the executor's ``[staging] path`` subdir) to prefer over the
     sibling directory; it is used only when a rename out of it can succeed.
     """
     if is_remote_target(target):
-        yield target
+        scheme, path = split_remote(target)
+        filesystem = _remote_filesystem(scheme, target)
+        if filesystem is None:
+            yield target
+            return
+        head, _, name = path.rpartition("/")
+        prefix = f"{head}/{STAGING_DIR}" if head else STAGING_DIR
+        staged = f"{prefix}/{name}.{uuid.uuid4().hex[:8]}.tmp"
+        _sweep_remote(filesystem, prefix, name)
+        try:
+            yield f"{scheme}://{staged}"
+            # Either the destination is replaced whole or it is untouched;
+            # a failure here leaves the previous object in place, which is
+            # the state a partial write used to destroy.
+            filesystem.copy_file(staged, path)
+        finally:
+            _delete_remote(filesystem, staged)
         return
     final = Path(target)
     if not final.parent.is_dir():

--- a/trilogy/execution/staged_write.py
+++ b/trilogy/execution/staged_write.py
@@ -44,6 +44,8 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
+from trilogy.constants import logger
+
 STAGING_DIR = ".trilogy-staging"
 _CREATE_ATTEMPTS = 5
 
@@ -138,10 +140,14 @@ def _remote_filesystem(scheme: str, uri: str):
 
 
 def _delete_remote(filesystem, path: str) -> None:
+    """Best-effort: a staged key we cannot collect costs storage, and the
+    next writer of this target sweeps it. Never worth failing a good publish
+    for, but worth saying out loud -- a rising count of these is a
+    credential or permission problem, not noise."""
     try:
         filesystem.delete_file(path)
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("Could not remove staged object %s: %s", path, exc)
 
 
 def _sweep_remote(filesystem, prefix: str, name: str) -> None:

--- a/trilogy/scripts/agent_info_docs/content.py
+++ b/trilogy/scripts/agent_info_docs/content.py
@@ -901,8 +901,12 @@ so a copy that fails or is killed part-way leaves the previous file in place
 rather than a truncated one; the staged file is removed on failure. Scratch
 is the `[staging] path` subdir when that is local and on the target's
 filesystem (a rename cannot cross filesystems), else a `.trilogy-staging`
-sibling directory of the target. Object-store targets (`gs://`) write in
-place, since their uploads are already all-or-nothing.
+sibling directory of the target. Object-store targets (`gs://`, `s3://`) are
+protected the same way: the write lands under a `.trilogy-staging` key prefix
+and is finalized with a server-side copy, so the target is replaced whole or
+not at all. GCS is finalized with the same `GOOGLE_HMAC_KEY` /
+`GOOGLE_HMAC_SECRET` pair the write itself uses; without those the target is
+written in place, as before.
 
 ## Running external scripts (`call`)
 


### PR DESCRIPTION
## Problem

#676 staged local file artifacts and swapped them in with one rename, but treated remote targets as already safe:

> Remote targets (`gs://` and friends) write in place. Object stores expose no rename, and their uploads are already all-or-nothing.

That does not hold for the path we publish through — and the incident #676 was written for was itself a remote write, so the fix did not cover it.

DuckDB writes `gcs://` through its S3-compatible **multipart** uploader. A writer that dies part-way can still finalize the parts it already sent, so an object appears **at the real name**, complete-looking and unreadable. The observed case, still on the bucket:

```
full_tree_info_v2.parquet.corrupt-20260905T060650Z   143,322,199 B   head=PAR1  tail=\xf1DS\xc0
full_tree_info_v2.parquet (good)                     205,079,822 B   head=PAR1  tail=PAR1
```

A PAR1 header, page data, no footer. It broke every multi-file scan that read it — the all-cities rollup. #679 makes a *reader* survive such an object; this stops it being published.

A file-backed managed datasource reaches the same seam: `executor.py` lowers a persist over a `file` address to a `ProcessedCopyStatement` with `target = write_location`, so `refresh` and `copy into` share one `staged_write` call and both were unprotected for remote.

## Change

- Remote targets stage under a `.trilogy-staging` key prefix and finalize with a **server-side copy**, then delete the staged key. A copy is atomic in the only sense that matters here: the destination is replaced whole or not at all, so a failure anywhere leaves the previous object exactly as it was.
- Staged keys left by an earlier killed writer **of the same target** are swept by the next writer, matching the local branch. Another target's staged key is never collected.
- GCS is finalized through its S3-compatible endpoint with the same `GOOGLE_HMAC_KEY` / `GOOGLE_HMAC_SECRET` pair the write uses — **not** pyarrow's `GcsFileSystem`, which authenticates as ADC. The write and the swap have to be one identity, or a pipeline authorised to publish cannot finalize what it wrote.
- Staging is limited to schemes whose `<scheme>://<rest>` splits into the `bucket/key` pyarrow addresses objects by, so the staged key round-trips back into a URI the writer can be handed. `file://` (platform-shaped paths) keeps writing in place, as do missing credentials — no credentials is a reason to lose the protection, never the write.
- No new dependency: `pyarrow` is already core, and it only copies and deletes.

Verified against the real bucket: pyarrow's multipart *upload* to GCS fails signature validation (`SIGNATURE_DOES_NOT_MATCH` on `UploadPart`), but `CopyObject` and `DeleteObject` both succeed — and DuckDB does the writing here regardless, so the upload path is never used.

## Tests

`tests/execution/test_staged_write.py`: success copies over the target and leaves the real object untouched while in flight; **failure leaves the previous object intact** (the regression itself); failure on a fresh target publishes nothing; the stale-key sweep collects this target's leftovers and not a sibling's; `file://` and missing credentials both write in place; GCS builds an S3-endpoint filesystem carrying the HMAC pair. Agent docs updated.

`tests/execution/` + `tests/engine/test_copy_atomic.py`: 426 passed, 1 skipped.

## Release contents

Bumps to **0.3.353**, rebased on latest `main` (`62385db3c`).

Two things ride along that have no version of their own, both for the same reason as #676:

- **#679** (0.3.352, the read-side half of this incident) — released.
- **#678** ("[Perf] Plan a partitioned model at city scale") — merged 13:00:13Z, **33 minutes after 0.3.352 published at 12:27:31Z**, without bumping. It is currently unreleased, so this bump is what carries it to PyPI.

So 0.3.353 = the perf work plus this fix. Verified against the rebased tree: `ruff`, `black --check`, `mypy` clean, and 440 passed / 1 skipped across `tests/execution/`, `tests/engine/test_copy_atomic.py` and `tests/scripts/test_state_computation.py`.

Worth stating the pattern, since it has now bitten three releases in a row: a PR that merges after the release carrying its version string is silently unreleased, because `pythonpublish.yml` publishes only when the local version is *ahead* of PyPI. Nothing fails; the fix simply never ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLXVv7S7cNg8i9UsE1LR99
