### PR TITLE
[Bug] cloud sync: measure the workspace body, and resolve it by name server-side

### DIFF
--- a/tests/cli/test_cloud.py
+++ b/tests/cli/test_cloud.py
@@ -219,6 +219,27 @@ class TestBundling:
         with pytest.raises(CloudError, match="budget"):
             check_bundle_size(payload)
 
+    def test_the_refusal_names_the_files_that_caused_it(self):
+        """A tree goes over because of a handful of data files among hundreds
+        of small scripts. "Narrow --include" is not actionable until you know
+        which ones, and the whole point of measuring client-side rather than
+        taking a 413 is that here we still have the names."""
+        payload = {
+            "files": [
+                {"name": "raw/dump.json", "content": "x" * (9 * 1024 * 1024)},
+                {"name": "model.preql", "content": "key id int;"},
+            ]
+        }
+        with pytest.raises(CloudError) as exc:
+            check_bundle_size(payload)
+        assert "raw/dump.json" in str(exc.value)
+
+    def test_a_bundle_with_no_files_key_still_reports_its_size(self):
+        """The size check has to survive a payload shaped differently from a
+        bundle — it is called on job and workspace bodies alike."""
+        with pytest.raises(CloudError, match="budget"):
+            check_bundle_size({"config": "x" * (9 * 1024 * 1024)})
+
     def test_encoded_bundle_is_returned_for_reuse(self):
         payload = {"files": []}
         assert check_bundle_size(payload) == json.dumps(payload).encode("utf-8")
@@ -5055,3 +5076,181 @@ class TestDryRunWritesNothing:
         assert result.exit_code == 0, result.output
         assert "would create" in result.output
         assert "would update" not in result.output
