### PR TITLE
[Bug] cloud sync: drop platform internals from the size refusal

### DIFF
--- a/tests/cli/test_cloud.py
+++ b/tests/cli/test_cloud.py
@@ -24,6 +24,7 @@ from trilogy.scripts.cloud import (
     CloudClient,
     CloudError,
     DeploySettings,
+    _ensure_workspace,
     _find_job,
     _fmt_job,
     _fmt_run,
@@ -220,10 +221,9 @@ class TestBundling:
             check_bundle_size(payload)
 
     def test_the_refusal_names_the_files_that_caused_it(self):
-        """A tree goes over because of a handful of data files among hundreds
-        of small scripts. "Narrow --include" is not actionable until you know
-        which ones, and the whole point of measuring client-side rather than
-        taking a 413 is that here we still have the names."""
+        """A tree usually goes over because of a few data files among many
+        small scripts. "Narrow --include" is not actionable without the names,
+        and checking client-side is what keeps them available to report."""
         payload = {
             "files": [
                 {"name": "raw/dump.json", "content": "x" * (9 * 1024 * 1024)},
@@ -235,8 +235,8 @@ class TestBundling:
         assert "raw/dump.json" in str(exc.value)
 
     def test_a_bundle_with_no_files_key_still_reports_its_size(self):
-        """The size check has to survive a payload shaped differently from a
-        bundle — it is called on job and workspace bodies alike."""
+        """The check runs on job and workspace bodies alike, so it has to
+        handle a payload shaped differently from a bundle."""
         with pytest.raises(CloudError, match="budget"):
             check_bundle_size({"config": "x" * (9 * 1024 * 1024)})
 
@@ -5081,11 +5081,9 @@ class TestDryRunWritesNothing:
 class TestWorkspaceLookupIsServerFiltered:
     """Resolving one workspace by name must not download the org's trees.
 
-    The list route returns **whole** workspaces, `files` included, and both
-    `sync` and `workspaces push` call it only to learn one workspace's id. Left
-    unfiltered, every sync pulled every tree in the org to find one — a cost
-    that grows with the org rather than with the question, and the read-side
-    twin of pushing a whole tree on every sync.
+    The list route returns whole workspaces, files included, and both `sync`
+    and `workspaces push` call it only to learn one workspace's id. Unfiltered,
+    every sync downloaded every project tree in the org to find one.
     """
 
     TOML = """
@@ -5149,10 +5147,9 @@ operation = "refresh"
     def test_an_api_that_ignores_the_filter_still_resolves_correctly(
         self, logged_in, run_cloud, tmp_path
     ):
-        """An API predating the parameter has no query extractor on that route,
-        so it answers with everything. The narrowing is bandwidth, never
-        correctness — without the client-side match this would pick whichever
-        workspace happened to come back first."""
+        """An older API ignores the parameter and answers with everything, so
+        the filter saves bandwidth but cannot be relied on for correctness.
+        Without the client-side match this would pick the first row back."""
         root = self._repo(tmp_path)
         self._seed(logged_in)
         logged_in.set(
@@ -5185,14 +5182,13 @@ operation = "refresh"
 
 
 class TestWorkspacePushIsSizeChecked:
-    """A sync's *workspace* body is the big one, and went unmeasured.
+    """The workspace body holds a shared project's files, and went unmeasured.
 
-    `check_bundle_size` was called on each job's payload, which was written
-    when a job carried its own copy of the project. Under a shared workspace
-    that layout inverts: the workspace holds the whole tree and the jobs beside
-    it carry no files at all — so the one body worth measuring was the one
-    nothing measured, and an oversized tree reached the server and came back as
-    a bare 413 naming nothing.
+    `check_bundle_size` ran on each job's payload, which was right when every
+    job carried its own copy of the project. With a shared workspace the
+    workspace holds the files and its jobs hold none, so nothing checked the
+    body that could actually be too large. It reached the server and came back
+    as a 413 with no detail.
     """
 
     TOML = """
@@ -5236,13 +5232,11 @@ operation = "refresh"
         assert "raw_dump.json" in run_cloud("sync", str(root)).output
 
     def test_a_dry_run_measures_it_too(self, logged_in, run_cloud, tmp_path):
-        """A dry run exists to find exactly this before a real sync does.
+        """A dry run should report an oversized tree before a real sync does.
 
-        Seeded with the workspace *already existing*, which is the case that
-        had no cover at all: a dry run against a new workspace resolves no
-        workspace id, so the jobs fall back to carrying the tree themselves and
-        the job-side check catches it by accident. Once the workspace exists
-        the jobs carry nothing, and the tree is measured here or nowhere.
+        Seeded with the workspace already existing, because that is the case
+        with no other check behind it: its jobs carry no files, so the
+        workspace body is the only thing measured.
         """
         root = self._oversized_repo(tmp_path)
         self._seed(logged_in)
@@ -5254,3 +5248,35 @@ operation = "refresh"
         result = run_cloud("sync", str(root), "--dry-run")
         assert result.exit_code != 0
         assert "budget" in result.output
+
+    def _ensure(self, api, dry_run: bool):
+        """`_ensure_workspace` against a *new* workspace — the fake API's
+        default answer for the list route is seeded empty by `_seed`."""
+        return _ensure_workspace(
+            CloudClient(api.url, "tri_stored"),
+            api.org,
+            "data",
+            "[cloud]\n",
+            [{"name": "raw_dump.json", "content": "x" * (9 * 1024 * 1024)}],
+            "github.com/acme/models",
+            dry_run,
+        )
+
+    @pytest.mark.parametrize("dry_run", [False, True])
+    def test_a_workspace_that_does_not_exist_yet_is_measured_too(
+        self, logged_in, dry_run
+    ):
+        """The size check runs before the create/update branch and before the
+        dry-run return, so a workspace that does not exist yet is refused the
+        same way one that does.
+
+        Checked against `_ensure_workspace` rather than through a sync,
+        because a sync would fail here even without this check: with no
+        workspace id to bind to, the jobs carry the project files themselves
+        and the job-side check rejects them a step later. Only an existing
+        workspace, whose jobs carry no files, depends on this check alone.
+        """
+        self._seed(logged_in)
+        with pytest.raises(CloudError, match="budget"):
+            self._ensure(logged_in, dry_run)
+        assert not logged_in.requests_for("POST", f"/orgs/{logged_in.org}/workspaces")

--- a/trilogy/__init__.py
+++ b/trilogy/__init__.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from trilogy.executor import Executor
     from trilogy.parser import parse
 
-__version__ = "0.3.355"
+__version__ = "0.3.356"
 
 __all__ = [
     "CONFIG",

--- a/trilogy/scripts/cloud.py
+++ b/trilogy/scripts/cloud.py
@@ -24,7 +24,7 @@ API's own response types, so an unexpected shape is an error naming the field.
 ``jobs push`` bundles a local project directory into the job's inline files —
 paths relative to ``--source``, so the directory shape (relative imports,
 ``sys.path`` tricks in Python datasources) survives the trip. A bundle over the
-PubSub size budget is refused at push time.
+platform's size budget is refused at push time.
 
 **Push is an upsert, keyed by job name.** Jobs are versioned platform-side —
 the row is stable identity and its content is a copy of the newest version — so
@@ -903,33 +903,31 @@ def _largest_files(payload: dict, limit: int = 5) -> list[tuple[str, int]]:
 
 
 def check_bundle_size(payload: dict) -> bytes:
-    """The encoded payload, refused if it cannot fit in a queue message.
+    """The encoded payload, refused if it is too large to send.
 
     Returns the bytes, so the caller sends exactly what was measured.
 
-    The budget is the platform's, twice over: the distributor refuses to
-    publish a flattened payload past it, and the API refuses a request body
-    past it (`job_limits::MAX_REQUEST_BODY_BYTES`) — the same number, so
-    measuring here is the same question asked one hop earlier, where the answer
-    can name files instead of arriving as a 413.
+    The budget matches the platform's own limit on both a request body and a
+    queued job. Checking it here rather than letting the server answer 413
+    means the error can name the files that caused it.
     """
     encoded = json.dumps(payload).encode("utf-8")
     budget = int(PUBSUB_MAX_BYTES * SAFETY_MARGIN)
     if len(encoded) > budget:
-        # Naming the offenders is most of the fix: a tree of several hundred
-        # small scripts goes over because of a handful of data files in it,
-        # and "narrow --include" is not actionable until you know which.
+        # Usually a few large data files among many small scripts, so list
+        # them: "narrow --include" is not actionable without the names.
         biggest = _largest_files(payload)
         detail = ""
         if biggest:
             listed = ", ".join(f"{name} ({size:,}B)" for name, size in biggest)
             detail = f" Largest: {listed}."
+        # Don't name where the budget comes from: the caller cannot see or
+        # change it. The size and the file names are what they can act on.
         raise CloudError(
-            f"Bundle is {len(encoded):,}B, over the {budget:,}B budget "
-            f"({SAFETY_MARGIN:.0%} of PubSub's {PUBSUB_MAX_BYTES:,}B message "
-            f"limit).{detail} Narrow --include, add --exclude, or split the "
-            "project. Data files especially do not belong in a bundle — they "
-            "are re-materialized onto a worker VM on every run."
+            f"Bundle is {len(encoded):,}B, over the {budget:,}B budget."
+            f"{detail} Narrow --include, add --exclude, or split the project. "
+            "Consider loading data files to an object store and referencing "
+            "them in script rather than bundling."
         )
     return encoded
 
@@ -1971,18 +1969,13 @@ def _find_workspace(
 def _workspace_by_name(client: CloudClient, org: str, name: str) -> Workspace | None:
     """The org's workspace with this exact name, or None.
 
-    Asks the server to do the filtering (`?name=`), which matters because the
-    list route returns **whole** workspaces — `files` included. A sync calls
-    this only to learn one workspace's id, and unfiltered that means
-    downloading every tree in the org to find it: a cost that grows with the
-    org rather than with the question, and the read-side twin of pushing a
-    whole tree on every sync.
+    Filters server-side (`?name=`) because the list route returns whole
+    workspaces, files included, and callers here need only one workspace's id.
+    Unfiltered, that downloads every project tree in the org.
 
-    The client-side match is kept deliberately. An API that predates the
-    parameter has no query extractor on that route at all, so it ignores the
-    filter and answers with everything — the narrowing has to be a bandwidth
-    optimization rather than something correctness rests on, or this silently
-    picks an arbitrary workspace against an older server.
+    The client-side match stays because an older API ignores the parameter and
+    answers with everything; without it, this would pick whichever workspace
+    came back first.
     """
     matches = client.get_many(
         f"/orgs/{org}/workspaces?{urlencode({'name': name})}", Workspace
@@ -3812,13 +3805,9 @@ def _ensure_workspace(
         existing=existing,
     )
     body["source_key"] = source_key
-    # Measured here, and on a dry run too, for the same reason `_sync_one`
-    # measures a job's: a tree over the budget is exactly what a dry run
-    # exists to find. This is the *workspace* push, which carries the whole
-    # project — so in workspace mode it is the big body and the jobs beside it
-    # are empty, the opposite of the per-job layout the job check was written
-    # for. Missing it, an oversized tree reached the server unmeasured and
-    # came back as a bare 413 naming nothing.
+    # In workspace mode this body carries the whole project and the jobs beside
+    # it carry no files, so this is the only size check that sees the files.
+    # Measured before the dry-run return as well, so a dry run reports it.
     encoded = check_bundle_size(body)
     if dry_run:
         return (existing.id if existing else None), (


### PR DESCRIPTION
Review follow-up to #685.

## The refusal named PubSub

The budget is a share of the queue's message limit. That is not something the caller can see or change, so the message no longer mentions it. And "data files especially do not belong in a bundle" told them off without telling them what to do; it now says what to do instead.

Both rendered from the same payload. Before:

```
Bundle is 9,437,288B, over the 8,388,608B budget (80% of PubSub's 10,485,760B
message limit). Largest: raw_dump.json (9,437,184B), model.preql (11B). Narrow
--include, add --exclude, or split the project. Data files especially do not
belong in a bundle — they are re-materialized onto a worker VM on every run.
```

After:

```
Bundle is 9,437,288B, over the 8,388,608B budget. Largest: raw_dump.json
(9,437,184B), model.preql (11B). Narrow --include, add --exclude, or split the
project. Consider loading data files to an object store and referencing them
in script rather than bundling.
```

The module docstring named PubSub for the same reason; it now says "the platform's size budget".

I also swept every string that can reach a terminal — `CloudError`, all `print_*`, click `help=`, and command docstrings, which click renders as `--help` — across `trilogy/scripts/`. Nothing else names a platform internal. The remaining mentions are in code comments and are never printed.

## The claim that the check does not fire on a new workspace

It does fire. `check_bundle_size` runs before the create/update branch and before the dry-run return, so a dry run refuses an oversized tree the same way whether the workspace exists or not: same message, same exit code, in the same place. I ran both to confirm.

What was actually true is that a **sync** would fail even without the check, because a new workspace resolves no workspace id and the jobs then carry the project files themselves:

| dry run against | with the check | check removed |
|---|---|---|
| **new** workspace | refused | still refused, by the job-side check a step later |
| **existing** workspace | refused | exit 0 — its jobs carry no files |

So the bottom-right cell is what #685 fixed, and the top-right is why the new test asserts on `_ensure_workspace` directly instead of running a sync: a sync test would pass either way. That is a reason to place the test where it is, not a gap in the check, and it is now written that way.

## Tests

2 new, both fail if the check is removed.

- `test_a_workspace_that_does_not_exist_yet_is_measured_too[False|True]` — `_ensure_workspace` against a workspace that does not exist yet, dry run and not.
- `test_a_dry_run_measures_it_too` — docstring corrected, assertion unchanged.

Comments and docstrings in the surrounding code have been shortened.

434 pass. black, ruff and mypy clean.

`__version__` → 0.3.356, so this reaches PyPI on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLXVv7S7cNg8i9UsE1LR99