+
+
+class TestWorkspaceLookupIsServerFiltered:
+    """Resolving one workspace by name must not download the org's trees.
+
+    The list route returns **whole** workspaces, `files` included, and both
+    `sync` and `workspaces push` call it only to learn one workspace's id. Left
+    unfiltered, every sync pulled every tree in the org to find one — a cost
+    that grows with the org rather than with the question, and the read-side
+    twin of pushing a whole tree on every sync.
+    """
+
+    TOML = """
+[cloud]
+
+[[cloud.job]]
+key = "refresh"
+name = "space-refresh"
+entrypoint = "refresh.preql"
+operation = "refresh"
+"""
+
+    def _repo(self, root: Path) -> Path:
+        directory = root / "data"
+        directory.mkdir(parents=True)
+        (directory / "trilogy.toml").write_text(self.TOML, encoding="utf-8")
+        (directory / "model.preql").write_text("key id int;", encoding="utf-8")
+        return root
+
+    def _seed(self, api) -> None:
+        api.set("GET", f"/orgs/{api.org}/workspaces", [])
+        api.set(
+            "POST",
+            f"/orgs/{api.org}/workspaces",
+            {"id": "ws-1", "org_id": "org-acme", "name": "data"},
+        )
+        api.set(
+            "PUT",
+            f"/orgs/{api.org}/workspaces/*",
+            {"id": "ws-1", "org_id": "org-acme", "name": "data"},
+        )
+        api.set("PATCH", f"/orgs/{api.org}/jobs/*", {})
+        api.set("GET", f"/orgs/{api.org}/jobs", [])
+        api.set("POST", f"/orgs/{api.org}/jobs", _job_payload("job-1", "space-refresh"))
+        api.set("GET", f"/orgs/{api.org}/schedules", [])
+
+    def test_sync_asks_the_server_for_the_one_workspace_by_name(
+        self, logged_in, run_cloud, tmp_path
+    ):
+        root = self._repo(tmp_path)
+        self._seed(logged_in)
+        assert run_cloud("sync", str(root)).exit_code == 0
+        call = logged_in.call_for("GET", f"/orgs/{logged_in.org}/workspaces")
+        assert call.query.get("name") == ["data"]
+
+    def test_push_asks_the_server_for_the_one_workspace_by_name(
+        self, logged_in, run_cloud, tmp_path
+    ):
+        source = tmp_path / "src"
+        source.mkdir()
+        (source / "model.preql").write_text("key id int;", encoding="utf-8")
+        assert (
+            run_cloud(
+                "workspaces", "push", "--source", str(source), "--name", "space"
+            ).exit_code
+            == 0
+        )
+        call = logged_in.call_for("GET", f"/orgs/{logged_in.org}/workspaces")
+        assert call.query.get("name") == ["space"]
+
+    def test_an_api_that_ignores_the_filter_still_resolves_correctly(
+        self, logged_in, run_cloud, tmp_path
+    ):
+        """An API predating the parameter has no query extractor on that route,
+        so it answers with everything. The narrowing is bandwidth, never
+        correctness — without the client-side match this would pick whichever
+        workspace happened to come back first."""
+        root = self._repo(tmp_path)
+        self._seed(logged_in)
+        logged_in.set(
+            "GET",
+            f"/orgs/{logged_in.org}/workspaces",
+            [
+                {"id": "ws-other", "org_id": "org-acme", "name": "unrelated"},
+                {"id": "ws-data", "org_id": "org-acme", "name": "data"},
+            ],
+        )
+        assert run_cloud("sync", str(root)).exit_code == 0
+        # Updated the workspace actually named `data`, not the first row back.
+        assert logged_in.requests_for(
+            "PUT", f"/orgs/{logged_in.org}/workspaces/ws-data"
+        )
+        assert not logged_in.requests_for(
+            "PUT", f"/orgs/{logged_in.org}/workspaces/ws-other"
+        )
+
+    def test_a_name_with_url_characters_is_encoded(
+        self, logged_in, run_cloud, tmp_path
+    ):
+        source = tmp_path / "src"
+        source.mkdir()
+        (source / "model.preql").write_text("key id int;", encoding="utf-8")
+        logged_in.set("GET", f"/orgs/{logged_in.org}/workspaces", [])
+        run_cloud("workspaces", "push", "--source", str(source), "--name", "a b&c")
+        call = logged_in.call_for("GET", f"/orgs/{logged_in.org}/workspaces")
+        assert call.query.get("name") == ["a b&c"]
+
+
+class TestWorkspacePushIsSizeChecked:
+    """A sync's *workspace* body is the big one, and went unmeasured.
+
+    `check_bundle_size` was called on each job's payload, which was written
+    when a job carried its own copy of the project. Under a shared workspace
+    that layout inverts: the workspace holds the whole tree and the jobs beside
+    it carry no files at all — so the one body worth measuring was the one
+    nothing measured, and an oversized tree reached the server and came back as
+    a bare 413 naming nothing.
+    """
+
+    TOML = """
+[cloud]
+
+[[cloud.job]]
+key = "refresh"
+name = "space-refresh"
+entrypoint = "refresh.preql"
+operation = "refresh"
+"""
+
+    def _oversized_repo(self, root: Path) -> Path:
+        directory = root / "data"
+        directory.mkdir(parents=True)
+        (directory / "trilogy.toml").write_text(self.TOML, encoding="utf-8")
+        (directory / "model.preql").write_text("key id int;", encoding="utf-8")
+        (directory / "raw_dump.json").write_text("x" * (9 * 1024 * 1024), "utf-8")
+        return root
+
+    def _seed(self, api) -> None:
+        api.set("GET", f"/orgs/{api.org}/workspaces", [])
+        api.set("GET", f"/orgs/{api.org}/jobs", [])
+        api.set("GET", f"/orgs/{api.org}/schedules", [])
+
+    def test_an_oversized_tree_is_refused_before_it_is_sent(
+        self, logged_in, run_cloud, tmp_path
+    ):
+        root = self._oversized_repo(tmp_path)
+        self._seed(logged_in)
+        result = run_cloud("sync", str(root))
+        assert result.exit_code != 0
+        assert "budget" in result.output
+        assert not logged_in.requests_for("POST", f"/orgs/{logged_in.org}/workspaces")
+
+    def test_the_refusal_names_the_file_to_exclude(
+        self, logged_in, run_cloud, tmp_path
+    ):
+        root = self._oversized_repo(tmp_path)
+        self._seed(logged_in)
+        assert "raw_dump.json" in run_cloud("sync", str(root)).output
+
+    def test_a_dry_run_measures_it_too(self, logged_in, run_cloud, tmp_path):
+        """A dry run exists to find exactly this before a real sync does.
+
+        Seeded with the workspace *already existing*, which is the case that
+        had no cover at all: a dry run against a new workspace resolves no
+        workspace id, so the jobs fall back to carrying the tree themselves and
+        the job-side check catches it by accident. Once the workspace exists
+        the jobs carry nothing, and the tree is measured here or nowhere.
+        """
+        root = self._oversized_repo(tmp_path)
+        self._seed(logged_in)
+        logged_in.set(
+            "GET",
+            f"/orgs/{logged_in.org}/workspaces",
+            [{"id": "ws-1", "org_id": "org-acme", "name": "data"}],
+        )
+        result = run_cloud("sync", str(root), "--dry-run")
+        assert result.exit_code != 0
+        assert "budget" in result.output

--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from trilogy.executor import Executor
     from trilogy.parser import parse
 
-__version__ = "0.3.354"
+__version__ = "0.3.355"
 
 __all__ = [
     "CONFIG",

--- a/trilogy/scripts/cloud.py
+++ b/trilogy/scripts/cloud.py
@@ -889,18 +889,47 @@ def parse_rewrite(
     return parsed
 
 
+def _largest_files(payload: dict, limit: int = 5) -> list[tuple[str, int]]:
+    """The biggest entries in a bundle, largest first, as (name, bytes)."""
+    files = payload.get("files")
+    if not isinstance(files, list):
+        return []
+    sized = [
+        (f["name"], len(f.get("content") or ""))
+        for f in files
+        if isinstance(f, dict) and isinstance(f.get("name"), str)
+    ]
+    return sorted(sized, key=lambda pair: pair[1], reverse=True)[:limit]
+
+
 def check_bundle_size(payload: dict) -> bytes:
     """The encoded payload, refused if it cannot fit in a queue message.
 
     Returns the bytes, so the caller sends exactly what was measured.
+
+    The budget is the platform's, twice over: the distributor refuses to
+    publish a flattened payload past it, and the API refuses a request body
+    past it (`job_limits::MAX_REQUEST_BODY_BYTES`) — the same number, so
+    measuring here is the same question asked one hop earlier, where the answer
+    can name files instead of arriving as a 413.
     """
     encoded = json.dumps(payload).encode("utf-8")
     budget = int(PUBSUB_MAX_BYTES * SAFETY_MARGIN)
     if len(encoded) > budget:
+        # Naming the offenders is most of the fix: a tree of several hundred
+        # small scripts goes over because of a handful of data files in it,
+        # and "narrow --include" is not actionable until you know which.
+        biggest = _largest_files(payload)
+        detail = ""
+        if biggest:
+            listed = ", ".join(f"{name} ({size:,}B)" for name, size in biggest)
+            detail = f" Largest: {listed}."
         raise CloudError(
             f"Bundle is {len(encoded):,}B, over the {budget:,}B budget "
             f"({SAFETY_MARGIN:.0%} of PubSub's {PUBSUB_MAX_BYTES:,}B message "
-            "limit). Narrow --include, add --exclude, or split the job."
+            f"limit).{detail} Narrow --include, add --exclude, or split the "
+            "project. Data files especially do not belong in a bundle — they "
+            "are re-materialized onto a worker VM on every run."
         )
     return encoded
 
@@ -1939,6 +1968,28 @@ def _find_workspace(
     raise CloudError(f"No workspace named {name_or_id!r} in org {org!r}.")
 
 
+def _workspace_by_name(client: CloudClient, org: str, name: str) -> Workspace | None:
+    """The org's workspace with this exact name, or None.
+
+    Asks the server to do the filtering (`?name=`), which matters because the
+    list route returns **whole** workspaces — `files` included. A sync calls
+    this only to learn one workspace's id, and unfiltered that means
+    downloading every tree in the org to find it: a cost that grows with the
+    org rather than with the question, and the read-side twin of pushing a
+    whole tree on every sync.
+
+    The client-side match is kept deliberately. An API that predates the
+    parameter has no query extractor on that route at all, so it ignores the
+    filter and answers with everything — the narrowing has to be a bandwidth
+    optimization rather than something correctness rests on, or this silently
+    picks an arbitrary workspace against an older server.
+    """
+    matches = client.get_many(
+        f"/orgs/{org}/workspaces?{urlencode({'name': name})}", Workspace
+    )
+    return next((w for w in matches if w.name == name), None)
+
+
 def _workspace_chain(
     workspaces_: Sequence[Workspace], workspace_id: str | None
 ) -> list[Workspace]:
@@ -2422,14 +2473,7 @@ def workspaces_push(
                     touched += 1
         print_info(f"Applied rewrites to {touched} file(s)")
 
-    existing = next(
-        (
-            w
-            for w in client.get_many(f"/orgs/{org}/workspaces", Workspace)
-            if w.name == name
-        ),
-        None,
-    )
+    existing = _workspace_by_name(client, org, name)
 
     # An explicit --config always wins. Otherwise a trilogy.toml in the tree is
     # sent only when the workspace already has a config — that is the file a
@@ -3759,14 +3803,7 @@ def _ensure_workspace(
     updated, through the payload builder `workspaces push` uses, since a `PUT`
     replaces a workspace wholesale and this body names only the tree.
     """
-    existing = next(
-        (
-            w
-            for w in client.get_many(f"/orgs/{org}/workspaces", Workspace)
-            if w.name == name
-        ),
-        None,
-    )
+    existing = _workspace_by_name(client, org, name)
     body = _workspace_payload(
         name=name,
         files=files,
@@ -3775,14 +3812,22 @@ def _ensure_workspace(
         existing=existing,
     )
     body["source_key"] = source_key
+    # Measured here, and on a dry run too, for the same reason `_sync_one`
+    # measures a job's: a tree over the budget is exactly what a dry run
+    # exists to find. This is the *workspace* push, which carries the whole
+    # project — so in workspace mode it is the big body and the jobs beside it
+    # are empty, the opposite of the per-job layout the job check was written
+    # for. Missing it, an oversized tree reached the server unmeasured and
+    # came back as a bare 413 naming nothing.
+    encoded = check_bundle_size(body)
     if dry_run:
         return (existing.id if existing else None), (
             "would update" if existing else "would create"
         )
     if existing:
-        client.put_one(f"/orgs/{org}/workspaces/{existing.id}", Workspace, body)
+        client.put_one(f"/orgs/{org}/workspaces/{existing.id}", Workspace, encoded)
         return existing.id, "updated"
-    created = client.post_one(f"/orgs/{org}/workspaces", Workspace, body)
+    created = client.post_one(f"/orgs/{org}/workspaces", Workspace, encoded)
     return created.id, "created"
 
 


### PR DESCRIPTION
Unblock sync commands for large workspaces.

## The workspace body went unmeasured

`check_bundle_size` is called on each job's payload, which was right when every job carried its own copy of the project. Under a shared workspace that layout **inverts**: the workspace carries most context instead of jobs, and that was not guarded.

`_ensure_workspace` now measures it, **on a dry run too** — a tree over the budget is exactly what a dry run exists to find.

**The refusal now names the largest files.** A tree of several hundred small scripts goes over because of a handful of data files in it, and "narrow `--include`" is not actionable until you know which. 

```
Bundle is 9,437,336B, over the 8,388,608B budget (80% of PubSub's 10,485,760B
message limit). Largest: raw_dump.json (9,437,184B), model.preql (12B). Narrow
--include, add --exclude, or split the project. Data files especially do not
belong in a bundle — they are re-materialized onto a worker VM on every run.
```

## The workspace lookup pulled the whole org

The list route returns **whole** workspaces, `files` included, and both `sync` and `workspaces push` call it only to learn one workspace's id — so every sync downloaded every tree in the org to find one. A cost that grows with the org rather than with the question, and the read-side twin of pushing a whole tree on every sync.

`_workspace_by_name` asks the server to filter (`?name=`, added in [trilogy-cloud#126](https://github.com/trilogy-data/trilogy-cloud/pull/126)).

The client-side match is **kept deliberately**: an API predating the parameter has no query extractor on that route, so it ignores the filter and answers with everything. The narrowing has to be bandwidth rather than something correctness rests on, or this silently picks an arbitrary workspace against an older server. Tested both ways — no coordinated deploy needed, and an older CLI against a newer API is equally fine.

## Tests

9 new, **7 of which fail without the change** (the other two are regression guards for behaviour that already held: the older-API fallback, and the encoded-name case).

- `TestBundling` — the refusal names the offending files; a payload with no `files` key still reports its size.
- `TestWorkspaceLookupIsServerFiltered` — sync and push both send `?name=`; an API that ignores it still resolves correctly; a name with URL characters is encoded.
- `TestWorkspacePushIsSizeChecked` — an oversized tree is refused before it is sent, names the file to exclude, and is caught on a dry run against an existing workspace.

432 pass. black, ruff and mypy clean.

`__version__` → 0.3.355, so this actually reaches PyPI on merge.